### PR TITLE
ci: auto-release on main merge with date+sha pre-release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
-# Triggered by a version tag (e.g. v0.1.0).
-# Runs the full CI suite first via the reusable ci.yml workflow, then — only
-# if both iso-test and hdd-test pass — builds fresh interactive release
-# artifacts and publishes a GitHub release.
+# Triggered two ways:
+#   1. Push to main (PR merge) — auto-release tagged v<date>-<sha>, marked pre-release.
+#   2. Version tag push (e.g. v0.1.0) — proper versioned release.
+#
+# Both paths run the full CI suite (iso-test + hdd-test) before building artifacts.
 #
 # Release artifacts (interactive kernel, no TEST_MODE):
 #   makar.iso      – bootable CD-ROM image
@@ -11,6 +12,7 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
 
@@ -31,6 +33,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Compute release tag
+        id: tag
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            SHORT=$(git rev-parse --short HEAD)
+            DATE=$(date -u +%Y.%m.%d)
+            echo "name=v${DATE}-${SHORT}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # Build the release ISO (interactive kernel, default -O2 -g flags).
       # Runs inside the compiler container; output lands in the bind-mounted
@@ -56,6 +71,8 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          prerelease: ${{ steps.tag.outputs.prerelease }}
           files: |
             makar.iso
             makar-hdd.img


### PR DESCRIPTION
On every push to main (PR merge), run the full CI suite and — if both iso-test and hdd-test pass — publish a pre-release tagged v<date>-<sha> with the interactive makar.iso and makar-hdd.img artifacts attached.

Versioned tag pushes (v*) continue to produce proper stable releases as before.