### PR TITLE
feat(shell): readline inline editing, file I/O commands, ring-3 stdin, exec wait

### DIFF
--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -68,6 +68,11 @@ bool vesa_tty_is_ready(void)
 	return tty_ready;
 }
 
+uint32_t vesa_tty_get_col(void)
+{
+	return tty_col;
+}
+
 uint32_t vesa_tty_get_row(void)
 {
 	return tty_row;
@@ -198,6 +203,14 @@ void vesa_tty_spinner_tick(uint32_t tick)
 	static const char frames[] = {'|', '/', '-', '\\'};
 	char c = frames[(tick / 12) % 4];
 	vesa_tty_put_at(c, tty_cols - 1, 0);
+}
+
+void vesa_tty_set_cursor(uint32_t col, uint32_t row)
+{
+	if (!tty_ready)
+		return;
+	if (col < tty_cols) tty_col = col;
+	if (row < tty_rows) tty_row = row;
 }
 
 void vesa_tty_set_scale(uint32_t scale)

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -28,6 +28,7 @@
 #include <kernel/task.h>
 #include <kernel/tty.h>
 #include <kernel/keyboard.h>
+#include <kernel/shell.h>
 #include <kernel/vfs.h>
 #include <kernel/heap.h>
 #include <kernel/vmm.h>
@@ -124,12 +125,15 @@ void syscall_dispatch(registers_t *regs)
         if (!buf || len == 0) { regs->eax = 0; break; }
 
         if (fd == FD_STDIN) {
-            uint32_t n = 0;
-            while (n < len) {
-                char c = keyboard_getchar();
-                buf[n++] = c;
-                if (c == '\n') break;   /* line-at-a-time terminal read */
-            }
+            /* Line-buffered stdin with echo, backspace, and cursor editing. */
+            static char s_stdin_line[256];
+            uint32_t cap = (len < sizeof(s_stdin_line)) ? len : (uint32_t)sizeof(s_stdin_line);
+            shell_readline(s_stdin_line, (size_t)cap);
+            uint32_t n = (uint32_t)strlen(s_stdin_line);
+            /* Append '\n' so callers see a complete line (like a real terminal). */
+            if (n < cap - 1) { s_stdin_line[n++] = '\n'; s_stdin_line[n] = '\0'; }
+            if (n > len) n = len;
+            memcpy(buf, s_stdin_line, n);
             regs->eax = n;
         } else {
             int idx = fd_to_slot(fd);

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -465,6 +465,11 @@ void vics_edit(const char *path)
         /* ---- Editing ---- */
         if (c == '\b')              { vics_backspace();  continue; }
         if (c == '\n' || c == '\r') { vics_newline();    continue; }
+        if (c == '\t') {
+            /* Tab → 4 spaces */
+            for (int s = 0; s < 4; s++) vics_insert_char(' ');
+            continue;
+        }
         if (c >= ' ' && c <= '~')   { vics_insert_char(c); continue; }
 
         /* All other characters (e.g. Tab, remaining Ctrl codes) are ignored. */

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -311,15 +311,21 @@ static void vics_parse(const char *buf, uint32_t size)
 
     uint32_t pos = 0;
     while (v_nlines < VICS_MAX_LINES) {
-        uint32_t start = pos;
-        while (pos < size && buf[pos] != '\n') pos++;
-
-        int len = (int)(pos - start);
-        if (len > VICS_LINE_CAP) len = VICS_LINE_CAP;
-
-        memcpy(v_lines[v_nlines], buf + start, (size_t)len);
-        v_lines[v_nlines][len] = '\0';
-        v_len[v_nlines]        = len;
+        /* Copy one line, expanding '\t' to spaces at 4-column stops so the
+         * buffer never contains raw tab bytes (which VGA renders as circles). */
+        int out = 0;
+        while (pos < size && buf[pos] != '\n') {
+            if (buf[pos] == '\t') {
+                int spaces = 4 - (out % 4);
+                while (spaces-- > 0 && out < VICS_LINE_CAP)
+                    v_lines[v_nlines][out++] = ' ';
+            } else if (out < VICS_LINE_CAP) {
+                v_lines[v_nlines][out++] = buf[pos];
+            }
+            pos++;
+        }
+        v_lines[v_nlines][out] = '\0';
+        v_len[v_nlines]        = out;
         v_nlines++;
 
         if (pos >= size) break;

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -13,8 +13,10 @@
 #include <kernel/shell.h>
 #include <kernel/keyboard.h>
 #include <kernel/tty.h>
+#include <kernel/vga.h>
 #include <kernel/vesa.h>
 #include <kernel/vesa_tty.h>
+#include <kernel/serial.h>
 #include <kernel/vfs.h>
 #include <kernel/ktest.h>
 
@@ -50,49 +52,142 @@ static const char *history_get(int ago)
 }
 
 /* ---------------------------------------------------------------------------
+ * readline_redraw – repaint the input line in-place and position cursors.
+ *
+ * VGA uses vga_start_col/row (always 80 cols).
+ * VESA uses vesa_start_col/row (tty_cols wide, which differs from VGA_WIDTH).
+ * Passing separate VESA coords avoids the t_row=0 desync that occurs when
+ * VESA is active and the VGA row counter wraps.
+ * --------------------------------------------------------------------------- */
+static void readline_redraw(const char *buf, size_t len, size_t cur,
+                             size_t vga_start_col, size_t vga_start_row,
+                             uint32_t vesa_start_col, uint32_t vesa_start_row)
+{
+    uint32_t vcols = vesa_tty_is_ready() ? vesa_tty_get_cols() : VGA_WIDTH;
+
+    for (size_t i = 0; i <= len; i++) {
+        char ch = (i < len) ? buf[i] : ' '; /* trailing space erases deletions */
+
+        size_t vga_lp  = vga_start_col + i;
+        size_t vga_row = vga_start_row + vga_lp / VGA_WIDTH;
+        size_t vga_col = vga_lp % VGA_WIDTH;
+        VGA_MEMORY[vga_row * VGA_WIDTH + vga_col] = make_vgaentry(ch, SHELL_COLOR_VGA);
+
+        if (vesa_tty_is_ready()) {
+            uint32_t vlp = vesa_start_col + (uint32_t)i;
+            vesa_tty_put_at(ch, vlp % vcols, vesa_start_row + vlp / vcols);
+        }
+    }
+
+    /* VGA hardware cursor */
+    size_t cp = vga_start_col + cur;
+    update_cursor(vga_start_row + cp / VGA_WIDTH, cp % VGA_WIDTH);
+
+    /* VESA internal cursor */
+    if (vesa_tty_is_ready()) {
+        uint32_t vcp = vesa_start_col + (uint32_t)cur;
+        vesa_tty_set_cursor(vcp % vcols, vesa_start_row + vcp / vcols);
+    }
+}
+
+/* ---------------------------------------------------------------------------
  * shell_readline – read a line from the PS/2 keyboard into buf.
  *
- * Echoes every printable character to the VGA terminal.  Handles:
- *   '\b'           – erase the previous character (if any).
- *   '\n'           – end of line.
- *   KEY_ARROW_UP   – recall older history entry.
- *   KEY_ARROW_DOWN – recall newer history entry (or restore working line).
+ * Handles:
+ *   Printable       – insert at cursor (inline editing).
+ *   '\b'            – delete char before cursor.
+ *   KEY_ARROW_LEFT  – move cursor left within the line.
+ *   KEY_ARROW_RIGHT – move cursor right within the line.
+ *   KEY_ARROW_UP    – recall older history entry.
+ *   KEY_ARROW_DOWN  – recall newer entry (or restore working line).
+ *   '\n' / '\r'     – end of line.
  * Always NUL-terminates buf.  Reads at most (max - 1) characters.
  * --------------------------------------------------------------------------- */
 void shell_readline(char *buf, size_t max)
 {
     size_t len      = 0;
-    int    hist_pos = -1;            /* -1 = not in history-navigation mode */
-    char   work[SHELL_MAX_INPUT];    /* in-progress line saved on first ↑   */
+    size_t cur      = 0;             /* cursor position within buf            */
+    int    hist_pos = -1;            /* -1 = not in history-navigation mode   */
+    char   work[SHELL_MAX_INPUT];    /* in-progress line saved on first ↑     */
 
     buf[0]  = '\0';
     work[0] = '\0';
+
+    /* Capture where the prompt ended.  VGA uses t_column/t_row (wraps at
+     * VGA_WIDTH and resets t_row=0 when VESA is active).  VESA tracks its
+     * own cursor which must be read separately to avoid the t_row=0 desync. */
+    size_t   rl_col      = t_column;
+    size_t   rl_row      = t_row;
+    uint32_t vesa_rl_col = vesa_tty_is_ready() ? vesa_tty_get_col() : (uint32_t)t_column;
+    uint32_t vesa_rl_row = vesa_tty_is_ready() ? vesa_tty_get_row() : (uint32_t)t_row;
 
     while (1) {
         char c = keyboard_getchar();
 
         if (c == '\n' || c == '\r') {
-            t_putchar('\n');
+            /* Sync VGA tty state to end of line, then emit newline. */
+            size_t end = rl_col + len;
+            t_row      = rl_row + end / VGA_WIDTH;
+            t_column   = end % VGA_WIDTH;
+            if (vesa_tty_is_ready()) {
+                uint32_t vcols = vesa_tty_get_cols();
+                uint32_t vend  = vesa_rl_col + (uint32_t)len;
+                vesa_tty_set_cursor(vend % vcols, vesa_rl_row + vend / vcols);
+            }
+            t_putchar('\n');  /* also writes '\n' to serial via tty.c */
             break;
         }
 
         if (c == '\b') {
-            if (len > 0) {
+            if (cur > 0) {
+                for (size_t i = cur - 1; i < len - 1; i++)
+                    buf[i] = buf[i + 1];
                 len--;
+                cur--;
                 buf[len] = '\0';
-                t_backspace();
+                Serial_WriteChar('\b');
+                readline_redraw(buf, len, cur,
+                                rl_col, rl_row, vesa_rl_col, vesa_rl_row);
             }
             hist_pos = -1;
             continue;
         }
 
-        /* ---- Arrow-key history navigation ---- */
+        /* ---- Inline cursor movement ---- */
+        if (c == KEY_ARROW_LEFT) {
+            if (cur > 0) {
+                cur--;
+                size_t cp = rl_col + cur;
+                update_cursor(rl_row + cp / VGA_WIDTH, cp % VGA_WIDTH);
+                if (vesa_tty_is_ready()) {
+                    uint32_t vcols = vesa_tty_get_cols();
+                    uint32_t vcp   = vesa_rl_col + (uint32_t)cur;
+                    vesa_tty_set_cursor(vcp % vcols, vesa_rl_row + vcp / vcols);
+                }
+            }
+            continue;
+        }
+
+        if (c == KEY_ARROW_RIGHT) {
+            if (cur < len) {
+                cur++;
+                size_t cp = rl_col + cur;
+                update_cursor(rl_row + cp / VGA_WIDTH, cp % VGA_WIDTH);
+                if (vesa_tty_is_ready()) {
+                    uint32_t vcols = vesa_tty_get_cols();
+                    uint32_t vcp   = vesa_rl_col + (uint32_t)cur;
+                    vesa_tty_set_cursor(vcp % vcols, vesa_rl_row + vcp / vcols);
+                }
+            }
+            continue;
+        }
+
+        /* ---- History navigation ---- */
         if (c == KEY_ARROW_UP || c == KEY_ARROW_DOWN) {
             int new_pos;
 
             if (c == KEY_ARROW_UP) {
                 if (hist_pos < 0) {
-                    /* First ↑ press: save the in-progress line. */
                     strncpy(work, buf, max - 1);
                     work[max - 1] = '\0';
                 }
@@ -105,25 +200,20 @@ void shell_readline(char *buf, size_t max)
 
             const char *entry;
             if (new_pos < 0) {
-                /* Went past the newest entry → restore the working line. */
                 entry    = work;
                 hist_pos = -1;
             } else {
                 entry = history_get(new_pos);
-                if (!entry)
-                    continue;
+                if (!entry) continue;
                 hist_pos = new_pos;
             }
 
-            /* Erase the current line on-screen. */
-            for (size_t i = 0; i < len; i++)
-                t_backspace();
-
-            /* Load and display the recalled line. */
             strncpy(buf, entry, max - 1);
             buf[max - 1] = '\0';
             len = strlen(buf);
-            t_writestring(buf);
+            cur = len;
+            readline_redraw(buf, len, cur,
+                            rl_col, rl_row, vesa_rl_col, vesa_rl_row);
             continue;
         }
 
@@ -131,13 +221,18 @@ void shell_readline(char *buf, size_t max)
         if (c < 0x20 || c > 0x7E)
             continue;
 
-        /* Any typed character exits history-navigation mode. */
         hist_pos = -1;
 
         if (len < max - 1) {
-            buf[len++] = c;
-            buf[len]   = '\0';
-            t_putchar(c);
+            for (size_t i = len; i > cur; i--)
+                buf[i] = buf[i - 1];
+            buf[cur] = c;
+            len++;
+            cur++;
+            buf[len] = '\0';
+            Serial_WriteChar(c);
+            readline_redraw(buf, len, cur,
+                            rl_col, rl_row, vesa_rl_col, vesa_rl_row);
         }
     }
 
@@ -216,6 +311,10 @@ typedef enum {
     CMD_PANIC,
     CMD_CHAINLOAD,
     CMD_EXEC,
+    /* File I/O */
+    CMD_WRITE,
+    CMD_TOUCH,
+    CMD_CP,
     CMD_UNKNOWN,
 } shell_cmd_t;
 
@@ -258,6 +357,10 @@ static const cmd_entry_t cmd_table[] = {
     { "panic",      CMD_PANIC      },
     { "chainload",  CMD_CHAINLOAD  },
     { "exec",       CMD_EXEC       },
+    /* File I/O */
+    { "write",      CMD_WRITE      },
+    { "touch",      CMD_TOUCH      },
+    { "cp",         CMD_CP         },
 };
 
 #define CMD_TABLE_SIZE ((int)(sizeof(cmd_table) / sizeof(cmd_table[0])))
@@ -374,7 +477,11 @@ void shell_run(void)
         case CMD_RING3TEST:  cmd_ring3test();             break;
         case CMD_PANIC:      cmd_panic(argc, argv);       break;
         case CMD_CHAINLOAD:  cmd_chainload(argc, argv);   break;
-        case CMD_EXEC:       cmd_exec(argc, argv);        break;
+        case CMD_EXEC:       cmd_exec(argc, argv);         break;
+        /* File I/O */
+        case CMD_WRITE:      cmd_write(argc, argv);        break;
+        case CMD_TOUCH:      cmd_touch(argc, argv);        break;
+        case CMD_CP:         cmd_cp(argc, argv);           break;
         default:
             /* Medli-style error: red text, matching CommandConsole.cs */
             t_setcolor(SHELL_ERROR_COLOR_VGA);

--- a/src/kernel/arch/i386/shell/shell_cmds.c
+++ b/src/kernel/arch/i386/shell/shell_cmds.c
@@ -1033,5 +1033,161 @@ void cmd_exec(int argc, char **argv)
         return;
     }
 
-    task_yield();
+    /* Wait for the child to finish before returning to the shell prompt.
+     * Without this, both the exec task and the shell end up in keyboard_getchar
+     * simultaneously and the shell consumes the user's input. */
+    while (t->state != TASK_DEAD)
+        task_yield();
+}
+
+/* ---------------------------------------------------------------------------
+ * File I/O commands
+ * --------------------------------------------------------------------------- */
+
+/*
+ * write <file> <text...>
+ *
+ * Create or overwrite <file> with the given text (argv[2..] joined by spaces,
+ * with a trailing newline).  FAT32 /hd/ paths only.
+ */
+void cmd_write(int argc, char **argv)
+{
+    if (argc < 3) {
+        t_writestring("Usage: write <file> <text...>\n");
+        return;
+    }
+
+    static char s_write_buf[SHELL_MAX_INPUT];
+    size_t off = 0;
+
+    for (int i = 2; i < argc; i++) {
+        if (i > 2 && off < sizeof(s_write_buf) - 1)
+            s_write_buf[off++] = ' ';
+        const char *s = argv[i];
+        while (*s && off < sizeof(s_write_buf) - 1)
+            s_write_buf[off++] = *s++;
+    }
+    if (off < sizeof(s_write_buf) - 1)
+        s_write_buf[off++] = '\n';
+    s_write_buf[off] = '\0';
+
+    /* Resolve path against CWD if relative. */
+    static char s_write_path[VFS_PATH_MAX];
+    const char *arg = argv[1];
+    const char *cwd = vfs_getcwd();
+    if (arg[0] == '/') {
+        strncpy(s_write_path, arg, VFS_PATH_MAX - 1);
+        s_write_path[VFS_PATH_MAX - 1] = '\0';
+    } else {
+        size_t cl = strlen(cwd), al = strlen(arg);
+        if (cl + 1 + al >= VFS_PATH_MAX) { t_writestring("write: path too long\n"); return; }
+        size_t p = 0;
+        memcpy(s_write_path, cwd, cl); p += cl;
+        if (cwd[cl - 1] != '/') s_write_path[p++] = '/';
+        memcpy(s_write_path + p, arg, al + 1);
+    }
+
+    int err = vfs_write_file(s_write_path, s_write_buf, (uint32_t)off);
+    if (err) {
+        t_writestring("write: error ");
+        t_dec((uint32_t)(-err));
+        t_putchar('\n');
+    }
+}
+
+/*
+ * touch <file>
+ *
+ * Create an empty file, or do nothing if it already exists (zero-byte write).
+ */
+void cmd_touch(int argc, char **argv)
+{
+    if (argc < 2) {
+        t_writestring("Usage: touch <file>\n");
+        return;
+    }
+
+    static char s_touch_path[VFS_PATH_MAX];
+    const char *arg = argv[1];
+    const char *cwd = vfs_getcwd();
+    if (arg[0] == '/') {
+        strncpy(s_touch_path, arg, VFS_PATH_MAX - 1);
+        s_touch_path[VFS_PATH_MAX - 1] = '\0';
+    } else {
+        size_t cl = strlen(cwd), al = strlen(arg);
+        if (cl + 1 + al >= VFS_PATH_MAX) { t_writestring("touch: path too long\n"); return; }
+        size_t p = 0;
+        memcpy(s_touch_path, cwd, cl); p += cl;
+        if (cwd[cl - 1] != '/') s_touch_path[p++] = '/';
+        memcpy(s_touch_path + p, arg, al + 1);
+    }
+
+    int err = vfs_write_file(s_touch_path, "", 0);
+    if (err) {
+        t_writestring("touch: error ");
+        t_dec((uint32_t)(-err));
+        t_putchar('\n');
+    }
+}
+
+/* 64 KiB staging buffer shared by cp (static → lives in BSS, not on stack). */
+static uint8_t s_cp_buf[64u * 1024u];
+
+/*
+ * cp <src> <dst>
+ *
+ * Copy a file.  src may be on /cdrom or /hd; dst must be on /hd (FAT32).
+ * Paths are resolved against the CWD if relative.
+ */
+void cmd_cp(int argc, char **argv)
+{
+    if (argc < 3) {
+        t_writestring("Usage: cp <src> <dst>\n");
+        return;
+    }
+
+    /* Helper: resolve path (absolute or relative to CWD) into out[outsz]. */
+    static char s_cp_src[VFS_PATH_MAX];
+    static char s_cp_dst[VFS_PATH_MAX];
+
+    const char *cwd = vfs_getcwd();
+
+    const char *paths[2] = { argv[1], argv[2] };
+    char       *outs [2] = { s_cp_src, s_cp_dst };
+
+    for (int i = 0; i < 2; i++) {
+        const char *arg = paths[i];
+        char       *out = outs[i];
+        if (arg[0] == '/') {
+            strncpy(out, arg, VFS_PATH_MAX - 1);
+            out[VFS_PATH_MAX - 1] = '\0';
+        } else {
+            size_t cl = strlen(cwd), al = strlen(arg);
+            if (cl + 1 + al >= VFS_PATH_MAX) { t_writestring("cp: path too long\n"); return; }
+            size_t p = 0;
+            memcpy(out, cwd, cl); p += cl;
+            if (cwd[cl - 1] != '/') out[p++] = '/';
+            memcpy(out + p, arg, al + 1);
+        }
+    }
+
+    uint32_t size = 0;
+    int err = vfs_read_file(s_cp_src, s_cp_buf, sizeof(s_cp_buf), &size);
+    if (err) {
+        t_writestring("cp: cannot read '");
+        t_writestring(s_cp_src);
+        t_writestring("'\n");
+        return;
+    }
+
+    err = vfs_write_file(s_cp_dst, s_cp_buf, size);
+    if (err) {
+        t_writestring("cp: cannot write '");
+        t_writestring(s_cp_dst);
+        t_writestring("'\n");
+        return;
+    }
+
+    t_dec(size);
+    t_writestring(" bytes copied.\n");
 }

--- a/src/kernel/arch/i386/shell/shell_help.c
+++ b/src/kernel/arch/i386/shell/shell_help.c
@@ -70,6 +70,9 @@ void cmd_help(void)
     pager_line("  ls [path]                    - list directory (/hd/.. or /cdrom/..)\n");
     pager_line("  cd <path>                    - change directory\n");
     pager_line("  cat <file>                   - print file contents\n");
+    pager_line("  write <file> <text...>       - create/overwrite file with text\n");
+    pager_line("  touch <file>                 - create empty file\n");
+    pager_line("  cp <src> <dst>               - copy a file\n");
     pager_line("  mkdir <path>                 - create directory (FAT32 only)\n");
     pager_line("  isols <drv> [path]           - list directory on an ISO9660 CD-ROM\n");
     pager_line("Installer:\n");

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -90,4 +90,9 @@ void cmd_chainload(int argc, char **argv);
 /* Load and run an ELF32 executable from the VFS */
 void cmd_exec(int argc, char **argv);
 
+/* File I/O */
+void cmd_write(int argc, char **argv);
+void cmd_touch(int argc, char **argv);
+void cmd_cp(int argc, char **argv);
+
 #endif /* SHELL_PRIV_H */

--- a/src/kernel/include/kernel/shell.h
+++ b/src/kernel/include/kernel/shell.h
@@ -1,6 +1,8 @@
 #ifndef _KERNEL_SHELL_H
 #define _KERNEL_SHELL_H
 
+#include <stddef.h>
+
 /*
  * Minimal kernel REPL over VGA + PS/2 keyboard.
  *
@@ -8,5 +10,17 @@
  * VGA) have been initialised.  It never returns.
  */
 void shell_run(void);
+
+/*
+ * shell_readline – read and echo one line from the PS/2 keyboard into buf.
+ *
+ * Supports inline cursor movement (←/→), backspace at cursor, and history
+ * navigation (↑/↓).  Terminates on Enter; always NUL-terminates buf.
+ * Reads at most (max - 1) characters.
+ *
+ * Exposed here so the syscall layer can provide echoing stdin reads to
+ * ring-3 user-space processes (SYS_READ fd=0).
+ */
+void shell_readline(char *buf, size_t max);
 
 #endif /* _KERNEL_SHELL_H */

--- a/src/kernel/include/kernel/vesa_font.h
+++ b/src/kernel/include/kernel/vesa_font.h
@@ -6,8 +6,8 @@
 /*
  * 8×8 bitmap font for ASCII 0x00–0x7F.
  *
- * Each entry is 8 bytes (8 scanlines).  In each byte, bit 0 is the leftmost
- * pixel and bit 7 is the rightmost pixel.
+ * Each entry is 8 bytes (8 scanlines).  In each byte, bit 7 is the leftmost
+ * pixel and bit 0 is the rightmost pixel (standard IBM VGA MSB-first order).
  *
  * Based on the classic IBM PC VGA 8×8 character ROM glyph set, which is
  * widely reproduced and considered to be in the public domain.

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -14,6 +14,9 @@ bool vesa_tty_init(void);
 /* Returns true once vesa_tty_init() has succeeded. */
 bool vesa_tty_is_ready(void);
 
+/* Returns the current cursor column (in character cells). */
+uint32_t vesa_tty_get_col(void);
+
 /* Returns the current cursor row (in character cells). */
 uint32_t vesa_tty_get_row(void);
 
@@ -64,5 +67,12 @@ void vesa_tty_clear(void);
  * Safe to call before vesa_tty_init() — exits immediately if not ready.
  */
 void vesa_tty_set_scale(uint32_t scale);
+
+/*
+ * Move the VESA text cursor to (col, row) without drawing anything.
+ * Use this to re-synchronise the internal cursor after direct put_at() writes.
+ * Safe to call before vesa_tty_init() — exits immediately if not ready.
+ */
+void vesa_tty_set_cursor(uint32_t col, uint32_t row);
 
 #endif

--- a/src/kernel/include/kernel/vics.h
+++ b/src/kernel/include/kernel/vics.h
@@ -12,6 +12,7 @@
  *   Printable   — insert character at cursor
  *   Backspace   — delete character before cursor; join lines at column 0
  *   Enter       — split line at cursor (insert newline)
+ *   Tab         — insert 4 spaces
  *   Ctrl+S      — save file
  *   Ctrl+Q      — quit (press twice to discard unsaved changes)
  *

--- a/src/userspace/hello.c
+++ b/src/userspace/hello.c
@@ -9,18 +9,23 @@ static void write_str(const char *s)
 
 int main(void)
 {
-    char buf[128];
+    char name[64];
 
-    write_str("Hello from ring-3 userspace!\n");
-    write_str("Type something: ");
+    write_str("What is your name? ");
 
-    long n = sys_read(0, buf, sizeof(buf) - 1);
+    long n = sys_read(0, name, sizeof(name) - 1);
     if (n > 0) {
-        buf[n] = '\0';
-        write_str("You typed: ");
-        sys_write(1, buf, (unsigned int)n);
+        /* Strip trailing newline from shell_readline. */
+        if (name[n - 1] == '\n')
+            n--;
+        name[n] = '\0';
+    } else {
+        name[0] = '\0';
     }
 
-    write_str("Goodbye.\n");
+    write_str("Hello, ");
+    write_str(name[0] ? name : "stranger");
+    write_str("!\n");
+
     return 0;
 }


### PR DESCRIPTION
## Summary

- **readline**: inline cursor movement (left/right), insert/delete at cursor, history nav; redraws in-place with serial echo per character
- **VESA cursor fix**: `vesa_tty_get_col()` added so readline captures the correct VESA start column/row independently of `t_row`/`t_column`, which resets to 0 in VESA mode when the VGA row counter overflows
- **File I/O commands**: `write <file> <text...>`, `touch <file>`, `cp <src> <dst>` (all CWD-relative path aware)
- **VICS**: Tab inserts 4 spaces
- **ring-3 stdin**: `SYS_READ fd=0` now uses `shell_readline` for echoing, line-buffered input with backspace/cursor support
- **exec wait**: `cmd_exec` spin-waits on `TASK_DEAD` before returning to the shell prompt, preventing the shell and child task from racing on keyboard input
- **hello.c**: updated to prompt for user's name and print `Hello, <name>!`

## Test plan

- [ ] Type a command with left/right arrow editing and backspace mid-word; confirm in-place redraw is correct
- [ ] Verify typed characters appear in serial log
- [ ] Run `exec /cdrom/apps/hello.elf`; confirm it waits for input, prints `Hello, <name>!`, then returns cleanly to shell prompt
- [ ] `write /hd/test.txt hello world` + `cat /hd/test.txt` round-trip on a mounted FAT32 volume
- [ ] `touch /hd/empty.txt` creates zero-byte file
- [ ] `cp /hd/test.txt /hd/copy.txt` produces identical file
- [ ] `vics /hd/test.txt` — Tab key inserts 4 spaces
- [ ] `ktest` suite passes