### PR TITLE
feat: per-TTY buffers, /proc fs, glob+tab completion, v0.5.0

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,14 @@
+CompileFlags:
+  Add:
+    - -m32
+    - -ffreestanding
+    - -nostdinc
+    - -fno-builtin
+    - -isystem
+    - src/kernel/include
+    - -isystem
+    - src/libc/include
+    - -DDEV_BUILD
+  Remove:
+    - -mfpmath=*
+    - -m64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,8 +224,8 @@ src/kernel/arch/i386/
   core/       GDT/IDT (descr_tbl.c), ISR stub (isr_asm.S), interrupt dispatch (isr.c)
   mm/         pmm.c (frame allocator), paging.c, vmm.c (per-task page dirs), heap.c
   drivers/    serial, keyboard, timer, IDE, ACPI, partition
-  fs/         fat32.c, iso9660.c, vfs.c
-  display/    tty.c (VGA text), vesa.c + vesa_tty.c (VESA framebuffer)
+  fs/         fat32.c, iso9660.c, procfs.c (synthetic /proc), vfs.c
+  display/    tty.c (VGA text), vesa.c + vesa_tty.c (VESA framebuffer), vt.c (per-TTY backing grid)
   proc/       task.c + task_asm.S (scheduler), syscall.c, ring3.S, usertest.c, ktest.c, vtty.c
   shell/      shell.c, shell_cmd_{display,disk,fs,apps,system,man}.c, shell_help.c
   debug/      exception handlers (INT 1/3/8/13/14, serial-first output)
@@ -257,16 +257,18 @@ relevant source file and in `docs/userland-libc.md`.
 
 Makar boots to an interactive VESA shell with 4 independent TTYs.
 Alt+F1–F4 switches between them; each is a separate **preemptive** kernel
-task with its own kernel stack and (for ring-3 programs) its own page
-directory. Major subsystems:
+task with its own kernel stack, its own backing screen buffer (so a
+background TTY's accumulated output survives a focus switch — Linux VT
+behaviour), and (for ring-3 programs) its own page directory. Major
+subsystems:
 
-- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VICS and the TTY manager.
-- **Multi-TTY**: 4 shell tasks (`shell0`–`shell3`). Alt+F1–F4 switches focus; `vtty.c` routes keyboard input and sends `KEY_FOCUS_GAIN` to the newly active task. Each task redraws on focus gain.
+- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VICS. Per-TTY logical character grid (`vt_buf_t` in `display/vt.c`) backs every shell — writes go to the grid first; the framebuffer is only painted when that TTY is focused.
+- **Multi-TTY**: 4 shell tasks (`shell0`–`shell3`). `vtty.c` routes keyboard input via `task_t.tty` (authoritative) and tracks the focused slot. `vtty_switch()` defers the framebuffer repaint out of IRQ context to `vtty_drain_pending()`, which runs from the destination shell's `keyboard_getchar` poll loop. A tmux-style status bar lives in the reserved bottom row showing `Makar  VT0  VT1  VT2  VT3  ...  Alt+F1-F4` with the active slot highlighted.
 - **VICS**: Pane-aware text editor. Derives column/row counts from the active `vesa_pane_t` at runtime - works correctly at any VESA resolution. Modelled on ELKS/FUZIX vi: lightweight, stable, no heap after startup.
-- **Storage**: FAT32 (HDD/USB) + ISO 9660 (CD-ROM) via IDE PIO. VFS layer with CWD, auto-mount. Full read/write/delete/rename support on FAT32.
+- **Storage**: FAT32 (HDD/USB) + ISO 9660 (CD-ROM) via IDE PIO. VFS layer with CWD, auto-mount. Full read/write/delete/rename support on FAT32. Synthetic `/proc` mount exposes `cpuinfo`, `meminfo`, `tasks`, `uname` as read-only files generated on demand.
 - **Tasking**: Round-robin scheduler with timer-driven preemption (PIT 100 Hz, `SCHED_QUANTUM = 4` ticks → 40 ms slice). Per-task `pid`, `cwd`, `tty`, signal bitmasks, fd-table placeholder. User PD reaped on task exit. Background ktest harness runs before the shell prompt appears.
-- **Userspace**: Ring-3 protected mode via `iret`. ELF loader (`elf_exec`) with argc/argv. Syscalls: `SYS_EXIT`, `SYS_READ`, `SYS_WRITE` (fd 1 = VGA, fd 2 = VGA + COM1 serial), `SYS_OPEN`, `SYS_CLOSE`, `SYS_LSEEK`, `SYS_BRK`, `SYS_DEBUG`, `SYS_YIELD`, plus Makar extensions (200–211 - terminal/file ops + `SYS_WRITE_SERIAL`). Apps: `calc.elf`, `hello.elf`, `ls.elf`, `echo.elf`, `vics.elf`, `diskinfo.elf`, `rm.elf`, `mv.elf`, `cp.elf`, `kbtester.elf`.
-- **Shell**: Inline editing, history, tab completion, Ctrl+C sigint. `lsman` / `man <cmd>` replace `help`. Built-in file ops: `rm`, `rmdir`, `mv`. `uptime` shows humanised h/m/s.
+- **Userspace**: Ring-3 protected mode via `iret`. ELF loader (`elf_exec`) with argc/argv. Syscalls: `SYS_EXIT`, `SYS_READ`, `SYS_WRITE` (fd 1 = VGA, fd 2 = VGA + COM1 serial), `SYS_OPEN`, `SYS_CLOSE`, `SYS_LSEEK`, `SYS_BRK`, `SYS_DEBUG`, `SYS_YIELD`, plus Makar extensions (200–214 - terminal/file ops + `SYS_WRITE_SERIAL`). Apps: `calc.elf`, `hello.elf`, `ls.elf`, `echo.elf`, `vics.elf`, `diskinfo.elf`, `rm.elf`, `mv.elf`, `cp.elf`, `kbtester.elf`.
+- **Shell**: Inline editing, history, tab completion, Ctrl+C sigint. `lsman` / `man <cmd>` replace `help`. Built-in file ops: `rm`, `rmdir`, `mv`. `uptime` shows humanised h/m/s. `cat /proc/<entry>` for system introspection.
 - **GRUB**: Two-entry menu (Makar OS + Next available device), 5-second timeout.
 
 ## Recently merged
@@ -277,6 +279,8 @@ directory. Major subsystems:
 | #123 | `feat/tty-multitasking` | Preemptive 100 Hz scheduler, per-task `task_t` plumbing (pid/cwd/tty/sig/fd), user-PD reaper, ring-3 lifecycle ktest, `SYS_WRITE_SERIAL`, humanised `uptime` |
 | #124 | `feat/keyboard-layered` | Layered PS/2 driver rewrite (scancode → keycode → sentinel → router), IRQ-driven per-TTY rings, `kbtester.elf` ring-3 diagnostic |
 | #125 | `feat/test-infra-cleanup` | ccache toolchain image, single-kernel/two-ISO emit, build-once fan-out CI (4 parallel jobs), KVM auto-detect (off by default), `act` local validation, new split `*-build`/`*-run` modes in `run.sh` |
+| #127 | `feat/keyboard-hygiene` | Keyboard hardening - `unsigned char` audit complete, typematic-repeat filter for modifiers, PS/2 LED sync (`0xED <bitmap>`), boot-time LED state read |
+| #128 | `fix/reaper-uaf` | Reaper UAF (deferred PD free), keyboard IRQ-init order fix, loading-bar progress on startup, isolate ring-3 lifecycle suites from bg ktest |
 
 ## Future roadmap
 
@@ -291,21 +295,18 @@ Tracked here, pulled into branches one at a time so each PR stays focused.
 | 3 | **Ring-3 lifecycle ktest** with serial proof | ✅ shipped (`f48d730`, `1a34c20`) |
 | 4 | **100 Hz timer + humanised uptime** + stderr→serial + `SYS_WRITE_SERIAL` | ✅ shipped (`5e40001`) |
 | 5 | **Keyboard rewrite** - full PS/2 set-1 + e0, layered decoder (scancode→keycode→ASCII/sentinel→router), IRQ-driven per-TTY rings with proper SPSC memory ordering, strict make/break separation, modifier state at decoder, key repeat / rollover / lost-IRQ recovery, `unsigned char` end-to-end (no sign-extension hazard for sentinel compares), escape-clean sentinels | ✅ shipped (#124) |
-| 5b | **Keyboard hardening** - finish the `unsigned char` audit (sign-extension hazard regressed: kbtester panic with EIP=0xFFFFFF83 ≡ sign-extended 0x83 sentinel); typematic-repeat filter for Caps/Shift/Ctrl/Alt/Super so holding the key doesn't re-toggle/re-fire at 30 Hz (visible in kbtester log as bursts of sentinel 0x94 making `mod_caps` oscillate); LED sync (`0xED <CNS bitmap>` to PS/2 after every Caps/Num/Scroll state change); boot-time read of physical LED state. | 🔥 **NEXT - urgent** |
+| 5b | **Keyboard hardening** - `unsigned char` audit, typematic-repeat filter for modifiers, PS/2 LED sync, boot-time LED state read | ✅ shipped (#127) |
 | 6 | **Test-infra cleanup** - ccache, single-kernel/two-ISO, build-once fan-out CI, KVM gate | ✅ shipped (#125) |
-| 7 | **Per-task consumer migration** - VFS `task->cwd`, vtty `task->tty`, real per-task FD table replaces keyboard owner ad-hoc | ⏭ |
+| 7 | **Per-task consumer migration** - vtty `task->tty` authoritative (drop `vtty_tasks[]` parallel array). VFS `task->cwd` and real per-task FD table remain on the queue. | ✅ partial (vtty done) |
 | 8 | **Linux-style signal subsystem** - full sigaction table, `kill()` syscall, htop-style picker | ⏭ |
 | 9 | **Preemption hardening** - interrupt-safe `schedule()`, per-task tick accounting, runtime-tunable quantum, busy-loop ktest | ⏭ |
-| 10 | **Per-TTY screen buffers** + task pausing in background TTYs | ⏭ |
-| 11 | **`ps`-style task listing** with privilege/state/CWD/TTY columns | ⏭ |
+| 10 | **Per-TTY screen buffers** - `vt_buf_t` backing grid per TTY, write-through to FB only when focused, repaint on Alt+Fn (deferred out of IRQ). tmux-style status bar at bottom row. `/proc` synthetic FS with `cpuinfo/meminfo/tasks/uname`. VGA-text fallback path stays on shared buffer (deferred). | ✅ shipped (this PR) |
+| 11 | **`ps`-style task listing** with privilege/state/CWD/TTY columns | ⏭ (covered by `cat /proc/tasks` for now) |
 | 12 | **fork() readiness** - PD clone (CoW), fd dup, PID alloc, return-value split | ⏭ |
 | 13 | **UTF-8 terminal** with ASCII fallback / runtime mode switch | ⏭ deferred |
-
-**Keyboard hardening - observed symptoms** (2026-05-13, kbtester session under PR #125's debug build):
-
-1. **Page fault with EIP=0xFFFFFF83 ≡ `(int32_t)(int8_t)0x83`** — sentinel byte 0x83 (KEY_ARROW_RIGHT) sign-extended through a `char` somewhere on the dispatch path, then the resulting negative value was treated as an address / function-pointer-derived value and the CPU faulted on the instruction fetch. The bit pattern is the smoking gun. Slice 5 explicitly called out `unsigned char` end-to-end; the audit needs to be redone post-merge — every cast, ring-buffer element type, table index, and compare on the keyboard path must be `unsigned char` (or `uint8_t`). Fault error code `[NP|READ|KERNEL]` from EIP=fault-addr confirms it was an instruction-fetch fault, not a data access.
-2. **Caps Lock oscillates under hold** — `apply_modifier()` does `if (down) mod_caps = !mod_caps` with no typematic-repeat filter. PS/2 hardware repeats Caps make codes at ~30 Hz; each repeat re-toggles. kbtester log shows bursts of sentinel 0x94 (e.g. entries 0049–0051 = 3 repeats, 0035–0036 = 2 repeats) confirming the hardware behaviour reaches the decoder unfiltered. Apply the same fix to Shift/Ctrl/Alt/Super and any other modifier that the decoder treats as edge-triggered. Standard approach: track `prev_make_kc`; ignore a make code that matches `prev_make_kc` without an intervening break.
-3. **No LED feedback / no boot-time sync** — kernel never writes `0xED <bitmap>` to the PS/2 controller, so the physical Caps/Num/Scroll LEDs never reflect kernel state, and at boot the kernel assumes all three are off regardless of BIOS state.
+| 14 | **Per-task FD table** - replace global keyboard owner + opaque `fd_table` placeholder with a real array; pipe(2) / dup(2) fall out naturally | 🔥 **NEXT** |
+| 15 | **VFS `task->cwd` authoritative** - drop the `s_cwd` global in `vfs.c`; resolve relative paths against the calling task's cwd | ⏭ |
+| 16 | **VGA-fallback per-TTY** - route `tty.c` writes through `vt_buf` so VGA-text mode gets the same per-TTY isolation that VESA already has | ⏭ |
 
 ### Userspace / libc porting
 

--- a/SURVEY.md
+++ b/SURVEY.md
@@ -144,6 +144,7 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 - `/` - virtual root; lists mount-points
 - `/hd/…` - FAT32 hard disk (mounted via `mount` command)
 - `/cdrom/…` - ISO9660 CD-ROM (auto-detected at init)
+- `/proc/…` - synthetic, always-present read-only view of kernel state (`cpuinfo`, `meminfo`, `tasks`, `uname`)
 
 ### Lifecycle
 - `vfs_init()` - probe IDE for ISO9660; reset CWD to `/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ roadmap.
 | [heap](kernel/heap.md) | Kernel heap allocator (`kmalloc` / `kfree`) |
 | [vesa](kernel/vesa.md) | VESA linear framebuffer driver |
 | [vesa_tty](kernel/vesa_tty.md) | VESA bitmap-font text renderer |
+| [vt](kernel/vt.md) | Per-TTY logical character grid (Linux `vc_data`-style backing buffer) |
+| [vtty](kernel/vtty.md) | Virtual TTY manager (focus, Alt+Fn switch, deferred repaint, status bar) |
 | [debug](kernel/debug.md) | INT 1 / INT 3 debug-exception handlers |
 | [multiboot](kernel/multiboot.md) | Multiboot 2 structure definitions |
 | [keyboard](kernel/keyboard.md) | PS/2 keyboard driver (IRQ 1, scan-code set 1, ring buffer) |
@@ -35,6 +37,7 @@ roadmap.
 
 | [fat32](kernel/fat32.md) | FAT32 filesystem driver (read, write, delete, rename) |
 | [vfs](kernel/vfs.md) | Virtual filesystem layer (unified path namespace) |
+| [procfs](kernel/procfs.md) | Synthetic `/proc` filesystem (`cpuinfo`, `meminfo`, `tasks`, `uname`) |
 | [syscall](kernel/syscall.md) | int 0x80 syscall dispatcher and userspace ABI |
 | [vmm](kernel/vmm.md) | Per-task page directory and ring-3 memory management |
 | [task](kernel/task.md) | Cooperative round-robin task scheduler |

--- a/docs/kernel/procfs.md
+++ b/docs/kernel/procfs.md
@@ -1,0 +1,40 @@
+# procfs - synthetic /proc filesystem
+
+`src/kernel/include/kernel/procfs.h` + `src/kernel/arch/i386/fs/procfs.c`.
+
+## Purpose
+
+Linux-style read-only view of kernel state. Each entry is generated on read
+by a small renderer that walks live kernel state and writes ASCII into the
+caller's buffer. No on-disk storage; nothing is cached between reads.
+
+## Entries
+
+| Path | Renderer | Content |
+|---|---|---|
+| `/proc/cpuinfo` | CPUID leaves 0 + 1 | `vendor_id`, `cpu family`, `model`, `stepping`, `flags` (fpu/tsc/msr/pae/apic/cmov/mmx/sse/sse2/sse3/sse4_1/sse4_2), `arch i386 (protected mode)` |
+| `/proc/meminfo` | `pmm_free_count()` + `heap_used/free()` | `MemFree`, `PageSize`, `FreeFrames`, `HeapTotal`, `HeapUsed`, `HeapFree` (all in kB where applicable) |
+| `/proc/tasks` | Walk `task_pool[]` | One row per task: `PID NAME STATE TTY CWD` |
+| `/proc/uname` | Build macros + `timer_get_ticks()` | `Makar 0.1.0 (i386) built <date> <time>` + uptime ticks |
+
+## VFS integration
+
+Wired in [vfs.c](vfs.md) as a new backend (`VFS_FS_PROC = 3`):
+
+- `vfs_route()` recognises any path under `/proc`.
+- `vfs_ls("/proc")` calls `procfs_ls()` to print the entry list.
+- `vfs_cat()` / `vfs_read_file()` route to `procfs_read_file()`.
+- `vfs_complete()` lets tab-completion enumerate `/proc/<entry>`.
+- `vfs_file_exists()` returns 1 for known entries.
+
+procfs is **flat** (no subdirectories) and **read-only** (no `vfs_write_file`
+path). `cd /proc` is allowed; `cd /proc/cpuinfo` is rejected as not-a-dir.
+
+## Adding a new entry
+
+1. Add a `PROC_XXX` enum value and an entry to the `s_entries[]` table.
+2. Write a `render_xxx(pf_writer_t *w)` function using `pf_puts`, `pf_putu`,
+   `pf_putc`.
+3. Add a dispatch case in `procfs_read_file`.
+
+No changes to vfs.c are needed.

--- a/docs/kernel/procfs.md
+++ b/docs/kernel/procfs.md
@@ -15,7 +15,7 @@ caller's buffer. No on-disk storage; nothing is cached between reads.
 | `/proc/cpuinfo` | CPUID leaves 0 + 1 | `vendor_id`, `cpu family`, `model`, `stepping`, `flags` (fpu/tsc/msr/pae/apic/cmov/mmx/sse/sse2/sse3/sse4_1/sse4_2), `arch i386 (protected mode)` |
 | `/proc/meminfo` | `pmm_free_count()` + `heap_used/free()` | `MemFree`, `PageSize`, `FreeFrames`, `HeapTotal`, `HeapUsed`, `HeapFree` (all in kB where applicable) |
 | `/proc/tasks` | Walk `task_pool[]` | One row per task: `PID NAME STATE TTY CWD` |
-| `/proc/uname` | Build macros + `timer_get_ticks()` | `Makar 0.1.0 (i386) built <date> <time>` + uptime ticks |
+| `/proc/uname` | `MAKAR_VERSION` + build macros + `timer_get_ticks()` | `Makar 0.5.0 (i386) built <date> <time>` + uptime ticks |
 
 ## VFS integration
 

--- a/docs/kernel/vt.md
+++ b/docs/kernel/vt.md
@@ -1,0 +1,59 @@
+# vt - virtual console backing grid
+
+`src/kernel/include/kernel/vt.h` + `src/kernel/arch/i386/display/vt.c`.
+
+## Purpose
+
+`vt_buf_t` is a logical `cols × rows` character grid plus cursor and current
+attribute. One instance per virtual terminal (allocated and owned by
+[vtty](vtty.md)). Pure data layer - no framebuffer knowledge.
+
+Modelled on Linux's `vc_data.vc_screenbuf` and the ELKS / xv6 console
+backing-buffer pattern. Lets background TTYs accumulate output silently and
+have it surface atomically when the user switches focus.
+
+## Data layout
+
+```c
+typedef struct vt_cell {
+    uint8_t  ch;
+    uint8_t  flags;   /* reserved (bold/inverse later) */
+    uint32_t fg;      /* renderer-specific - composed FB pixel for VESA */
+    uint32_t bg;
+} vt_cell_t;
+
+typedef struct vt_buf {
+    uint32_t   cols, rows;
+    uint32_t   cur_col, cur_row;
+    uint32_t   fg, bg;        /* current attribute for incoming chars */
+    vt_cell_t *cells;         /* heap, row-major: cells[row*cols + col] */
+} vt_buf_t;
+```
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `vt_init(vt, cols, rows, fg, bg)` | Allocate grid on heap; init all cells to space-on-bg. |
+| `vt_putchar(vt, c)` | Write `c` at cursor, advance, scroll. Honours `\n`, `\r`, `\b`. Returns `vt_dirty_t` so the renderer knows whether to paint one cell or repaint the whole grid (scroll). |
+| `vt_put_at(vt, c, col, row)` | Write `c` at fixed cell, no cursor move. |
+| `vt_set_color(vt, fg, bg)` | Update current attribute. |
+| `vt_set_cursor(vt, col, row)` | Move cursor; clamped to grid. |
+| `vt_clear(vt)` | Fill grid with space-on-bg; reset cursor. |
+| `vt_get_cell(vt, col, row)` | Read-only cell access (bounds-checked). |
+
+## Renderer integration
+
+vesa_tty.c routes the legacy global API (`vesa_tty_putchar` etc.) through the
+calling task's `vt_buf_t`:
+
+1. Write update to the backing grid.
+2. If the grid matches `vtty_buf_focused()`, paint only the cell that changed
+   (or the full grid on scroll) to the framebuffer.
+3. If not focused, do nothing visible - the grid will surface on the next
+   `vtty_switch`.
+
+The VGA-text fallback path (tty.c) currently shares one buffer across all
+TTYs; the per-TTY routing is a follow-up.
+
+See also: [vtty](vtty.md), [vesa_tty](vesa_tty.md).

--- a/docs/kernel/vtty.md
+++ b/docs/kernel/vtty.md
@@ -1,0 +1,56 @@
+# vtty - virtual TTY manager
+
+`src/kernel/include/kernel/vtty.h` + `src/kernel/arch/i386/proc/vtty.c`.
+
+## Purpose
+
+Up to `VTTY_MAX = 4` shell tasks run concurrently. Alt+F1–F4 switches the
+active (focused) TTY. Only the active TTY paints to the physical framebuffer;
+background TTYs keep writing into their own [vt_buf_t](vt.md) and the
+accumulated state is repainted atomically when the user switches back. This
+is Linux's classic VT model.
+
+## Authoritative state
+
+`task_t.tty` (in `kernel/task.h`) is authoritative for which TTY a task is
+bound to. vtty itself owns:
+
+| Field | Purpose |
+|---|---|
+| `vtty_nslots` | How many slots have been registered |
+| `vtty_current` | Index of the focused slot |
+| `vtty_bufs[VTTY_MAX]` | Per-slot [vt_buf_t](vt.md) backing grids |
+| `vtty_pending` | Deferred-paint target (set in IRQ, drained in task context) |
+
+The "owning task" of slot N is resolved by walking the task pool for the
+live task with the lowest pid whose `task->tty == N` (the registered shell —
+exec children inherit `tty` but always have higher pids).
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `vtty_init()` | Allocate the four backing grids sized to the display geometry (last row reserved for the status bar). |
+| `vtty_register()` | Called by `shell_run` at start. Assigns the calling task to the next free slot and sets `task->tty`. |
+| `vtty_switch(n)` | Called from the keyboard IRQ when Alt+F<n+1> fires. Updates focus, sends `KEY_FOCUS_GAIN` to the new owner, records a pending repaint target. Returns immediately - the paint is deferred. |
+| `vtty_drain_pending()` | Called from `keyboard_getchar`'s wait loop. If a pending paint exists *and the calling task owns the destination TTY*, paint the new buffer to the framebuffer. The owner-check avoids races where a non-focused shell would paint over the destination shell's concurrent writes. |
+| `vtty_buf(n)` / `vtty_buf_current()` / `vtty_buf_focused()` | Accessors for renderer code. |
+| `vtty_active()` / `vtty_count()` / `vtty_is_focused()` | State queries. |
+
+## Why deferred paint
+
+Painting the framebuffer from `vtty_switch` directly meant doing thousands
+of pixel writes inside the keyboard IRQ handler. That held the i8042's
+1-byte OBF full long enough that the edge-triggered PIC missed subsequent
+key edges - the same failure shape as PR #127's regression. Recording a
+pending target and letting `keyboard_getchar` drain it in task context
+keeps the IRQ short.
+
+## Status bar
+
+`vtty_init` shrinks each backing grid by `VTTY_STATUS_ROWS = 1` so the
+bottom framebuffer row is reserved for a tmux-style indicator
+(`vesa_tty_paint_status` in vesa_tty.c). The bar lists `VT0 VT1 VT2 VT3`
+with the active slot highlighted; it is repainted on `vtty_register`,
+`vtty_switch`, and `vesa_tty_clear` so it survives focus changes and
+full-screen clears.

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -449,6 +449,52 @@ void vesa_tty_paint_cell(uint32_t col, uint32_t row, char ch,
 	paint_cell(ch, fg, bg, col, row);
 }
 
+void vesa_tty_paint_string_at(uint32_t col, uint32_t row, const char *s,
+                              uint32_t fg_rgb, uint32_t bg_rgb)
+{
+	if (!tty_ready || !s) return;
+	uint32_t fg = compose_rgb(fg_rgb);
+	uint32_t bg = compose_rgb(bg_rgb);
+	while (*s && col < tty_cols) {
+		paint_cell(*s++, fg, bg, col++, row);
+	}
+}
+
+void vesa_tty_paint_status(int active, int count)
+{
+	if (!tty_ready) return;
+	uint32_t row = tty_rows - 1;     /* bottom row reserved for status */
+	uint32_t bar_fg = 0xC0C0C0;      /* light grey on dark             */
+	uint32_t bar_bg = 0x202020;
+	uint32_t act_fg = 0x000000;      /* black-on-yellow active marker  */
+	uint32_t act_bg = 0xFFC800;
+
+	/* Wipe the row first. */
+	for (uint32_t c = 0; c < tty_cols; c++)
+		paint_cell(' ', compose_rgb(bar_fg), compose_rgb(bar_bg), c, row);
+
+	/* Left-aligned "Makar" label. */
+	vesa_tty_paint_string_at(1, row, "Makar", bar_fg, bar_bg);
+
+	/* TTY indicators starting at column 8. */
+	uint32_t col = 8;
+	for (int i = 0; i < count && col + 5 < tty_cols; i++) {
+		char label[6] = { ' ', 'V', 'T', (char)('0' + i), ' ', '\0' };
+		if (i == active)
+			vesa_tty_paint_string_at(col, row, label, act_fg, act_bg);
+		else
+			vesa_tty_paint_string_at(col, row, label, bar_fg, bar_bg);
+		col += 6;
+	}
+
+	/* Right-aligned hint. */
+	const char *hint = "Alt+F1-F4";
+	uint32_t hlen = 9;
+	if (tty_cols > hlen + 2)
+		vesa_tty_paint_string_at(tty_cols - hlen - 1, row, hint,
+		                         bar_fg, bar_bg);
+}
+
 void vesa_tty_paint_buf(const vt_buf_t *vt)
 {
 	if (!tty_ready || !vt || !vt->cells) return;
@@ -578,6 +624,10 @@ void vesa_tty_clear(void)
 	 * next set_cursor saves fresh pixels instead of restoring stale
 	 * ones over the now-blank cell. */
 	caret_drawn = false;
+	/* Restore the status bar - vesa_clear blew it away.  Only relevant
+	 * when called from a vtty-bound task; the no-task / boot path runs
+	 * before vtty_init so paint_status is a no-op then anyway. */
+	if (vt) vesa_tty_paint_status(vtty_active(), vtty_count());
 }
 
 void vesa_tty_spinner_tick(uint32_t tick)

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -3,6 +3,8 @@
 #include <kernel/vesa_font.h>
 #include <kernel/paging.h>
 #include <kernel/serial.h>
+#include <kernel/vt.h>
+#include <kernel/vtty.h>
 #include <string.h>
 
 /* Scale factor applied to every glyph pixel.  2 makes each 8×8 glyph appear
@@ -411,29 +413,147 @@ uint32_t vesa_tty_pane_get_col(const vesa_pane_t *p) { return p->cur_col; }
 uint32_t vesa_tty_pane_get_row(const vesa_pane_t *p) { return p->cur_row; }
 
 /* ------------------------------------------------------------------ */
-/* Legacy global API - delegates to the default pane                  */
+/* Cell paint primitives - take explicit fg/bg, used by both the      */
+/* global API and by vtty_switch when repainting a full buffer.       */
 /* ------------------------------------------------------------------ */
 
-uint32_t vesa_tty_get_col(void) { return default_pane.cur_col; }
-uint32_t vesa_tty_get_row(void) { return default_pane.cur_row; }
+/* Render glyph ch at absolute cell (col, row) with explicit fg/bg.
+ * Caller pre-clipped; we still bounds-check defensively. */
+static void paint_cell(char ch, uint32_t fg, uint32_t bg,
+                       uint32_t col, uint32_t row)
+{
+	if (!tty_ready) return;
+	if (col >= tty_cols || row >= tty_rows) return;
+	caret_invalidate_at(col, row);
+
+	uint8_t idx = (uint8_t)ch;
+	if (idx >= 128) idx = 0;
+	const uint8_t *glyph = FONT8x8[idx];
+	uint32_t px = col * FONT_CELL_W;
+	uint32_t py = row * FONT_CELL_H;
+	for (uint32_t y = 0; y < FONT8x8_CHAR_H; y++) {
+		uint8_t bits = glyph[y];
+		for (uint32_t x = 0; x < FONT8x8_CHAR_W; x++) {
+			uint32_t colour = (bits & (1u << x)) ? fg : bg;
+			for (uint32_t sy = 0; sy < font_scale; sy++)
+				for (uint32_t sx = 0; sx < font_scale; sx++)
+					vesa_put_pixel(px + x * font_scale + sx,
+					               py + y * font_scale + sy, colour);
+		}
+	}
+}
+
+void vesa_tty_paint_cell(uint32_t col, uint32_t row, char ch,
+                         uint32_t fg, uint32_t bg)
+{
+	paint_cell(ch, fg, bg, col, row);
+}
+
+void vesa_tty_paint_buf(const vt_buf_t *vt)
+{
+	if (!tty_ready || !vt || !vt->cells) return;
+	/* Hide the caret first - the strip stash holds pixels from the OLD VT;
+	 * those would smear back over the new VT's content on the next move. */
+	caret_drawn = false;
+	for (uint32_t r = 0; r < vt->rows && r < tty_rows; r++) {
+		for (uint32_t c = 0; c < vt->cols && c < tty_cols; c++) {
+			vt_cell_t cell = vt->cells[r * vt->cols + c];
+			paint_cell((char)cell.ch, cell.fg, cell.bg, c, r);
+		}
+	}
+	/* Sync the default pane's cursor + colours to the buffer we just
+	 * painted, so subsequent caret rendering lands at the right spot. */
+	default_pane.cur_col = (vt->cur_col < default_pane.cols)
+	                     ? vt->cur_col : (default_pane.cols - 1);
+	default_pane.cur_row = (vt->cur_row < default_pane.rows)
+	                     ? vt->cur_row : (default_pane.rows - 1);
+	default_pane.fg = vt->fg;
+	default_pane.bg = vt->bg;
+	vesa_tty_pane_set_cursor(&default_pane,
+	                         default_pane.cur_col, default_pane.cur_row);
+}
+
+/* ------------------------------------------------------------------ */
+/* Legacy global API - now routes through the calling task's vt_buf.  */
+/*                                                                     */
+/* Resolution:                                                          */
+/*   - If task_current() has a TTY index (->tty >= 0), writes update    */
+/*     vtty_buf(tty); only the cell that changed is mirrored to the FB  */
+/*     when that buffer matches vtty_buf_focused().                     */
+/*   - If no current task or task->tty == TASK_TTY_NONE (boot CPU,      */
+/*     idle, ktest_bg), writes fall through to the default_pane path    */
+/*     directly so kernel boot output still hits the framebuffer.       */
+/* ------------------------------------------------------------------ */
+
+uint32_t vesa_tty_get_col(void)
+{
+	vt_buf_t *vt = vtty_buf_current();
+	if (vt) return vt->cur_col;
+	return default_pane.cur_col;
+}
+
+uint32_t vesa_tty_get_row(void)
+{
+	vt_buf_t *vt = vtty_buf_current();
+	if (vt) return vt->cur_row;
+	return default_pane.cur_row;
+}
 
 void vesa_tty_putchar(char c)
 {
-	vesa_tty_pane_putchar(&default_pane, c);
+	vt_buf_t *vt = vtty_buf_current();
+	if (!vt) {
+		vesa_tty_pane_putchar(&default_pane, c);
+		return;
+	}
+
+	bool   focused = (vt == vtty_buf_focused());
+	vt_dirty_t d   = vt_putchar(vt, c);
+
+	if (!focused) return;
+
+	if (d.scrolled) {
+		vesa_tty_paint_buf(vt);
+		return;
+	}
+	if (d.has_cell) {
+		vt_cell_t cell = vt_get_cell(vt, d.col, d.row);
+		paint_cell((char)cell.ch, cell.fg, cell.bg, d.col, d.row);
+	}
+	/* Sync the FB cursor (caret) to vt's new cursor.  Even pure control
+	 * chars like \\r move the cursor visibly. */
+	vesa_tty_pane_set_cursor(&default_pane, vt->cur_col, vt->cur_row);
 }
 
 void vesa_tty_setcolor(uint32_t fg_rgb, uint32_t bg_rgb)
 {
+	/* Compose to framebuffer pixel format once; both default_pane and the
+	 * backing vt_buf store the composed value. */
 	vesa_tty_pane_setcolor(&default_pane, fg_rgb, bg_rgb);
+	vt_buf_t *vt = vtty_buf_current();
+	if (vt) vt_set_color(vt, default_pane.fg, default_pane.bg);
 }
 
 void vesa_tty_put_at(char c, uint32_t col, uint32_t row)
 {
-	vesa_tty_pane_put_at(&default_pane, c, col, row);
+	vt_buf_t *vt = vtty_buf_current();
+	if (!vt) {
+		vesa_tty_pane_put_at(&default_pane, c, col, row);
+		return;
+	}
+	vt_put_at(vt, c, col, row);
+	if (vt == vtty_buf_focused())
+		paint_cell(c, vt->fg, vt->bg, col, row);
 }
 
 void vesa_tty_set_cursor(uint32_t col, uint32_t row)
 {
+	vt_buf_t *vt = vtty_buf_current();
+	if (vt) {
+		vt_set_cursor(vt, col, row);
+		if (vt != vtty_buf_focused())
+			return;
+	}
 	vesa_tty_pane_set_cursor(&default_pane, col, row);
 }
 
@@ -441,8 +561,15 @@ void vesa_tty_clear(void)
 {
 	if (!tty_ready)
 		return;
-	/* Match legacy behaviour: clear the whole screen, including any sub-pane
-	 * regions that may have been carved out by phase-3 callers. */
+
+	vt_buf_t *vt = vtty_buf_current();
+	if (vt) {
+		vt_clear(vt);
+		if (vt != vtty_buf_focused())
+			return;
+	}
+
+	/* Focused-buffer (or no-task) clear: paint the framebuffer too. */
 	vesa_clear(default_pane.bg);
 	default_pane.cur_col = 0;
 	default_pane.cur_row = 0;

--- a/src/kernel/arch/i386/display/vt.c
+++ b/src/kernel/arch/i386/display/vt.c
@@ -79,9 +79,10 @@ void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row)
                  (uint8_t)c, vt->fg, vt->bg);
 }
 
-void vt_putchar(vt_buf_t *vt, char c)
+vt_dirty_t vt_putchar(vt_buf_t *vt, char c)
 {
-    if (!vt->cells || vt->cols == 0 || vt->rows == 0) return;
+    vt_dirty_t d = { 0, 0, 0, 0 };
+    if (!vt->cells || vt->cols == 0 || vt->rows == 0) return d;
 
     /* Clamp transient out-of-range cursor (preemption between increment
      * and bounds check elsewhere). */
@@ -90,11 +91,13 @@ void vt_putchar(vt_buf_t *vt, char c)
         if (++vt->cur_row >= vt->rows) {
             vt_scroll_up(vt);
             vt->cur_row = vt->rows - 1;
+            d.scrolled = 1;
         }
     }
     if (vt->cur_row >= vt->rows) {
         vt_scroll_up(vt);
         vt->cur_row = vt->rows - 1;
+        d.scrolled = 1;
     }
 
     if (c == '\n') {
@@ -102,13 +105,14 @@ void vt_putchar(vt_buf_t *vt, char c)
         if (++vt->cur_row >= vt->rows) {
             vt_scroll_up(vt);
             vt->cur_row = vt->rows - 1;
+            d.scrolled = 1;
         }
-        return;
+        return d;
     }
 
     if (c == '\r') {
         vt->cur_col = 0;
-        return;
+        return d;
     }
 
     if (c == '\b') {
@@ -116,18 +120,29 @@ void vt_putchar(vt_buf_t *vt, char c)
             vt->cur_col--;
         vt_fill_cell(&vt->cells[(size_t)vt->cur_row * vt->cols + vt->cur_col],
                      ' ', vt->fg, vt->bg);
-        return;
+        d.has_cell = 1;
+        d.col = vt->cur_col;
+        d.row = vt->cur_row;
+        return d;
     }
 
-    vt_fill_cell(&vt->cells[(size_t)vt->cur_row * vt->cols + vt->cur_col],
+    uint32_t wrote_col = vt->cur_col;
+    uint32_t wrote_row = vt->cur_row;
+    vt_fill_cell(&vt->cells[(size_t)wrote_row * vt->cols + wrote_col],
                  (uint8_t)c, vt->fg, vt->bg);
+    d.has_cell = 1;
+    d.col = wrote_col;
+    d.row = wrote_row;
+
     if (++vt->cur_col >= vt->cols) {
         vt->cur_col = 0;
         if (++vt->cur_row >= vt->rows) {
             vt_scroll_up(vt);
             vt->cur_row = vt->rows - 1;
+            d.scrolled = 1;
         }
     }
+    return d;
 }
 
 vt_cell_t vt_get_cell(const vt_buf_t *vt, uint32_t col, uint32_t row)

--- a/src/kernel/arch/i386/display/vt.c
+++ b/src/kernel/arch/i386/display/vt.c
@@ -1,0 +1,138 @@
+/*
+ * vt.c - virtual console backing grid.  See kernel/vt.h.
+ */
+
+#include <kernel/vt.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void vt_fill_cell(vt_cell_t *c, uint8_t ch, uint32_t fg, uint32_t bg)
+{
+    c->ch    = ch;
+    c->flags = 0;
+    c->fg    = fg;
+    c->bg    = bg;
+}
+
+bool vt_init(vt_buf_t *vt, uint32_t cols, uint32_t rows,
+             uint32_t default_fg, uint32_t default_bg)
+{
+    vt->cols    = cols;
+    vt->rows    = rows;
+    vt->cur_col = 0;
+    vt->cur_row = 0;
+    vt->fg      = default_fg;
+    vt->bg      = default_bg;
+
+    size_t n = (size_t)cols * (size_t)rows;
+    vt->cells = (vt_cell_t *)malloc(n * sizeof(vt_cell_t));
+    if (!vt->cells) return false;
+
+    for (size_t i = 0; i < n; i++)
+        vt_fill_cell(&vt->cells[i], ' ', default_fg, default_bg);
+    return true;
+}
+
+void vt_set_color(vt_buf_t *vt, uint32_t fg, uint32_t bg)
+{
+    vt->fg = fg;
+    vt->bg = bg;
+}
+
+void vt_set_cursor(vt_buf_t *vt, uint32_t col, uint32_t row)
+{
+    if (vt->cols == 0 || vt->rows == 0) return;
+    if (col >= vt->cols) col = vt->cols - 1;
+    if (row >= vt->rows) row = vt->rows - 1;
+    vt->cur_col = col;
+    vt->cur_row = row;
+}
+
+void vt_clear(vt_buf_t *vt)
+{
+    vt->cur_col = 0;
+    vt->cur_row = 0;
+    if (!vt->cells) return;
+    size_t n = (size_t)vt->cols * (size_t)vt->rows;
+    for (size_t i = 0; i < n; i++)
+        vt_fill_cell(&vt->cells[i], ' ', vt->fg, vt->bg);
+}
+
+static void vt_scroll_up(vt_buf_t *vt)
+{
+    if (vt->rows <= 1) {
+        vt_clear(vt);
+        return;
+    }
+    size_t row_bytes = (size_t)vt->cols * sizeof(vt_cell_t);
+    memmove(vt->cells, vt->cells + vt->cols, (size_t)(vt->rows - 1) * row_bytes);
+    vt_cell_t *last = vt->cells + (size_t)(vt->rows - 1) * vt->cols;
+    for (uint32_t c = 0; c < vt->cols; c++)
+        vt_fill_cell(&last[c], ' ', vt->fg, vt->bg);
+}
+
+void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row)
+{
+    if (!vt->cells) return;
+    if (col >= vt->cols || row >= vt->rows) return;
+    vt_fill_cell(&vt->cells[(size_t)row * vt->cols + col],
+                 (uint8_t)c, vt->fg, vt->bg);
+}
+
+void vt_putchar(vt_buf_t *vt, char c)
+{
+    if (!vt->cells || vt->cols == 0 || vt->rows == 0) return;
+
+    /* Clamp transient out-of-range cursor (preemption between increment
+     * and bounds check elsewhere). */
+    if (vt->cur_col >= vt->cols) {
+        vt->cur_col = 0;
+        if (++vt->cur_row >= vt->rows) {
+            vt_scroll_up(vt);
+            vt->cur_row = vt->rows - 1;
+        }
+    }
+    if (vt->cur_row >= vt->rows) {
+        vt_scroll_up(vt);
+        vt->cur_row = vt->rows - 1;
+    }
+
+    if (c == '\n') {
+        vt->cur_col = 0;
+        if (++vt->cur_row >= vt->rows) {
+            vt_scroll_up(vt);
+            vt->cur_row = vt->rows - 1;
+        }
+        return;
+    }
+
+    if (c == '\r') {
+        vt->cur_col = 0;
+        return;
+    }
+
+    if (c == '\b') {
+        if (vt->cur_col > 0)
+            vt->cur_col--;
+        vt_fill_cell(&vt->cells[(size_t)vt->cur_row * vt->cols + vt->cur_col],
+                     ' ', vt->fg, vt->bg);
+        return;
+    }
+
+    vt_fill_cell(&vt->cells[(size_t)vt->cur_row * vt->cols + vt->cur_col],
+                 (uint8_t)c, vt->fg, vt->bg);
+    if (++vt->cur_col >= vt->cols) {
+        vt->cur_col = 0;
+        if (++vt->cur_row >= vt->rows) {
+            vt_scroll_up(vt);
+            vt->cur_row = vt->rows - 1;
+        }
+    }
+}
+
+vt_cell_t vt_get_cell(const vt_buf_t *vt, uint32_t col, uint32_t row)
+{
+    vt_cell_t zero = { 0, 0, 0, 0 };
+    if (!vt || !vt->cells || col >= vt->cols || row >= vt->rows) return zero;
+    return vt->cells[(size_t)row * vt->cols + col];
+}

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1398,12 +1398,18 @@ uint32_t keyboard_test_mod_state(void)
 
 unsigned char keyboard_getchar(void)
 {
+    /* Apply any pending vtty_switch repaint deferred from IRQ context.
+     * Cheap when nothing is pending; the cost only lands here, in task
+     * context, so the keyboard IRQ stays short. */
+    vtty_drain_pending();
+
     int s = slot_for_current();
     if (s >= 0) {
         kb_slot_t *slot = &kb_slots[s];
         while (slot_empty_v(slot)) {
             vesa_tty_caret_blink_tick(timer_get_ticks());
             task_yield();
+            vtty_drain_pending();
             asm volatile("pause");
         }
         return slot_pop(slot);
@@ -1411,6 +1417,7 @@ unsigned char keyboard_getchar(void)
     while (buf_count_v() == 0) {
         vesa_tty_caret_blink_tick(timer_get_ticks());
         task_yield();
+        vtty_drain_pending();
         asm volatile("pause");
     }
     return buf_pop();

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -264,12 +264,12 @@ int procfs_ls(const char *path)
     }
 
     if (classify(path) != PROC_NONE) {
-        t_writestring("ls: ");
+        t_writestring("ls: " PROCFS_MOUNT);
         t_writestring(path);
         t_writestring(": Not a directory\n");
         return -1;
     }
-    t_writestring("ls: ");
+    t_writestring("ls: " PROCFS_MOUNT);
     t_writestring(path);
     t_writestring(": No such entry\n");
     return -1;

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -1,0 +1,288 @@
+/*
+ * procfs.c - synthetic /proc filesystem.  See kernel/procfs.h.
+ */
+
+#include <kernel/procfs.h>
+#include <kernel/tty.h>
+#include <kernel/pmm.h>
+#include <kernel/heap.h>
+#include <kernel/task.h>
+#include <kernel/timer.h>
+#include <string.h>
+#include <stdio.h>
+
+/* -------------------------------------------------------------------------
+ * Path matching helpers
+ *
+ * Caller passes a procfs-relative path that always starts with '/'.
+ * "/" itself means the procfs root (directory listing).
+ * "/<name>" matches a specific entry.
+ * ---------------------------------------------------------------------- */
+
+typedef enum {
+    PROC_NONE = 0,
+    PROC_CPUINFO,
+    PROC_MEMINFO,
+    PROC_TASKS,
+    PROC_UNAME,
+} procfs_id_t;
+
+typedef struct {
+    const char  *name;
+    procfs_id_t  id;
+} procfs_entry_t;
+
+static const procfs_entry_t s_entries[] = {
+    { "cpuinfo", PROC_CPUINFO },
+    { "meminfo", PROC_MEMINFO },
+    { "tasks",   PROC_TASKS   },
+    { "uname",   PROC_UNAME   },
+    { NULL,      PROC_NONE    },
+};
+
+static procfs_id_t classify(const char *path)
+{
+    if (!path || path[0] != '/') return PROC_NONE;
+    if (path[1] == '\0') return PROC_NONE;  /* root, not a file */
+    const char *name = path + 1;
+    for (const procfs_entry_t *e = s_entries; e->name; e++) {
+        if (strcmp(name, e->name) == 0)
+            return e->id;
+    }
+    return PROC_NONE;
+}
+
+/* -------------------------------------------------------------------------
+ * Buffered writer - a tiny snprintf-style appender that respects the
+ * caller's output buffer cap and reports how many bytes it wrote.
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    char    *buf;
+    uint32_t cap;
+    uint32_t len;
+} pf_writer_t;
+
+static void pf_putc(pf_writer_t *w, char c)
+{
+    if (w->len + 1 < w->cap) {
+        w->buf[w->len++] = c;
+    }
+}
+
+static void pf_puts(pf_writer_t *w, const char *s)
+{
+    while (*s) pf_putc(w, *s++);
+}
+
+static void pf_putu(pf_writer_t *w, uint32_t v)
+{
+    char tmp[16];
+    int  n = 0;
+    if (v == 0) { pf_putc(w, '0'); return; }
+    while (v > 0 && n < (int)sizeof(tmp)) {
+        tmp[n++] = (char)('0' + (v % 10));
+        v /= 10;
+    }
+    while (n > 0) pf_putc(w, tmp[--n]);
+}
+
+/* -------------------------------------------------------------------------
+ * CPUID
+ * ---------------------------------------------------------------------- */
+
+static inline void cpuid_raw(uint32_t leaf,
+                             uint32_t *eax, uint32_t *ebx,
+                             uint32_t *ecx, uint32_t *edx)
+{
+    __asm__ volatile ("cpuid"
+                      : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+                      : "a"(leaf));
+}
+
+static void render_cpuinfo(pf_writer_t *w)
+{
+    uint32_t eax, ebx, ecx, edx;
+
+    cpuid_raw(0, &eax, &ebx, &ecx, &edx);
+    char vendor[13];
+    *(uint32_t *)&vendor[0] = ebx;
+    *(uint32_t *)&vendor[4] = edx;
+    *(uint32_t *)&vendor[8] = ecx;
+    vendor[12] = '\0';
+    uint32_t max_leaf = eax;
+
+    pf_puts(w, "vendor_id   : ");
+    pf_puts(w, vendor);
+    pf_putc(w, '\n');
+
+    if (max_leaf >= 1) {
+        cpuid_raw(1, &eax, &ebx, &ecx, &edx);
+        uint32_t family   = (eax >> 8)  & 0xF;
+        uint32_t model    = (eax >> 4)  & 0xF;
+        uint32_t stepping =  eax        & 0xF;
+        uint32_t ext_fam  = (eax >> 20) & 0xFF;
+        uint32_t ext_mod  = (eax >> 16) & 0xF;
+        if (family == 0xF) family += ext_fam;
+        if (family == 0x6 || family == 0xF)
+            model = (ext_mod << 4) | model;
+
+        pf_puts(w, "cpu family  : "); pf_putu(w, family);   pf_putc(w, '\n');
+        pf_puts(w, "model       : "); pf_putu(w, model);    pf_putc(w, '\n');
+        pf_puts(w, "stepping    : "); pf_putu(w, stepping); pf_putc(w, '\n');
+
+        pf_puts(w, "flags       :");
+        if (edx & (1u << 0))  pf_puts(w, " fpu");
+        if (edx & (1u << 4))  pf_puts(w, " tsc");
+        if (edx & (1u << 5))  pf_puts(w, " msr");
+        if (edx & (1u << 6))  pf_puts(w, " pae");
+        if (edx & (1u << 9))  pf_puts(w, " apic");
+        if (edx & (1u << 15)) pf_puts(w, " cmov");
+        if (edx & (1u << 23)) pf_puts(w, " mmx");
+        if (edx & (1u << 25)) pf_puts(w, " sse");
+        if (edx & (1u << 26)) pf_puts(w, " sse2");
+        if (ecx & (1u << 0))  pf_puts(w, " sse3");
+        if (ecx & (1u << 19)) pf_puts(w, " sse4_1");
+        if (ecx & (1u << 20)) pf_puts(w, " sse4_2");
+        pf_putc(w, '\n');
+    }
+
+    pf_puts(w, "arch        : i386 (protected mode)\n");
+}
+
+/* -------------------------------------------------------------------------
+ * meminfo
+ * ---------------------------------------------------------------------- */
+
+static void render_meminfo(pf_writer_t *w)
+{
+    uint32_t free_frames = pmm_free_count();
+    uint32_t free_kb     = free_frames * 4u;       /* 4 KiB per frame */
+    size_t   heap_total  = (size_t)(0x1800000u - 0x800000u); /* HEAP_MAX-HEAP_START */
+    size_t   heap_u      = heap_used();
+    size_t   heap_f      = heap_free();
+
+    pf_puts(w, "MemFree     : "); pf_putu(w, free_kb);            pf_puts(w, " kB\n");
+    pf_puts(w, "PageSize    : 4 kB\n");
+    pf_puts(w, "FreeFrames  : "); pf_putu(w, free_frames);        pf_putc(w, '\n');
+    pf_puts(w, "HeapTotal   : "); pf_putu(w, (uint32_t)(heap_total / 1024u)); pf_puts(w, " kB\n");
+    pf_puts(w, "HeapUsed    : "); pf_putu(w, (uint32_t)(heap_u / 1024u));     pf_puts(w, " kB\n");
+    pf_puts(w, "HeapFree    : "); pf_putu(w, (uint32_t)(heap_f / 1024u));     pf_puts(w, " kB\n");
+}
+
+/* -------------------------------------------------------------------------
+ * tasks
+ * ---------------------------------------------------------------------- */
+
+static const char *state_name(int s)
+{
+    switch (s) {
+    case 0: return "READY";
+    case 1: return "RUN";
+    case 2: return "DEAD";
+    default: return "?";
+    }
+}
+
+static void render_tasks(pf_writer_t *w)
+{
+    pf_puts(w, "PID NAME            STATE TTY CWD\n");
+    int n = task_count();
+    for (int i = 0; i < n; i++) {
+        task_t *t = task_get(i);
+        if (!t) continue;
+        pf_putu(w, (uint32_t)t->pid);
+        pf_putc(w, ' ');
+        const char *name = t->name ? t->name : "(noname)";
+        uint32_t nl = 0;
+        while (name[nl] && nl < 16) { pf_putc(w, name[nl]); nl++; }
+        while (nl < 16) { pf_putc(w, ' '); nl++; }
+        pf_puts(w, state_name((int)t->state));
+        pf_putc(w, ' ');
+        if (t->tty < 0) pf_putc(w, '-');
+        else            pf_putu(w, (uint32_t)t->tty);
+        pf_putc(w, ' ');
+        pf_puts(w, t->cwd[0] ? t->cwd : "-");
+        pf_putc(w, '\n');
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * uname
+ * ---------------------------------------------------------------------- */
+
+static void render_uname(pf_writer_t *w)
+{
+    pf_puts(w, "Makar 0.1.0 (i386) built " __DATE__ " " __TIME__ "\n");
+    pf_puts(w, "uptime ticks: ");
+    pf_putu(w, timer_get_ticks());
+    pf_puts(w, " (100 Hz)\n");
+}
+
+/* -------------------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------------- */
+
+int procfs_file_exists(const char *path)
+{
+    return classify(path) != PROC_NONE ? 1 : 0;
+}
+
+int procfs_read_file(const char *path, void *buf, uint32_t bufsz,
+                     uint32_t *out_sz)
+{
+    procfs_id_t id = classify(path);
+    if (id == PROC_NONE) {
+        if (out_sz) *out_sz = 0;
+        return -1;
+    }
+
+    pf_writer_t w = { (char *)buf, bufsz, 0 };
+    switch (id) {
+    case PROC_CPUINFO: render_cpuinfo(&w); break;
+    case PROC_MEMINFO: render_meminfo(&w); break;
+    case PROC_TASKS:   render_tasks(&w);   break;
+    case PROC_UNAME:   render_uname(&w);   break;
+    default: break;
+    }
+
+    if (out_sz) *out_sz = w.len;
+    return 0;
+}
+
+int procfs_ls(const char *path)
+{
+    if (!path || path[0] != '/') return -1;
+
+    if (path[1] == '\0') {
+        for (const procfs_entry_t *e = s_entries; e->name; e++) {
+            t_writestring(e->name);
+            t_writestring("\n");
+        }
+        return 0;
+    }
+
+    if (classify(path) != PROC_NONE) {
+        t_writestring("ls: ");
+        t_writestring(path);
+        t_writestring(": Not a directory\n");
+        return -1;
+    }
+    t_writestring("ls: ");
+    t_writestring(path);
+    t_writestring(": No such entry\n");
+    return -1;
+}
+
+int procfs_complete(const char *dir, const char *prefix,
+                    fat32_complete_cb_t cb, void *ctx)
+{
+    (void)dir;  /* /proc is flat; the dir argument is always "/proc" */
+    if (!cb) return -1;
+    size_t plen = prefix ? strlen(prefix) : 0;
+    for (const procfs_entry_t *e = s_entries; e->name; e++) {
+        if (plen == 0 || strncmp(e->name, prefix, plen) == 0)
+            cb(e->name, 0, ctx);
+    }
+    return 0;
+}

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -8,6 +8,7 @@
 #include <kernel/heap.h>
 #include <kernel/task.h>
 #include <kernel/timer.h>
+#include <kernel/version.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -213,7 +214,7 @@ static void render_tasks(pf_writer_t *w)
 
 static void render_uname(pf_writer_t *w)
 {
-    pf_puts(w, "Makar 0.1.0 (i386) built " __DATE__ " " __TIME__ "\n");
+    pf_puts(w, "Makar " MAKAR_VERSION " (i386) built " __DATE__ " " __TIME__ "\n");
     pf_puts(w, "uptime ticks: ");
     pf_putu(w, timer_get_ticks());
     pf_puts(w, " (100 Hz)\n");

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -169,10 +169,12 @@ static int vfs_route(const char *abs, const char **drv_path)
         return VFS_FS_CDROM;
     }
 
-    /* "/proc" or "/proc/…" */
-    if (abs[1] == 'p' && abs[2] == 'r' && abs[3] == 'o' && abs[4] == 'c' &&
-        (abs[5] == '/' || abs[5] == '\0')) {
-        *drv_path = (abs[5] == '/') ? (abs + 5) : "/";
+    /* /proc (mount prefix is the single source of truth in procfs.h). */
+    if (memcmp(abs, PROCFS_MOUNT, PROCFS_MOUNT_LEN) == 0 &&
+        (abs[PROCFS_MOUNT_LEN] == '/' || abs[PROCFS_MOUNT_LEN] == '\0')) {
+        *drv_path = (abs[PROCFS_MOUNT_LEN] == '/')
+                        ? (abs + PROCFS_MOUNT_LEN)
+                        : "/";
         return VFS_FS_PROC;
     }
 

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -18,6 +18,7 @@
 #include <kernel/vfs.h>
 #include <kernel/fat32.h>
 #include <kernel/iso9660.h>
+#include <kernel/procfs.h>
 #include <kernel/ide.h>
 #include <kernel/partition.h>
 #include <kernel/tty.h>
@@ -39,6 +40,7 @@ static uint32_t s_boot_biosdev = 0xFFu; /* BIOS drive we booted from (0xFF = unk
 #define VFS_FS_ROOT    0
 #define VFS_FS_HD      1
 #define VFS_FS_CDROM   2
+#define VFS_FS_PROC    3
 #define VFS_FS_UNKNOWN (-1)
 
 /* -------------------------------------------------------------------------
@@ -167,6 +169,13 @@ static int vfs_route(const char *abs, const char **drv_path)
         return VFS_FS_CDROM;
     }
 
+    /* "/proc" or "/proc/…" */
+    if (abs[1] == 'p' && abs[2] == 'r' && abs[3] == 'o' && abs[4] == 'c' &&
+        (abs[5] == '/' || abs[5] == '\0')) {
+        *drv_path = (abs[5] == '/') ? (abs + 5) : "/";
+        return VFS_FS_PROC;
+    }
+
     *drv_path = abs;
     return VFS_FS_UNKNOWN;
 }
@@ -178,8 +187,9 @@ static void ls_root(void)
 {
     if (fat32_mounted())    t_writestring("[hd]\n");
     if (s_cdrom_drive >= 0) t_writestring("[cdrom]\n");
+    t_writestring("[proc]\n");   /* always present - synthesised */
     if (!fat32_mounted() && s_cdrom_drive < 0)
-        t_writestring("(no filesystems mounted - use 'mount' to mount FAT32)\n");
+        t_writestring("(no disk filesystems mounted - use 'mount' to mount FAT32)\n");
 }
 
 /* =========================================================================
@@ -370,6 +380,9 @@ int vfs_ls(const char *path)
         }
         return iso9660_ls((uint8_t)s_cdrom_drive, drv);
 
+    case VFS_FS_PROC:
+        return procfs_ls(drv);
+
     default:
         t_writestring("ls: path not found\n");
         return -1;
@@ -417,6 +430,17 @@ int vfs_cd(const char *path)
         s_cwd[VFS_PATH_MAX - 1] = '\0';
         return 0;
 
+    case VFS_FS_PROC:
+        /* /proc is flat: only "/proc" itself is a directory.  Reject
+         * any deeper cd. */
+        if (drv[0] == '/' && drv[1] == '\0') {
+            strncpy(s_cwd, abs, VFS_PATH_MAX - 1);
+            s_cwd[VFS_PATH_MAX - 1] = '\0';
+            return 0;
+        }
+        t_writestring("cd: not a directory\n");
+        return -1;
+
     default:
         t_writestring("cd: path not found\n");
         return -1;
@@ -461,6 +485,10 @@ int vfs_cat(const char *path)
             return -1;
         }
         err = iso9660_read_file((uint8_t)s_cdrom_drive, drv, buf, CAT_MAX, &got);
+        break;
+
+    case VFS_FS_PROC:
+        err = procfs_read_file(drv, buf, CAT_MAX, &got);
         break;
 
     default:
@@ -520,6 +548,9 @@ int vfs_read_file(const char *path, void *buf, uint32_t bufsz, uint32_t *out_sz)
     case VFS_FS_CDROM:
         if (s_cdrom_drive < 0) return -1;
         return iso9660_read_file((uint8_t)s_cdrom_drive, drv, buf, bufsz, out_sz);
+
+    case VFS_FS_PROC:
+        return procfs_read_file(drv, buf, bufsz, out_sz);
 
     default:
         return -1;
@@ -589,6 +620,8 @@ int vfs_file_exists(const char *path)
     case VFS_FS_CDROM:
         if (s_cdrom_drive < 0) return 0;
         return iso9660_file_exists((uint8_t)s_cdrom_drive, drv);
+    case VFS_FS_PROC:
+        return procfs_file_exists(drv);
     default:
         return 0;
     }
@@ -618,6 +651,8 @@ int vfs_complete(const char *dir, const char *prefix,
     case VFS_FS_CDROM:
         if (s_cdrom_drive < 0) return -1;
         return iso9660_complete((uint8_t)s_cdrom_drive, drv, prefix, cb, ctx);
+    case VFS_FS_PROC:
+        return procfs_complete(drv, prefix, cb, ctx);
     default:
         return -1;
     }

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -25,6 +25,7 @@ $(ARCHDIR)/mm/vmm.o \
 $(ARCHDIR)/display/tty.o \
 $(ARCHDIR)/display/vesa.o \
 $(ARCHDIR)/display/vesa_tty.o \
+$(ARCHDIR)/display/vt.o \
 $(ARCHDIR)/display/bochs_vbe.o \
 $(ARCHDIR)/proc/system.o \
 $(ARCHDIR)/proc/task_asm.o \

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -17,6 +17,7 @@ $(ARCHDIR)/drivers/partition.o \
 $(ARCHDIR)/drivers/acpi.o \
 $(ARCHDIR)/fs/fat32.o \
 $(ARCHDIR)/fs/iso9660.o \
+$(ARCHDIR)/fs/procfs.o \
 $(ARCHDIR)/fs/vfs.o \
 $(ARCHDIR)/mm/pmm.o \
 $(ARCHDIR)/mm/paging.o \

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -41,6 +41,7 @@ $(ARCHDIR)/proc/installer.o \
 $(ARCHDIR)/proc/vics.o \
 $(ARCHDIR)/proc/vtty.o \
 $(ARCHDIR)/shell/shell.o \
+$(ARCHDIR)/shell/shell_glob.o \
 $(ARCHDIR)/shell/shell_help.o \
 $(ARCHDIR)/shell/shell_cmd_display.o \
 $(ARCHDIR)/shell/shell_cmd_system.o \

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -6,22 +6,58 @@
  * KEY_FOCUS_GAIN to the newly focused task so it can redraw.
  *
  * `task_t.tty` is authoritative for the TTY a task is bound to.  vtty itself
- * only tracks the focused slot index and the number of registered slots; the
- * "owning task" of slot N is resolved by walking the task pool for the live
- * task with the lowest pid whose `tty == N` (the original shell — exec
- * children inherit the same tty but always have higher pids).
+ * tracks the focused slot index, the number of registered slots, and the
+ * per-slot backing grid (vt_buf_t).  The "owning task" of slot N is resolved
+ * by walking the task pool for the live task with the lowest pid whose
+ * `tty == N` (the original shell -- exec children inherit the same tty but
+ * always have higher pids).
+ *
+ * Per-TTY backing grids hold all output the shell / ring-3 apps emit; the
+ * display renderer (vesa_tty / VGA tty) writes through the current task's
+ * buffer and only mirrors to the physical framebuffer when that buffer
+ * matches the focused TTY.  Switching TTYs re-paints the new buffer's grid
+ * back to the framebuffer so the background shell's state is preserved.
  */
 
 #include <kernel/vtty.h>
 #include <kernel/keyboard.h>
+#include <kernel/vesa_tty.h>
 
-static int vtty_nslots  = 0;
-static int vtty_current = 0;
+static int      vtty_nslots  = 0;
+static int      vtty_current = 0;
+static vt_buf_t vtty_bufs[VTTY_MAX];
+static bool     vtty_bufs_ready = false;
+
+/* Default attribute values used when no display renderer has set colours
+ * yet.  Renderer interprets - VESA uses these as composed FB pixels,
+ * VGA uses only the low byte as a VGA attribute. */
+#define VTTY_DEFAULT_FG  0xFFFFFFFFu
+#define VTTY_DEFAULT_BG  0x00000000u
 
 void vtty_init(void)
 {
     vtty_nslots  = 0;
     vtty_current = 0;
+
+    uint32_t cols = 0, rows = 0;
+    if (vesa_tty_is_ready()) {
+        cols = vesa_tty_get_cols();
+        rows = vesa_tty_get_rows();
+    }
+    if (cols == 0 || rows == 0) {
+        cols = 80;
+        rows = 50;
+    }
+
+    vtty_bufs_ready = true;
+    for (int i = 0; i < VTTY_MAX; i++) {
+        if (!vt_init(&vtty_bufs[i], cols, rows,
+                     VTTY_DEFAULT_FG, VTTY_DEFAULT_BG)) {
+            /* Allocation failed: leave cells == NULL so vt_putchar
+             * becomes a no-op for that slot.  Better than panic at boot. */
+            vtty_bufs[i].cells = NULL;
+        }
+    }
 }
 
 /*
@@ -70,6 +106,27 @@ int vtty_is_focused(void)
 int vtty_count(void)
 {
     return vtty_nslots;
+}
+
+vt_buf_t *vtty_buf(int n)
+{
+    if (!vtty_bufs_ready || n < 0 || n >= VTTY_MAX) return NULL;
+    return &vtty_bufs[n];
+}
+
+vt_buf_t *vtty_buf_current(void)
+{
+    if (!vtty_bufs_ready) return NULL;
+    task_t *me = task_current();
+    if (!me) return NULL;
+    int n = me->tty;
+    if (n < 0 || n >= VTTY_MAX) return NULL;
+    return &vtty_bufs[n];
+}
+
+vt_buf_t *vtty_buf_focused(void)
+{
+    return vtty_buf(vtty_current);
 }
 
 void vtty_switch(int n)

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -42,15 +42,26 @@ static volatile int vtty_pending = -1;
 #define VTTY_DEFAULT_FG  0xFFFFFFFFu
 #define VTTY_DEFAULT_BG  0x00000000u
 
+/* Bottom-row status bar reservation.  When VESA is active we steal the
+ * last character row so the tmux-style indicator can live there without
+ * being scrolled away by shell output.  In VGA-text fallback the bar
+ * isn't drawn (yet); the full 80x50 grid stays available. */
+#define VTTY_STATUS_ROWS 1
+
 void vtty_init(void)
 {
     vtty_nslots  = 0;
     vtty_current = 0;
 
     uint32_t cols = 0, rows = 0;
+    bool reserve_status = false;
     if (vesa_tty_is_ready()) {
         cols = vesa_tty_get_cols();
         rows = vesa_tty_get_rows();
+        if (rows > VTTY_STATUS_ROWS) {
+            rows -= VTTY_STATUS_ROWS;
+            reserve_status = true;
+        }
     }
     if (cols == 0 || rows == 0) {
         cols = 80;
@@ -66,6 +77,11 @@ void vtty_init(void)
             vtty_bufs[i].cells = NULL;
         }
     }
+
+    /* Initial status bar.  count=0 - no slots registered yet, but draw
+     * the row so the dark band is visible during boot. */
+    if (reserve_status)
+        vesa_tty_paint_status(0, 0);
 }
 
 /*
@@ -97,6 +113,8 @@ int vtty_register(void)
     if (me) me->tty = slot;
     if (slot == 0)
         keyboard_set_focus(me);
+    /* Refresh the status bar so the new slot lights up. */
+    vesa_tty_paint_status(vtty_current, vtty_nslots);
     return slot;
 }
 
@@ -174,4 +192,8 @@ void vtty_drain_pending(void)
 
     vt_buf_t *vt = vtty_buf(n);
     if (vt) vesa_tty_paint_buf(vt);
+    /* paint_buf only walks vt->rows, which excludes the status row, so
+     * the bar survives a focus switch.  Repaint it anyway to update the
+     * "active" highlight. */
+    vesa_tty_paint_status(vtty_current, vtty_nslots);
 }

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -1,33 +1,58 @@
 /*
  * vtty.c - virtual TTY manager.
  *
- * Each slot holds one shell task.  Alt+F1-F4 (handled in keyboard.c) calls
+ * Each slot binds one shell task.  Alt+F1-F4 (handled in keyboard.c) calls
  * vtty_switch() to change the active slot, update keyboard routing, and send
  * KEY_FOCUS_GAIN to the newly focused task so it can redraw.
+ *
+ * `task_t.tty` is authoritative for the TTY a task is bound to.  vtty itself
+ * only tracks the focused slot index and the number of registered slots; the
+ * "owning task" of slot N is resolved by walking the task pool for the live
+ * task with the lowest pid whose `tty == N` (the original shell — exec
+ * children inherit the same tty but always have higher pids).
  */
 
 #include <kernel/vtty.h>
 #include <kernel/keyboard.h>
 
-static task_t *vtty_tasks[VTTY_MAX];
-static int     vtty_nslots  = 0;
-static int     vtty_current = 0;
+static int vtty_nslots  = 0;
+static int vtty_current = 0;
 
 void vtty_init(void)
 {
-    for (int i = 0; i < VTTY_MAX; i++)
-        vtty_tasks[i] = NULL;
     vtty_nslots  = 0;
     vtty_current = 0;
+}
+
+/*
+ * vtty_owner - find the registered shell task for slot n.
+ * Returns the live task with t->tty == n and the lowest pid, or NULL if
+ * no such task exists (slot vacated by death).
+ */
+static task_t *vtty_owner(int n)
+{
+    task_t *best = NULL;
+    int     best_pid = 0;
+    for (int i = 0; i < task_count(); i++) {
+        task_t *t = task_get(i);
+        if (!t || t->state == TASK_DEAD) continue;
+        if (t->tty != n) continue;
+        if (!best || t->pid < best_pid) {
+            best     = t;
+            best_pid = t->pid;
+        }
+    }
+    return best;
 }
 
 int vtty_register(void)
 {
     if (vtty_nslots >= VTTY_MAX) return -1;
     int slot = vtty_nslots++;
-    vtty_tasks[slot] = task_current();
+    task_t *me = task_current();
+    if (me) me->tty = slot;
     if (slot == 0)
-        keyboard_set_focus(vtty_tasks[0]);
+        keyboard_set_focus(me);
     return slot;
 }
 
@@ -38,7 +63,8 @@ int vtty_active(void)
 
 int vtty_is_focused(void)
 {
-    return vtty_tasks[vtty_current] == task_current();
+    task_t *me = task_current();
+    return me && me->tty == vtty_current;
 }
 
 int vtty_count(void)
@@ -49,7 +75,9 @@ int vtty_count(void)
 void vtty_switch(int n)
 {
     if (n < 0 || n >= vtty_nslots || n == vtty_current) return;
+    task_t *owner = vtty_owner(n);
+    if (!owner) return;
     vtty_current = n;
-    keyboard_set_focus(vtty_tasks[n]);
-    keyboard_send_to(vtty_tasks[n], KEY_FOCUS_GAIN);
+    keyboard_set_focus(owner);
+    keyboard_send_to(owner, KEY_FOCUS_GAIN);
 }

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -28,6 +28,14 @@ static int      vtty_current = 0;
 static vt_buf_t vtty_bufs[VTTY_MAX];
 static bool     vtty_bufs_ready = false;
 
+/* Pending repaint target.  vtty_switch runs in the keyboard IRQ; doing a
+ * full framebuffer repaint there would block subsequent keyboard IRQs
+ * long enough that the i8042's 1-byte OBF stays full and the edge-
+ * triggered PIC misses key events (the same failure mode as PR #127).
+ * Mark the target instead; vtty_drain_pending() flushes the paint from
+ * task context the next time the new owner's REPL yields. */
+static volatile int vtty_pending = -1;
+
 /* Default attribute values used when no display renderer has set colours
  * yet.  Renderer interprets - VESA uses these as composed FB pixels,
  * VGA uses only the low byte as a VGA attribute. */
@@ -137,4 +145,33 @@ void vtty_switch(int n)
     vtty_current = n;
     keyboard_set_focus(owner);
     keyboard_send_to(owner, KEY_FOCUS_GAIN);
+    /* Defer the FB repaint to task context - see vtty_pending comment. */
+    __atomic_store_n(&vtty_pending, n, __ATOMIC_RELEASE);
+}
+
+void vtty_drain_pending(void)
+{
+    int n = __atomic_load_n(&vtty_pending, __ATOMIC_ACQUIRE);
+    if (n < 0) return;
+
+    /* Only the task that owns the destination TTY repaints.  Otherwise
+     * a non-focused shell calling keyboard_getchar (sitting idle on its
+     * own slot) would race with the destination shell writing the
+     * prompt / accumulated content to vt_buf[n] AND directly to the FB
+     * via the focused-write path.  That race produced visible artefacts
+     * (stray caret glyphs in the middle of the screen) in interactive
+     * Alt+Fn switches. */
+    task_t *me = task_current();
+    if (!me || me->tty != n) return;
+
+    /* Compare-exchange so concurrent owners (parent shell + exec child
+     * sharing the same TTY) don't double-paint. */
+    int expected = n;
+    if (!__atomic_compare_exchange_n(&vtty_pending, &expected, -1,
+                                     /*weak=*/0,
+                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+        return;
+
+    vt_buf_t *vt = vtty_buf(n);
+    if (vt) vesa_tty_paint_buf(vt);
 }

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -294,23 +294,11 @@ void shell_readline(char *buf, size_t max)
             return;
         }
 
-        /* TTY focus gained: clear screen, reprint prompt, redraw pending input. */
+        /* TTY focus gained: vtty_switch has already repainted the framebuffer
+         * from this TTY's backing grid (vt_buf), which already contains the
+         * full prompt + accumulated input.  Just drop the sentinel byte and
+         * keep reading - no clear, no reprint, no redraw.  Linux VT behaviour. */
         if (c == KEY_FOCUS_GAIN) {
-            terminal_set_colorscheme(SHELL_COLOR_VGA);
-            if (vesa_tty_is_ready()) {
-                vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
-                vesa_tty_clear();
-            }
-            shell_print_prompt();
-            rl_col = t_column;
-            rl_row = t_row;
-            if (vesa_tty_is_ready()) {
-                vesa_rl_col = vesa_tty_get_col();
-                vesa_rl_row = vesa_tty_get_row();
-            }
-            if (len > 0)
-                readline_redraw(buf, len, cur, len,
-                                rl_col, rl_row, vesa_rl_col, vesa_rl_row);
             continue;
         }
 
@@ -684,13 +672,17 @@ void shell_run(void)
             task_yield();
         while (!vtty_is_focused())
             task_yield();
-        /* Drain the KEY_FOCUS_GAIN byte vtty_switch queued for us. */
-        while (keyboard_poll()) {}
         terminal_set_colorscheme(SHELL_COLOR_VGA);
         if (vesa_tty_is_ready()) {
             vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
             vesa_tty_clear();
         }
+        /* Do NOT drain the input ring here.  The user may have typed a key
+         * the same instant they hit Alt+Fn (single QEMU sendkey burst or a
+         * fast typist on real hardware) - draining would swallow that first
+         * keystroke.  shell_readline's KEY_FOCUS_GAIN handler drops the
+         * sentinel byte cleanly; any real chars that arrived alongside it
+         * stay queued for the readline loop. */
     }
 
     while (1) {

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -394,16 +394,35 @@ void shell_readline(char *buf, size_t max)
             if (nmatches == 1) {
                 /* Insert remainder of the single match. */
                 size_t mlen = strlen(vctx.matches[0]);
+                int    inserted_any = 0;
                 for (size_t i = wlen; i < mlen && len < max - 1; i++) {
                     for (size_t j = len; j > cur; j--)
                         buf[j] = buf[j - 1];
                     buf[cur++] = vctx.matches[0][i];
                     len++;
+                    inserted_any = 1;
                 }
+                /* Trailing affix: '/' for directories so the next TAB drills
+                 * into the dir; ' ' for finished tokens (commands or files)
+                 * so the user can immediately type the next argument.  Match
+                 * bash's behaviour: only append when the cursor is at the
+                 * end and nothing's already there.  Skip the space when we
+                 * inserted nothing AND the next char is already a space - no
+                 * point typing one twice. */
                 if (vctx.is_dir[0] && len < max - 1) {
                     for (size_t j = len; j > cur; j--)
                         buf[j] = buf[j - 1];
                     buf[cur++] = '/';
+                    len++;
+                } else if (!vctx.is_dir[0] && len < max - 1 &&
+                           (cur == len || buf[cur] != ' ')) {
+                    /* Append space - even if no chars were inserted, so users
+                     * of unique-prefix names (cat, cd) get visible feedback
+                     * that the match succeeded. */
+                    (void)inserted_any;
+                    for (size_t j = len; j > cur; j--)
+                        buf[j] = buf[j - 1];
+                    buf[cur++] = ' ';
                     len++;
                 }
                 buf[len] = '\0';

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -710,6 +710,13 @@ void shell_run(void)
         if (argc == 0)
             continue;
 
+        /* Expand wildcards (*, ?) against the VFS.  Storage arena lives on
+         * this stack frame so expanded tokens are valid until the next
+         * REPL iteration.  Large enough for ~32 typical-length paths. */
+        static char glob_buf[1024];
+        argc = shell_expand_globs(argc, argv, SHELL_MAX_ARGS,
+                                  glob_buf, sizeof(glob_buf));
+
         if (!shell_dispatch(argc, argv)) {
             t_setcolor(SHELL_ERROR_COLOR_VGA);
             t_writestring("Unknown command '");

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -329,6 +329,12 @@ void shell_readline(char *buf, size_t max)
             vctx.pfxlen = wlen;
             vctx.n      = 0;
             int nmatches = 0;
+            /* Length of the prefix the match should *extend*: equals wlen for
+             * first-token (command) completion, but only the basename portion
+             * of word for path-style completion - matches contain basenames
+             * only, so we must skip the dir part of word when figuring out
+             * how many chars of the match are already typed. */
+            size_t match_prefix_len = wlen;
 
             if (is_cmd && !is_path) {
                 /* Bash-style first-token completion: built-ins + every ELF
@@ -389,13 +395,16 @@ void shell_readline(char *buf, size_t max)
                 vctx.pfxlen = strlen(file_prefix);
                 vfs_complete(dir_part, file_prefix, tab_complete_cb, &vctx);
                 nmatches = vctx.n;
+                /* User has typed only the basename portion of the match;
+                 * insertion below extends from there. */
+                match_prefix_len = vctx.pfxlen;
             }
 
             if (nmatches == 1) {
                 /* Insert remainder of the single match. */
                 size_t mlen = strlen(vctx.matches[0]);
                 int    inserted_any = 0;
-                for (size_t i = wlen; i < mlen && len < max - 1; i++) {
+                for (size_t i = match_prefix_len; i < mlen && len < max - 1; i++) {
                     for (size_t j = len; j > cur; j--)
                         buf[j] = buf[j - 1];
                     buf[cur++] = vctx.matches[0][i];

--- a/src/kernel/arch/i386/shell/shell_cmd_fileops.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_fileops.c
@@ -12,31 +12,36 @@
 static void cmd_rm(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: rm <file>\n");
+        t_writestring("Usage: rm <file>...\n");
         return;
     }
-    if (vfs_delete_file(argv[1]) != 0) {
-        t_writestring("rm: cannot delete '");
-        t_writestring(argv[1]);
-        t_writestring("'\n");
+    /* Iterate so wildcards (`rm *.tmp`) and explicit multi-arg both work. */
+    for (int i = 1; i < argc; i++) {
+        if (vfs_delete_file(argv[i]) != 0) {
+            t_writestring("rm: cannot delete '");
+            t_writestring(argv[i]);
+            t_writestring("'\n");
+        }
     }
 }
 
 static void cmd_rmdir(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: rmdir <directory>\n");
+        t_writestring("Usage: rmdir <directory>...\n");
         return;
     }
-    int r = vfs_delete_dir(argv[1]);
-    if (r == -5) {
-        t_writestring("rmdir: directory not empty: '");
-        t_writestring(argv[1]);
-        t_writestring("'\n");
-    } else if (r != 0) {
-        t_writestring("rmdir: cannot remove '");
-        t_writestring(argv[1]);
-        t_writestring("'\n");
+    for (int i = 1; i < argc; i++) {
+        int r = vfs_delete_dir(argv[i]);
+        if (r == -5) {
+            t_writestring("rmdir: directory not empty: '");
+            t_writestring(argv[i]);
+            t_writestring("'\n");
+        } else if (r != 0) {
+            t_writestring("rmdir: cannot remove '");
+            t_writestring(argv[i]);
+            t_writestring("'\n");
+        }
     }
 }
 

--- a/src/kernel/arch/i386/shell/shell_cmd_fs.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_fs.c
@@ -136,24 +136,27 @@ static void cmd_cd(int argc, char **argv)
 static void cmd_mkdir(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: mkdir <path>\n");
+        t_writestring("Usage: mkdir <path>...\n");
         return;
     }
-
-    int err = vfs_mkdir(argv[1]);
-    switch (err) {
-    case  0: t_writestring("Directory created.\n");    break;
-    case -1: t_writestring("mkdir: path error\n");     break;
-    case -2: t_writestring("mkdir: I/O error\n");      break;
-    case -4: t_writestring("mkdir: disk full\n");      break;
-    case -6: t_writestring("mkdir: already exists\n"); break;
-    default:
-        if (err < 0) {
-            t_writestring("mkdir: error ");
-            t_dec((uint32_t)(-err));
-            t_putchar('\n');
+    for (int i = 1; i < argc; i++) {
+        int err = vfs_mkdir(argv[i]);
+        switch (err) {
+        case  0: break;  /* silent on success when batching, like coreutils */
+        case -1: t_writestring("mkdir: path error: ");   t_writestring(argv[i]); t_putchar('\n'); break;
+        case -2: t_writestring("mkdir: I/O error: ");    t_writestring(argv[i]); t_putchar('\n'); break;
+        case -4: t_writestring("mkdir: disk full: ");    t_writestring(argv[i]); t_putchar('\n'); break;
+        case -6: t_writestring("mkdir: already exists: ");t_writestring(argv[i]); t_putchar('\n'); break;
+        default:
+            if (err < 0) {
+                t_writestring("mkdir: error ");
+                t_dec((uint32_t)(-err));
+                t_writestring(": ");
+                t_writestring(argv[i]);
+                t_putchar('\n');
+            }
+            break;
         }
-        break;
     }
 }
 
@@ -289,30 +292,40 @@ static void cmd_write(int argc, char **argv)
 static void cmd_touch(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: touch <file>\n");
+        t_writestring("Usage: touch <file>...\n");
         return;
     }
 
     static char s_touch_path[VFS_PATH_MAX];
-    const char *arg = argv[1];
     const char *cwd = vfs_getcwd();
-    if (arg[0] == '/') {
-        strncpy(s_touch_path, arg, VFS_PATH_MAX - 1);
-        s_touch_path[VFS_PATH_MAX - 1] = '\0';
-    } else {
-        size_t cl = strlen(cwd), al = strlen(arg);
-        if (cl + 1 + al >= VFS_PATH_MAX) { t_writestring("touch: path too long\n"); return; }
-        size_t p = 0;
-        memcpy(s_touch_path, cwd, cl); p += cl;
-        if (cwd[cl - 1] != '/') s_touch_path[p++] = '/';
-        memcpy(s_touch_path + p, arg, al + 1);
-    }
 
-    int err = vfs_write_file(s_touch_path, "", 0);
-    if (err) {
-        t_writestring("touch: error ");
-        t_dec((uint32_t)(-err));
-        t_putchar('\n');
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (arg[0] == '/') {
+            strncpy(s_touch_path, arg, VFS_PATH_MAX - 1);
+            s_touch_path[VFS_PATH_MAX - 1] = '\0';
+        } else {
+            size_t cl = strlen(cwd), al = strlen(arg);
+            if (cl + 1 + al >= VFS_PATH_MAX) {
+                t_writestring("touch: path too long: ");
+                t_writestring(arg);
+                t_putchar('\n');
+                continue;
+            }
+            size_t p = 0;
+            memcpy(s_touch_path, cwd, cl); p += cl;
+            if (cwd[cl - 1] != '/') s_touch_path[p++] = '/';
+            memcpy(s_touch_path + p, arg, al + 1);
+        }
+
+        int err = vfs_write_file(s_touch_path, "", 0);
+        if (err) {
+            t_writestring("touch: error ");
+            t_dec((uint32_t)(-err));
+            t_writestring(": ");
+            t_writestring(arg);
+            t_putchar('\n');
+        }
     }
 }
 

--- a/src/kernel/arch/i386/shell/shell_cmd_fs.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_fs.c
@@ -86,19 +86,38 @@ static void cmd_umount(int argc, char **argv)
 
 static void cmd_ls(int argc, char **argv)
 {
-    const char *path = (argc >= 2) ? argv[1] : NULL;
-    t_writestring(path ? path : vfs_getcwd());
-    t_writestring(":\n");
-    vfs_ls(path);
+    if (argc < 2) {
+        t_writestring(vfs_getcwd());
+        t_writestring(":\n");
+        vfs_ls(NULL);
+        return;
+    }
+    /* Iterate every path argument so wildcard expansions like `ls /proc/*`
+     * list every match instead of only the first.  Header line per target
+     * mirrors GNU ls when multiple operands are given. */
+    for (int i = 1; i < argc; i++) {
+        if (argc > 2) {
+            if (i > 1) t_putchar('\n');
+            t_writestring(argv[i]);
+            t_writestring(":\n");
+        } else {
+            t_writestring(argv[1]);
+            t_writestring(":\n");
+        }
+        vfs_ls(argv[i]);
+    }
 }
 
 static void cmd_cat(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: cat <file>\n");
+        t_writestring("Usage: cat <file>...\n");
         return;
     }
-    vfs_cat(argv[1]);
+    /* Concatenate every file given - lets wildcards (`cat /proc/*`) emit
+     * the whole set in one shot, matching bash/cat semantics. */
+    for (int i = 1; i < argc; i++)
+        vfs_cat(argv[i]);
 }
 
 static void cmd_cd(int argc, char **argv)

--- a/src/kernel/arch/i386/shell/shell_glob.c
+++ b/src/kernel/arch/i386/shell/shell_glob.c
@@ -1,0 +1,214 @@
+/*
+ * shell_glob.c -- wildcard (glob) expansion for the kernel shell.
+ *
+ * Expands `*` and `?` in argv tokens against the VFS via vfs_complete(),
+ * so wildcards work uniformly across every mount: /hd (FAT32),
+ * /cdrom (ISO9660), /proc (synthetic), and any future backend
+ * (NFS/SMB/USB) that implements the same enumeration callback.
+ *
+ * Semantics:
+ *   *      - matches zero or more chars, never crosses '/'
+ *   ?      - matches exactly one char, never matches '/'
+ *   no match - token is left unchanged (bash default, not zsh's NOMATCH=error)
+ *   non-glob tokens - passed through untouched
+ *
+ * argv expansion is in-place: matches replace the wildcard token, and
+ * subsequent argv entries shift right.  Capped at SHELL_MAX_ARGS total
+ * so an over-broad glob never overruns the dispatch array.
+ */
+
+#include "shell_priv.h"
+
+#include <kernel/vfs.h>
+#include <kernel/fat32.h>   /* fat32_complete_cb_t */
+
+#include <string.h>
+
+/* ---------------------------------------------------------------------------
+ * glob_has_wildcard - quick precheck so non-glob tokens skip the dir scan.
+ * --------------------------------------------------------------------------- */
+static int glob_has_wildcard(const char *s)
+{
+    for (; *s; s++)
+        if (*s == '*' || *s == '?')
+            return 1;
+    return 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * glob_match - fnmatch-style match without FNM_PATHNAME complications.
+ *
+ * `*` greedy match over any chars; `?` exactly one.  Recursive form is fine
+ * here because basenames are short and SHELL_MAX_INPUT caps the pattern.
+ * --------------------------------------------------------------------------- */
+static int glob_match(const char *pat, const char *name)
+{
+    while (*pat) {
+        if (*pat == '*') {
+            /* Collapse consecutive stars. */
+            while (*pat == '*') pat++;
+            if (!*pat) return 1;          /* trailing * matches the rest */
+            while (*name) {
+                if (glob_match(pat, name)) return 1;
+                name++;
+            }
+            return 0;
+        }
+        if (!*name) return 0;
+        if (*pat == '?' || *pat == *name) {
+            pat++; name++;
+            continue;
+        }
+        return 0;
+    }
+    return *name == '\0';
+}
+
+/* ---------------------------------------------------------------------------
+ * Callback context: vfs_complete invokes glob_cb for every entry in the
+ * scanned directory.  We filter by pattern, append the dir prefix, and
+ * stash the resulting full path into the shared storage arena.
+ * --------------------------------------------------------------------------- */
+typedef struct {
+    const char *pattern;     /* basename pattern (no slashes) */
+    const char *dir_prefix;  /* "" if no dir was in the token, else "dir" or "dir/" */
+    int         prefix_needs_slash;
+    char       *buf;         /* next free byte in storage arena */
+    size_t      buf_left;
+    char      **matches;
+    int         max_matches;
+    int         nmatches;
+} glob_ctx_t;
+
+static void glob_cb(const char *name, int is_dir, void *opaque)
+{
+    (void)is_dir;
+    glob_ctx_t *g = (glob_ctx_t *)opaque;
+
+    if (g->nmatches >= g->max_matches) return;
+    if (!glob_match(g->pattern, name))  return;
+
+    /* Hide ".." entries unless the pattern explicitly asks for them - matches
+     * shell convention and stops "ls *" from echoing parent-dir links. */
+    if (name[0] == '.' && g->pattern[0] != '.')
+        return;
+
+    size_t plen = strlen(g->dir_prefix);
+    size_t slen = g->prefix_needs_slash ? 1 : 0;
+    size_t nlen = strlen(name);
+    size_t need = plen + slen + nlen + 1;
+    if (need > g->buf_left) return;
+
+    char *out = g->buf;
+    memcpy(out, g->dir_prefix, plen);
+    if (slen) out[plen] = '/';
+    memcpy(out + plen + slen, name, nlen + 1);
+
+    g->matches[g->nmatches++] = out;
+    g->buf      += need;
+    g->buf_left -= need;
+}
+
+/* ---------------------------------------------------------------------------
+ * shell_expand_globs - expand wildcards in argv in place.
+ *
+ *   argcp        : in/out token count
+ *   argv         : in/out token pointers
+ *   argv_cap     : max slots in argv (must be >= *argcp)
+ *   storage      : scratch arena for expanded names
+ *   storage_size : capacity of `storage`
+ *
+ * Tokens that contain `*` or `?` are split into dir + pattern, the dir is
+ * enumerated via vfs_complete(), and matching basenames replace the token
+ * (with the dir prefix prepended so the path is absolute when applicable).
+ * Tokens with no matches are left untouched.  Returns the new argc.
+ * --------------------------------------------------------------------------- */
+int shell_expand_globs(int argc, char **argv, int argv_cap,
+                       char *storage, size_t storage_size)
+{
+    char  *buf  = storage;
+    size_t left = storage_size;
+
+    int i = 0;
+    while (i < argc) {
+        char *tok = argv[i];
+        if (!glob_has_wildcard(tok)) { i++; continue; }
+
+        /* Split tok into dir_part and basename pattern. */
+        char *last_slash = NULL;
+        for (char *p = tok; *p; p++) if (*p == '/') last_slash = p;
+
+        char dir_part[VFS_PATH_MAX];
+        const char *pat;
+        int   prefix_needs_slash;
+
+        if (last_slash) {
+            size_t dl = (size_t)(last_slash - tok);
+            if (dl == 0) {
+                /* Pattern was "/foo*" - scan root. */
+                dir_part[0] = '/';
+                dir_part[1] = '\0';
+                prefix_needs_slash = 0;   /* "/" already ends in slash */
+            } else {
+                if (dl >= sizeof(dir_part)) dl = sizeof(dir_part) - 1;
+                memcpy(dir_part, tok, dl);
+                dir_part[dl] = '\0';
+                prefix_needs_slash = 1;
+            }
+            pat = last_slash + 1;
+        } else {
+            /* No slash: scan CWD, emit basenames only. */
+            dir_part[0] = '\0';
+            prefix_needs_slash = 0;
+            pat = tok;
+        }
+
+        if (!glob_has_wildcard(pat)) { i++; continue; }
+
+        /* Enumerate and collect matches.  Cap per-token at the remaining argv
+         * slots so we never need to re-truncate after the fact. */
+        int    slots_left = argv_cap - argc;
+        int    max_here   = slots_left + 1;  /* +1: the wildcard slot itself */
+        if (max_here > 32) max_here = 32;
+
+        char  *matches[32];
+        glob_ctx_t ctx = {
+            .pattern             = pat,
+            .dir_prefix          = dir_part,
+            .prefix_needs_slash  = prefix_needs_slash,
+            .buf                 = buf,
+            .buf_left            = left,
+            .matches             = matches,
+            .max_matches         = max_here,
+            .nmatches            = 0,
+        };
+
+        const char *scan = (dir_part[0] == '\0') ? NULL : dir_part;
+        vfs_complete(scan, "", glob_cb, &ctx);
+
+        if (ctx.nmatches == 0) {
+            /* No match - leave token alone (bash default behaviour). */
+            i++;
+            continue;
+        }
+
+        /* Reserve the consumed arena. */
+        buf  = ctx.buf;
+        left = ctx.buf_left;
+
+        /* Splice matches into argv at position i, shifting the tail. */
+        int extra = ctx.nmatches - 1;
+        if (extra > 0) {
+            /* Shift argv[i+1..argc-1] right by `extra`. */
+            for (int j = argc - 1; j > i; j--)
+                argv[j + extra] = argv[j];
+        }
+        for (int k = 0; k < ctx.nmatches; k++)
+            argv[i + k] = matches[k];
+
+        argc += extra;
+        i    += ctx.nmatches;
+    }
+
+    return argc;
+}

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -12,14 +12,16 @@
 #include <string.h>
 
 #define SHELL_MAX_INPUT  256
-#define SHELL_MAX_ARGS   8
+#define SHELL_MAX_ARGS   16   /* enough headroom for glob expansion */
 
 /* Medli-compatible identity: username and hostname shown in the prompt. */
 #define SHELL_USERNAME   "root"
 #define SHELL_HOSTNAME   "makar"
 
-/* Kernel version string (shared with cmd_version and the welcome banner). */
-#define SHELL_VERSION    "0.1.0"
+/* Shell version - independent of the kernel version (<kernel/version.h>).
+ * The shell is conceptually a separate component; bump this when shell
+ * features change, MAKAR_VERSION when the kernel itself changes. */
+#define SHELL_VERSION    "0.5.0"
 
 #define BUILD_DATE __DATE__
 #define BUILD_TIME __TIME__

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -62,6 +62,10 @@ extern const shell_cmd_entry_t fileops_cmds[];
 /* shell.c – REPL core */
 void shell_readline(char *buf, size_t max);
 
+/* shell_glob.c – wildcard (* and ?) expansion of argv tokens via VFS. */
+int  shell_expand_globs(int argc, char **argv, int argv_cap,
+                        char *storage, size_t storage_size);
+
 /* shell_cmd_apps.c – shared ELF launcher used by exec and PATH lookup */
 void shell_exec_elf(const char *path, int argc, char **argv);
 

--- a/src/kernel/include/kernel/procfs.h
+++ b/src/kernel/include/kernel/procfs.h
@@ -1,0 +1,41 @@
+#ifndef _KERNEL_PROCFS_H
+#define _KERNEL_PROCFS_H
+
+/*
+ * procfs - synthetic /proc filesystem.
+ *
+ * Linux-style read-only view of kernel state.  Each entry is generated
+ * on demand by a renderer that writes ASCII into the caller's buffer:
+ *
+ *   /proc/cpuinfo  CPUID vendor / family / model / features
+ *   /proc/meminfo  PMM frame count + heap usage
+ *   /proc/tasks    one row per live task (pid name state tty cwd)
+ *   /proc/uname    kernel name, version, build timestamp
+ *
+ * No write support.  VFS routes paths under /proc here.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <kernel/fat32.h>   /* fat32_complete_cb_t */
+
+/* List the /proc directory (or report 'not a dir' for entry paths) to
+ * the current terminal.  Returns 0. */
+int procfs_ls(const char *path);
+
+/* Read entire synthesised content of /proc/<entry> into buf (up to
+ * bufsz bytes).  Returns 0 on success, -1 if path is unknown.
+ * *out_sz receives the number of bytes written. */
+int procfs_read_file(const char *path, void *buf, uint32_t bufsz,
+                     uint32_t *out_sz);
+
+/* Tab-completion enumeration: invokes cb for each entry under /proc
+ * whose name starts with prefix.  Returns 0. */
+int procfs_complete(const char *dir, const char *prefix,
+                    fat32_complete_cb_t cb, void *ctx);
+
+/* Returns 1 if path names a known /proc entry, 0 otherwise. */
+int procfs_file_exists(const char *path);
+
+#endif /* _KERNEL_PROCFS_H */

--- a/src/kernel/include/kernel/procfs.h
+++ b/src/kernel/include/kernel/procfs.h
@@ -20,6 +20,12 @@
 
 #include <kernel/fat32.h>   /* fat32_complete_cb_t */
 
+/* Mount-point prefix.  Single source of truth: procfs error messages
+ * and any other consumer that needs to format absolute /proc paths
+ * should derive them from this string rather than hardcoding "/proc". */
+#define PROCFS_MOUNT      "/proc"
+#define PROCFS_MOUNT_LEN  5
+
 /* List the /proc directory (or report 'not a dir' for entry paths) to
  * the current terminal.  Returns 0. */
 int procfs_ls(const char *path);

--- a/src/kernel/include/kernel/version.h
+++ b/src/kernel/include/kernel/version.h
@@ -1,0 +1,12 @@
+#ifndef _KERNEL_VERSION_H
+#define _KERNEL_VERSION_H
+
+/*
+ * Single source of truth for Makar's version string.  Bumped per
+ * SemVer when a significant slice ships.  Consumed by the shell welcome
+ * banner, the `version` builtin, /proc/uname, and anywhere else that
+ * wants to report the kernel version.
+ */
+#define MAKAR_VERSION "0.5.0"
+
+#endif /* _KERNEL_VERSION_H */

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -122,6 +122,18 @@ void vesa_tty_paint_cell(uint32_t col, uint32_t row, char ch,
  * vtty_switch to surface a background TTY's accumulated state. */
 void vesa_tty_paint_buf(const struct vt_buf *vt);
 
+/* Paint a string starting at cell (col, row) using explicit RGB colours.
+ * Bypasses cursor / scrolling / vt_buf routing - direct FB write.  Used
+ * for status-bar overlay rows that live outside any TTY's grid. */
+void vesa_tty_paint_string_at(uint32_t col, uint32_t row,
+                              const char *s,
+                              uint32_t fg_rgb, uint32_t bg_rgb);
+
+/* Paint the tmux-style status bar at the bottom row of the screen.
+ * Active TTY is highlighted with inverse video.  active=current VT,
+ * count=number of registered slots.  No-op if vesa_tty isn't ready. */
+void vesa_tty_paint_status(int active, int count);
+
 /* ------------------------------------------------------------------ */
 /* Visible caret on the default pane                                   */
 /* ------------------------------------------------------------------ */

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+struct vt_buf;
+
 /*
  * vesa_tty - text renderer over the VESA framebuffer.
  *
@@ -105,6 +107,20 @@ void vesa_tty_clear(void);
 /* Animate a spinning cursor at the top-right corner of the screen.
  * Always renders into the default pane regardless of focus. */
 void vesa_tty_spinner_tick(uint32_t tick);
+
+/* ------------------------------------------------------------------ */
+/* Backing-grid integration                                            */
+/* ------------------------------------------------------------------ */
+
+/* Paint a single cell at (col, row) using explicit framebuffer-pixel
+ * fg/bg.  Bypasses cursor / scrolling logic; used by vtty_switch when
+ * replaying a VT's backing grid. */
+void vesa_tty_paint_cell(uint32_t col, uint32_t row, char ch,
+                         uint32_t fg, uint32_t bg);
+
+/* Repaint the entire framebuffer from a backing vt_buf.  Used by
+ * vtty_switch to surface a background TTY's accumulated state. */
+void vesa_tty_paint_buf(const struct vt_buf *vt);
 
 /* ------------------------------------------------------------------ */
 /* Visible caret on the default pane                                   */

--- a/src/kernel/include/kernel/vt.h
+++ b/src/kernel/include/kernel/vt.h
@@ -1,0 +1,68 @@
+#ifndef _KERNEL_VT_H
+#define _KERNEL_VT_H
+
+/*
+ * vt - virtual console backing grid.
+ *
+ * One vt_buf_t per virtual terminal.  Holds a cols x rows grid of cells
+ * ({char, fg, bg}), the current cursor position, and the "current"
+ * fg/bg attribute applied to incoming characters.  Pure data layer -
+ * no framebuffer knowledge.
+ *
+ * Modelled on Linux's vc_data.vc_screenbuf and the ELKS / xv6 console
+ * backing-buffer pattern.  vtty owns one buffer per TTY slot; the
+ * vesa_tty / VGA renderers consult the current task's buffer when
+ * deciding whether a write also needs to hit the physical framebuffer.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef struct vt_cell {
+    uint8_t  ch;
+    uint8_t  flags;   /* reserved for bold/inverse/etc. */
+    uint32_t fg;      /* framebuffer-pixel-encoded foreground */
+    uint32_t bg;      /* framebuffer-pixel-encoded background */
+} vt_cell_t;
+
+typedef struct vt_buf {
+    uint32_t   cols;
+    uint32_t   rows;
+    uint32_t   cur_col;
+    uint32_t   cur_row;
+    uint32_t   fg;        /* current attribute applied to incoming chars */
+    uint32_t   bg;
+    vt_cell_t *cells;     /* row-major: cells[row * cols + col] */
+} vt_buf_t;
+
+/* Allocate the cell grid on the heap.  cols * rows cells, all set to
+ * {' ', 0, fg, bg} so the buffer is paint-ready immediately.  Returns
+ * true on success, false on allocation failure (caller may keep using
+ * the buffer with cells == NULL; vt_putchar / vt_clear become no-ops). */
+bool vt_init(vt_buf_t *vt, uint32_t cols, uint32_t rows,
+             uint32_t default_fg, uint32_t default_bg);
+
+/* Write c into the grid at the current cursor, advancing it.  Honours
+ * \n, \r, \b.  Scrolls the grid up by one row when the cursor walks off
+ * the bottom (top row is discarded).  No-op if cells == NULL. */
+void vt_putchar(vt_buf_t *vt, char c);
+
+/* Write c at (col, row) without moving the cursor.  Bounds-checked. */
+void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row);
+
+/* Set the current attribute applied to subsequent vt_putchar / vt_put_at
+ * calls.  Does not repaint existing cells. */
+void vt_set_color(vt_buf_t *vt, uint32_t fg, uint32_t bg);
+
+/* Move the cursor.  Coordinates are clamped to the grid. */
+void vt_set_cursor(vt_buf_t *vt, uint32_t col, uint32_t row);
+
+/* Fill the grid with the current bg colour and reset cursor to (0,0). */
+void vt_clear(vt_buf_t *vt);
+
+/* Read-only accessor for cell (col, row).  Returns a zero-filled cell
+ * for out-of-bounds reads (caller must not pass NULL vt). */
+vt_cell_t vt_get_cell(const vt_buf_t *vt, uint32_t col, uint32_t row);
+
+#endif /* _KERNEL_VT_H */

--- a/src/kernel/include/kernel/vt.h
+++ b/src/kernel/include/kernel/vt.h
@@ -36,6 +36,15 @@ typedef struct vt_buf {
     vt_cell_t *cells;     /* row-major: cells[row * cols + col] */
 } vt_buf_t;
 
+/* Result of vt_putchar - lets the renderer know what to repaint without
+ * having to diff before/after state itself. */
+typedef struct vt_dirty {
+    int      scrolled;   /* 1 if the grid scrolled; full repaint needed */
+    int      has_cell;   /* 1 if a single cell was written (col,row valid) */
+    uint32_t col;
+    uint32_t row;
+} vt_dirty_t;
+
 /* Allocate the cell grid on the heap.  cols * rows cells, all set to
  * {' ', 0, fg, bg} so the buffer is paint-ready immediately.  Returns
  * true on success, false on allocation failure (caller may keep using
@@ -45,8 +54,14 @@ bool vt_init(vt_buf_t *vt, uint32_t cols, uint32_t rows,
 
 /* Write c into the grid at the current cursor, advancing it.  Honours
  * \n, \r, \b.  Scrolls the grid up by one row when the cursor walks off
- * the bottom (top row is discarded).  No-op if cells == NULL. */
-void vt_putchar(vt_buf_t *vt, char c);
+ * the bottom (top row is discarded).  No-op if cells == NULL.
+ *
+ * Returns a vt_dirty_t describing what changed so the renderer can
+ * paint exactly the affected cells:
+ *   - .scrolled == 1: the grid scrolled; renderer must repaint all rows.
+ *   - .has_cell == 1: the single cell at (col, row) was modified.
+ *   - both 0: control character with no visible effect (just cursor moved). */
+vt_dirty_t vt_putchar(vt_buf_t *vt, char c);
 
 /* Write c at (col, row) without moving the cursor.  Bounds-checked. */
 void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row);

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -10,10 +10,13 @@
  */
 
 #include <kernel/task.h>
+#include <kernel/vt.h>
 
 #define VTTY_MAX 4
 
-/* Call once before spawning shell tasks. */
+/* Call once before spawning shell tasks.  Allocates per-slot backing
+ * grids sized from the active display geometry (VESA cell dims if the
+ * framebuffer renderer is ready, otherwise the 80x50 VGA-text fallback). */
 void vtty_init(void);
 
 /* Register the calling task as the next available TTY slot.
@@ -33,5 +36,21 @@ void vtty_switch(int n);
 
 /* Returns the number of registered TTY slots. */
 int vtty_count(void);
+
+/* ------------------------------------------------------------------ */
+/* Per-TTY backing-grid access                                          */
+/* ------------------------------------------------------------------ */
+
+/* Returns the backing buffer for slot n, or NULL if n is out of range
+ * or vtty has not initialised buffers yet. */
+vt_buf_t *vtty_buf(int n);
+
+/* Returns the backing buffer bound to the calling task's TTY index, or
+ * NULL if the task has TASK_TTY_NONE (e.g. idle, ktest_bg, boot CPU). */
+vt_buf_t *vtty_buf_current(void);
+
+/* Returns the backing buffer for the currently focused TTY, or NULL if
+ * buffers are not yet allocated. */
+vt_buf_t *vtty_buf_focused(void);
 
 #endif /* _KERNEL_VTTY_H */

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -53,4 +53,9 @@ vt_buf_t *vtty_buf_current(void);
  * buffers are not yet allocated. */
 vt_buf_t *vtty_buf_focused(void);
 
+/* Apply any pending vtty_switch repaint deferred from IRQ context.
+ * Safe to call from task context (yields, REPL polling); cheap when
+ * no switch is pending. */
+void vtty_drain_pending(void);
+
 #endif /* _KERNEL_VTTY_H */


### PR DESCRIPTION
## Summary

Slice 10 of the per-TTY/multitasking roadmap, plus follow-on shell UX polish:

- **Per-TTY backing buffers** (`vt_buf_t`) so each shell's screen survives Alt+F1-F4 switches (Linux VT semantics). Repaint is deferred out of IRQ context to the destination task.
- **Tmux-style status bar** in the reserved bottom row showing `Makar  VT0..VT3  Alt+F1-F4` with the active slot highlighted.
- **Synthetic `/proc` filesystem** with `cpuinfo`, `meminfo`, `tasks`, `uname` rendered on-demand. Plugs into the existing VFS routing.
- **Slice 7 (partial)**: `task->tty` is now authoritative; the parallel `vtty_tasks[]` array is gone.
- **Wildcard expansion** (`*`, `?`) for shell argv, routed through `vfs_complete()` so it works uniformly across `/hd`, `/cdrom`, `/proc`, and any future backend.
- **Uniform multi-arg consumption** in `ls`, `cat`, `rm`, `rmdir`, `mkdir`, `touch` - so glob results aren't dropped after the first.
- **TAB-completion fixes**: trailing space appended on unique-prefix matches (visible feedback for `cat<TAB>`, `cd<TAB>`); fixed off-by-error in the path-completion inserter (`/proc/c<TAB>` was finding the match but inserting zero chars).
- **`MAKAR_VERSION` header** as the single source of truth for the kernel version string; bumped to `0.5.0`. `/proc/uname` and procfs error messages derive from it (single `PROCFS_MOUNT` constant, no more duplicated `"/proc"` literals).

## Test plan

- [x] `./run.sh iso-test` green (ktest + GDB boot checkpoints + bg ktest + CD-ROM content)
- [x] `./run.sh hdd-test` green
- [x] End-to-end interactive verification via QEMU HMP monitor + screendump:
  - [x] `cat /proc/*` renders cpuinfo + meminfo + tasks + uname in one shot
  - [x] `cat<TAB>` inserts trailing space
  - [x] `/proc/c<TAB>` completes to `/proc/cpuinfo`
  - [x] Combined `cat<TAB>/proc/c<TAB><Enter>` runs and prints cpuinfo
- [x] Status bar visible at bottom row across all 4 TTYs, active slot highlighted
- [x] Background TTY output survives Alt+Fn focus switches