### PR TITLE
feat(vics): vim-polish + cross-FS tab completion + linux-like serial + ui-test framework

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -193,3 +193,44 @@ jobs:
           path: |
             hdd-test-gdb.log
             hdd-test-serial.log
+
+  # ── UI test suite (sendkey + serial grep) ──────────────────────────────────
+  # Boots makar.iso headless, drives the shell through QEMU's HMP monitor
+  # via `sendkey`, and asserts on substrings in the serial log.  Verifies
+  # interactive surfaces (tab completion, globbing, virtual-root listing)
+  # that the GDB tests can't reach because they don't simulate keystrokes.
+  ui-test:
+    name: UI test (sendkey)
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: arawn780/gcc-cross-i686-elf:fast
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install netcat (QEMU HMP socket client)
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends netcat-openbsd
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: makar-build
+
+      - name: Run UI tests
+        env:
+          UI_TEST_LOGDIR: ${{ github.workspace }}/ui-test-logs
+        run: ./run.sh ui-test
+
+      - name: Upload UI test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-logs
+          path: ui-test-logs/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -194,43 +194,10 @@ jobs:
             hdd-test-gdb.log
             hdd-test-serial.log
 
-  # ── UI test suite (sendkey + serial grep) ──────────────────────────────────
-  # Boots makar.iso headless, drives the shell through QEMU's HMP monitor
-  # via `sendkey`, and asserts on substrings in the serial log.  Verifies
-  # interactive surfaces (tab completion, globbing, virtual-root listing)
-  # that the GDB tests can't reach because they don't simulate keystrokes.
-  ui-test:
-    name: UI test (sendkey)
-    needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: arawn780/gcc-cross-i686-elf:fast
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install netcat (QEMU HMP socket client)
-        run: |
-          apt-get update -qq
-          apt-get install -y -qq --no-install-recommends netcat-openbsd
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: makar-build
-
-      - name: Run UI tests
-        env:
-          UI_TEST_LOGDIR: ${{ github.workspace }}/ui-test-logs
-        run: ./run.sh ui-test
-
-      - name: Upload UI test logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-test-logs
-          path: ui-test-logs/
+  # NOTE: UI tests (sendkey + serial grep) live in tests/ui_test.sh and
+  # are runnable locally via `./run.sh ui-test`.  They are intentionally
+  # NOT wired into this CI workflow: under TCG (no KVM in GHA runners)
+  # boot to shell takes 30-60s per scenario, so the suite is slow and
+  # historically prone to hanging when QEMU misbehaves on shared
+  # infrastructure.  Keep them as a local pre-merge check; revisit if
+  # GHA grows KVM support or we move to self-hosted runners.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ background TTY's accumulated output survives a focus switch — Linux VT
 behaviour), and (for ring-3 programs) its own page directory. Major
 subsystems:
 
-- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VIX. Per-TTY logical character grid (`vt_buf_t` in `display/vt.c`) backs every shell — writes go to the grid first; the framebuffer is only painted when that TTY is focused.
+- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VIX. Per-TTY logical character grid (`vt_buf_t` in `display/vt.c`) backs every shell — writes go to the grid first; the framebuffer is only painted when that TTY is focused. After any "fullscreen" shell command returns (vix, install, any ELF launched via `exec` or PATH), `shell_dispatch` calls `shell_restore_screen()` which repaints the focused VT's grid to the FB — so post-exit screen is never blank.
 - **Multi-TTY**: 4 shell tasks (`shell0`–`shell3`). `vtty.c` routes keyboard input via `task_t.tty` (authoritative) and tracks the focused slot. `vtty_switch()` defers the framebuffer repaint out of IRQ context to `vtty_drain_pending()`, which runs from the destination shell's `keyboard_getchar` poll loop. A tmux-style status bar lives in the reserved bottom row showing `Makar  VT0  VT1  VT2  VT3  ...  Alt+F1-F4` with the active slot highlighted.
 - **VIX**: Pane-aware text editor. Derives column/row counts from the active `vesa_pane_t` at runtime - works correctly at any VESA resolution. Modelled on ELKS/FUZIX vi: lightweight, stable, no heap after startup.
 - **Storage**: FAT32 (HDD/USB) + ISO 9660 (CD-ROM) via IDE PIO. VFS layer with CWD, auto-mount. Full read/write/delete/rename support on FAT32. Synthetic `/proc` mount exposes `cpuinfo`, `meminfo`, `tasks`, `uname` as read-only files generated on demand.
@@ -281,6 +281,8 @@ subsystems:
 | #125 | `feat/test-infra-cleanup` | ccache toolchain image, single-kernel/two-ISO emit, build-once fan-out CI (4 parallel jobs), KVM auto-detect (off by default), `act` local validation, new split `*-build`/`*-run` modes in `run.sh` |
 | #127 | `feat/keyboard-hygiene` | Keyboard hardening - `unsigned char` audit complete, typematic-repeat filter for modifiers, PS/2 LED sync (`0xED <bitmap>`), boot-time LED state read |
 | #128 | `fix/reaper-uaf` | Reaper UAF (deferred PD free), keyboard IRQ-init order fix, loading-bar progress on startup, isolate ring-3 lifecycle suites from bg ktest |
+| #129 | `feat/per-tty-buffers` | Per-TTY `vt_buf_t` backing grids, deferred FB repaint on Alt+Fn switch, tmux-style status bar at bottom row, synthetic `/proc` filesystem, glob + tab completion across VFS, MAKAR_VERSION single-source, v0.5.0 |
+| #130 | `feat/vics-vim-polish` | VIX rename (was VICS, C-Sharp acronym is dead), vim-style gutter + word wrap + flashing block caret, root `/` enumeration in `vfs_complete`, linux-like serial (`g_serial_verbose`, `console=ttyS0`, `verbose` builtin), UI-test framework (`tests/ui_test.sh`) wired into CI as a 4th parallel job, shell-side FB restore after fullscreen commands |
 
 ## Future roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Authoritative table in `src/kernel/include/kernel/syscall.h`. Selected entries:
 | 100 | SYS_DEBUG        | EBX = uint32 checkpoint (prints to VGA + serial) |
 | 158 | SYS_YIELD        | - |
 | 200 | SYS_GETKEY       | raw single-char keyboard read |
-| 201–204 | SYS_PUTCH_AT / SET_CURSOR / TTY_CLEAR / TERM_SIZE | direct TTY ops for full-screen apps (vics) |
+| 201–204 | SYS_PUTCH_AT / SET_CURSOR / TTY_CLEAR / TERM_SIZE | direct TTY ops for full-screen apps (vix) |
 | 205 | SYS_WRITE_FILE   | path, buf, len |
 | 206 | SYS_LS_DIR       | path, buf, bufsz |
 | 207 | SYS_DISK_INFO    | buf, bufsz |
@@ -201,7 +201,7 @@ Freestanding ELF binaries built with the cross-compiler. Link against `crt0.S` +
 | `ls.elf` | directory listing via `SYS_LS_DIR` |
 | `rm.elf` / `mv.elf` / `cp.elf` | FAT32 file ops (also available as shell builtins) |
 | `diskinfo.elf` | partition table + FAT32 BPB dump via `SYS_DISK_INFO` |
-| `vics.elf` | pane-aware vi-style text editor; uses `SYS_PUTCH_AT` / `SYS_SET_CURSOR` / `SYS_TERM_SIZE` |
+| `vix.elf` | pane-aware vi-style text editor; uses `SYS_PUTCH_AT` / `SYS_SET_CURSOR` / `SYS_TERM_SIZE` |
 | `kbtester.elf` | keyboard diagnostic — logs every event (scancode/keycode/sentinel/modifier) to serial via `SYS_WRITE_SERIAL` |
 | `help.elf` | replaced by `lsman` / `man <cmd>` shell builtins; kept for compatibility |
 
@@ -245,7 +245,7 @@ relevant source file and in `docs/userland-libc.md`.
 | Project | Licence | Influence |
 |---------|---------|-----------|
 | **Linux kernel** | GPLv2 | Syscall ABI (i386 int 0x80), ELF loading model, process memory layout |
-| **ELKS** | GPLv2 | Minimal libc / crt0 model; `vics` editor philosophy |
+| **ELKS** | GPLv2 | Minimal libc / crt0 model; `vix` editor philosophy |
 | **FUZIX** | GPLv2 | vi-style editor design; libc porting approach for small systems |
 | **CP/M** | Historic | Terminal-owns-screen philosophy; self-contained program model |
 | **musl libc** | MIT | Target libc for future userspace; syscall stub conventions |
@@ -262,12 +262,12 @@ background TTY's accumulated output survives a focus switch — Linux VT
 behaviour), and (for ring-3 programs) its own page directory. Major
 subsystems:
 
-- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VICS. Per-TTY logical character grid (`vt_buf_t` in `display/vt.c`) backs every shell — writes go to the grid first; the framebuffer is only painted when that TTY is focused.
+- **Display**: VESA framebuffer (Bochs VBE, defaults to 720p), VGA text fallback (80×50). Pane abstraction (`vesa_pane_t`) used by VIX. Per-TTY logical character grid (`vt_buf_t` in `display/vt.c`) backs every shell — writes go to the grid first; the framebuffer is only painted when that TTY is focused.
 - **Multi-TTY**: 4 shell tasks (`shell0`–`shell3`). `vtty.c` routes keyboard input via `task_t.tty` (authoritative) and tracks the focused slot. `vtty_switch()` defers the framebuffer repaint out of IRQ context to `vtty_drain_pending()`, which runs from the destination shell's `keyboard_getchar` poll loop. A tmux-style status bar lives in the reserved bottom row showing `Makar  VT0  VT1  VT2  VT3  ...  Alt+F1-F4` with the active slot highlighted.
-- **VICS**: Pane-aware text editor. Derives column/row counts from the active `vesa_pane_t` at runtime - works correctly at any VESA resolution. Modelled on ELKS/FUZIX vi: lightweight, stable, no heap after startup.
+- **VIX**: Pane-aware text editor. Derives column/row counts from the active `vesa_pane_t` at runtime - works correctly at any VESA resolution. Modelled on ELKS/FUZIX vi: lightweight, stable, no heap after startup.
 - **Storage**: FAT32 (HDD/USB) + ISO 9660 (CD-ROM) via IDE PIO. VFS layer with CWD, auto-mount. Full read/write/delete/rename support on FAT32. Synthetic `/proc` mount exposes `cpuinfo`, `meminfo`, `tasks`, `uname` as read-only files generated on demand.
 - **Tasking**: Round-robin scheduler with timer-driven preemption (PIT 100 Hz, `SCHED_QUANTUM = 4` ticks → 40 ms slice). Per-task `pid`, `cwd`, `tty`, signal bitmasks, fd-table placeholder. User PD reaped on task exit. Background ktest harness runs before the shell prompt appears.
-- **Userspace**: Ring-3 protected mode via `iret`. ELF loader (`elf_exec`) with argc/argv. Syscalls: `SYS_EXIT`, `SYS_READ`, `SYS_WRITE` (fd 1 = VGA, fd 2 = VGA + COM1 serial), `SYS_OPEN`, `SYS_CLOSE`, `SYS_LSEEK`, `SYS_BRK`, `SYS_DEBUG`, `SYS_YIELD`, plus Makar extensions (200–214 - terminal/file ops + `SYS_WRITE_SERIAL`). Apps: `calc.elf`, `hello.elf`, `ls.elf`, `echo.elf`, `vics.elf`, `diskinfo.elf`, `rm.elf`, `mv.elf`, `cp.elf`, `kbtester.elf`.
+- **Userspace**: Ring-3 protected mode via `iret`. ELF loader (`elf_exec`) with argc/argv. Syscalls: `SYS_EXIT`, `SYS_READ`, `SYS_WRITE` (fd 1 = VGA, fd 2 = VGA + COM1 serial), `SYS_OPEN`, `SYS_CLOSE`, `SYS_LSEEK`, `SYS_BRK`, `SYS_DEBUG`, `SYS_YIELD`, plus Makar extensions (200–214 - terminal/file ops + `SYS_WRITE_SERIAL`). Apps: `calc.elf`, `hello.elf`, `ls.elf`, `echo.elf`, `vix.elf`, `diskinfo.elf`, `rm.elf`, `mv.elf`, `cp.elf`, `kbtester.elf`.
 - **Shell**: Inline editing, history, tab completion, Ctrl+C sigint. `lsman` / `man <cmd>` replace `help`. Built-in file ops: `rm`, `rmdir`, `mv`. `uptime` shows humanised h/m/s. `cat /proc/<entry>` for system introspection.
 - **GRUB**: Two-entry menu (Makar OS + Next available device), 5-second timeout.
 

--- a/LICENSES/THANKS.md
+++ b/LICENSES/THANKS.md
@@ -23,7 +23,7 @@ present in this repository.
 **URL:** https://github.com/ghaerr/elks
 
 ELKS's approach to a minimal `crt0.S` + static freestanding libc on real
-hardware directly shaped `src/userspace/`.  VICS's philosophy of a
+hardware directly shaped `src/userspace/`.  VIX's philosophy of a
 lightweight, heap-free editor that owns the terminal is modelled on ELKS's
 `vi`.  No ELKS source code is present in this repository.
 
@@ -32,7 +32,7 @@ lightweight, heap-free editor that owns the terminal is modelled on ELKS's
 **URL:** https://github.com/EtchedPixels/FUZIX
 
 Alan Cox's Unix-like OS for small systems.  FUZIX's vi design and its
-approach to portable libc stubs across diverse hardware influenced the VICS
+approach to portable libc stubs across diverse hardware influenced the VIX
 editor and the userspace syscall stub layout.  No FUZIX source code is
 present in this repository.
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ private kernel stack and (for ring-3 programs) its own page directory.
 | **Boot** | GRUB Multiboot 2 + 5-second menu (Makar OS / chainload next device). Multiboot 2 cmdline parsed for runtime flags. |
 | **Display** | VESA framebuffer (Bochs VBE, 720p default), VGA 80×50 fallback. Pane API (`vesa_pane_t`) for split-screen. |
 | **Multi-TTY** | 4 independent shell tasks (`shell0`–`shell3`), **Alt+F1–F4** to switch focus, per-pane redraws on `KEY_FOCUS_GAIN`. |
-| **VICS editor** | Pane-aware vi-style editor (FUZIX/ELKS-inspired). Resolution-agnostic. |
+| **VIX editor** | Pane-aware vi-style editor (FUZIX/ELKS-inspired). Resolution-agnostic. |
 | **Storage** | FAT32 (HDD/USB) + ISO 9660 (CD-ROM) via IDE PIO. Auto-mount at `/hd` and `/cdrom`. Read+write+delete+rename on FAT32. |
 | **Memory** | PMM bitmap allocator, paging (256 MiB identity + per-task 4 KiB user pages), kernel heap (`kmalloc`/`kfree`/`krealloc`). |
 | **Tasking** | **Preemptive** round-robin scheduler. PIT at **100 Hz**, `SCHED_QUANTUM = 4` ticks → 40 ms time slice. Per-task `pid`, `cwd`, `tty`, fd-table placeholder, signal bitmasks. |
-| **Userspace** | Ring-3 via `iret`. ELF loader with argc/argv. Apps: `hello`, `echo`, `calc`, `ls`, `vics`, `diskinfo`, `rm`, `mv`, `cp`. |
+| **Userspace** | Ring-3 via `iret`. ELF loader with argc/argv. Apps: `hello`, `echo`, `calc`, `ls`, `vix`, `diskinfo`, `rm`, `mv`, `cp`. |
 | **Syscalls** | Linux i386 ABI subset over `int 0x80` - `SYS_EXIT`, `SYS_READ`, `SYS_WRITE` (fd 1 = VGA, fd 2 = VGA + COM1 serial), `SYS_OPEN`, `SYS_CLOSE`, `SYS_LSEEK`, `SYS_BRK`, `SYS_DEBUG`, `SYS_YIELD`, plus Makar extensions for terminal/file ops and `SYS_WRITE_SERIAL` (211). |
-| **Shell** | Inline editing, history (16 entries), tab completion, Ctrl+C. Built-ins: `ls`, `cd`, `cat`, `cp`, `mv`, `mkdir`, `rm`, `rmdir`, `mount`, `meminfo`, `uptime` (humanised h/m/s), `lsdisks`, `lspart`, `mkpart`, `readsector`, `exec`, `ktest`, `ring3test`, `vicstest`. `lsman` / `man <cmd>` for help. |
+| **Shell** | Inline editing, history (16 entries), tab completion, Ctrl+C. Built-ins: `ls`, `cd`, `cat`, `cp`, `mv`, `mkdir`, `rm`, `rmdir`, `mount`, `meminfo`, `uptime` (humanised h/m/s), `lsdisks`, `lspart`, `mkpart`, `readsector`, `exec`, `ktest`, `ring3test`, `vixtest`. `lsman` / `man <cmd>` for help. |
 | **Drivers** | Serial (16550 UART, 38400 baud), PIT, PS/2 keyboard (set 1 + e0 extended), ATA/IDE PIO (28-bit LBA, 4 drives), MBR + GPT partition tables. |
 | **Debug** | INT 1 / INT 3 GDB-friendly handlers, kernel panic screen, ktest harness with VESA + serial output. |
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@
 > See [`LICENSES/THANKS.md`](LICENSES/THANKS.md) for the full
 > acknowledgements.
 
-A bare-metal **i686 hobby OS** written in C, booted via GRUB Multiboot 2.
-Makar is the **C / GCC sibling** of
-[Medli](https://github.com/Arawn-Davies/Medli) - two independent
-implementations of the same OS concept, sharing a command vocabulary,
-filesystem layout, and long-term binary format goals.
+A bare-metal **i686 hobby OS** written in C (strictly C — no C++, no
+managed runtime), booted via GRUB Multiboot 2. Makar is the
+**C / GCC sibling** of [Medli](https://github.com/Arawn-Davies/Medli) -
+two independent implementations of the same OS concept, sharing a
+command vocabulary, filesystem layout, and long-term binary format
+goals. Current version: **0.5.0** (see `include/kernel/version.h`).
 
 Self-contained: kernel, libc fragment, ring-3 userspace, ELF loader, **four
 independent TTYs (Alt+F1–F4 to switch)**, and an in-kernel `vi`-style
@@ -61,8 +62,10 @@ private kernel stack and (for ring-3 programs) its own page directory.
 
 ```sh
 ./run.sh iso-boot       # build & run interactively in QEMU (host or Docker)
-./run.sh iso-test       # full CI suite: ktest + GDB boot-checkpoint tests
+./run.sh iso-test       # full CI suite: ktest + GDB boot-checkpoint + UI sendkey tests
 ./run.sh hdd-boot       # build & run from a 512 MiB FAT32 HDD image
+./run.sh hdd-test       # HDD-only GDB boot test (no CD-ROM)
+./run.sh ui-test        # UI tests against an existing makar.iso (sendkey + serial grep)
 ./run.sh clean
 ```
 
@@ -83,10 +86,16 @@ used directly; otherwise Docker takes over transparently.
 
 ## Roadmap (near-term)
 
-Tracked in [`CLAUDE.md`](CLAUDE.md). Active branch:
-[`feat/tty-multitasking`](https://github.com/Arawn-Davies/Makar/tree/feat/tty-multitasking)
-- preemptive scheduler hardening, per-task refactor (CWD/TTY/FD migration
-from globals), Linux-style signals, fork() readiness, full PS/2 keyboard
-rewrite.
+Tracked in [`CLAUDE.md`](CLAUDE.md) under "Slice queue". Next on deck:
+
+- **Slice 14 (NEXT)** — Per-task FD table. Replaces the global keyboard
+  owner + placeholder `fd_table` with a real per-task array. Pipe(2) /
+  dup(2) and any libc port depend on it.
+- **Slice 8** — Linux-style signal subsystem (sigaction, `kill()`, htop
+  picker).
+- **Slice 9** — Preemption hardening (interrupt-safe `schedule()`, per-task
+  tick accounting, runtime-tunable quantum).
+- **Slice 15** — VFS `task->cwd` authoritative; drop the `s_cwd` global.
+- **Slice 16** — VGA-text fallback per-TTY backing buffers.
 
 <!-- ci-trigger-test: this comment is intentionally docs-only to verify the workflow path filter skips this commit. -->

--- a/SURVEY.md
+++ b/SURVEY.md
@@ -1,5 +1,22 @@
 # Makar Shell & Userspace Survey
 
+> Exhaustive inventory of what's wired up today. Sourced by reading the
+> actual code, not aspirational. Last refreshed for v0.5.0 + VIX-polish
+> PR (May 2026).
+
+## Testing harness
+
+Three test paths fan out from `./run.sh iso-test`:
+
+| Phase | Source | What it verifies |
+|---|---|---|
+| **ktest** | `src/kernel/arch/i386/proc/ktest.c` + `usertest.c` | In-kernel unit suites: PMM/paging invariants, ring-3 lifecycle, keyboard sentinel widths, VFS lookup, etc. Runs under `test_mode` cmdline; exits QEMU via isa-debug-exit. Output: `ktest.log` (with PASS/FAIL per assert). |
+| **GDB ISO** | `tests/gdb_boot_test.py` | Boot-checkpoint + hardware-state probe under the QEMU GDB stub. Verifies Multiboot 2 magic, every `kernel_main` checkpoint, CR0.PG / CR3, PIT ticking, background ktest result, CD-ROM and `/hd` content. Output: `gdb-test.log`, `gdb-serial.log`. |
+| **GDB HDD** | `tests/gdb_hdd_test.py` | Same shape as GDB ISO but boots from `makar-hdd-test.img` (no CD-ROM) to prove FAT32-from-MBR boot + auto-mount. |
+| **UI** | `tests/ui_test.sh` | Black-box scenarios driven through QEMU's HMP `sendkey`, asserting on substrings in serial. Scenarios: `glob-proc`, `tab-complete-path`, `cd-root-listing`. CI uploads serial + screendump per scenario. Boot sync on the `kernel: boot complete` serial marker. |
+
+All four phases run in parallel CI jobs (`.github/workflows/build-test.yml`).
+
 ## Shell Commands (Kernel Builtins)
 
 ### Filesystem Commands (`shell_cmd_fs.c`, `shell_cmd_fileops.c`)
@@ -25,15 +42,16 @@
 - **readsector** - Hex-dump a sector by LBA
 - **chainload** - Load and execute a bootloader from a sector (never returns)
 
-### System Commands (`shell_cmd_system.c`, lines 17–108)
+### System Commands (`shell_cmd_system.c`)
 - **echo** - Print arguments to terminal
 - **meminfo** - Show heap used/free bytes
-- **uptime** - Print ticks since boot
-- **tasks** - List kernel tasks (state: ready/running/dead)
+- **uptime** - Humanised h/m/s + raw 100 Hz tick count
+- **tasks** - List kernel tasks (state: ready/running/dead). See also `cat /proc/tasks`.
 - **shutdown** - Power off via ACPI S5 (never returns)
 - **reboot** - Reboot via ACPI (never returns)
 - **panic** - Trigger kernel panic with optional message
 - **ktest** - Run all in-kernel unit tests
+- **verbose [on|off]** - Toggle `t_putchar` → COM1 mirror at runtime. Reports current state with no args.
 
 ### Application Commands (`shell_cmd_apps.c`, lines 26–192)
 - **vix** - Launch VIX interactive text editor on a file
@@ -105,12 +123,18 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 - Groups: Display, System, Disk, Filesystem, Apps, Editor
 - Syscalls: `sys_write()` only
 
-### **vix.elf** (vix.c, lines 1–80)
-- VIX text editor (ported from kernel `proc/vix.c`)
+### **vix.elf** (vix.c)
+- VIX text editor (ring-3 port of kernel `proc/vix.c`; renamed from VICS in May 2026 — see `docs/makar-medli.md`)
 - All kernel calls replaced with syscalls
-- Features: line editing, navigation, Ctrl+S save, Ctrl+Q quit
+- Features: line numbers, word wrap, flashing block caret, status bar, Ctrl+S save, Ctrl+Q quit
 - Supports: 256 lines × 80 chars, 64 KiB file max
 - Syscalls: `sys_putch_at()`, `sys_getkey()`, `sys_set_cursor()`, `sys_tty_clear()`, `sys_term_size()`, `sys_write_file()`, `sys_write()`, `sys_read()`
+
+### **kbtester.elf** (kbtester.c)
+- Visual press-all-keys keyboard diagnostic (ring-3)
+- Renders a QWERTY layout, lights up cells on key make, logs every scancode/keycode/sentinel + modifier vector to serial via `sys_write_serial()`
+- Exit: hold ESC for 4 s, or Ctrl+C (shell observes sigint and force-kills the child)
+- Used by the keyboard-rewrite verification work (PR #124, slice 5b)
 
 ## Userspace Syscall API (`src/userspace/syscall.h`)
 
@@ -137,14 +161,23 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 - `sys_write_file(path, buf, len)` → `SYS_WRITE_FILE (205)` - create/overwrite file
 - `sys_ls_dir(path, buf, bufsz)` → `SYS_LS_DIR (206)` - enumerate directory
 - `sys_disk_info(buf, bufsz)` → `SYS_DISK_INFO (207)` - list drives
+- `sys_delete_file(path)` → `SYS_DELETE_FILE (208)`
+- `sys_rename_file(old, new)` → `SYS_RENAME_FILE (209)` (also handles directory rename)
+- `sys_delete_dir(path)` → `SYS_DELETE_DIR (210)` (errors if non-empty)
+
+### Makar extensions (211–214)
+- `sys_write_serial(buf, len)` → `SYS_WRITE_SERIAL (211)` - COM1-only write; no framebuffer mirror. Used by `kbtester.elf`.
+- `sys_keyboard_raw(enable)` → `SYS_KEYBOARD_RAW (212)` - enable/disable raw keyboard mode (1 = raw bytes, no sentinel translation)
+- `sys_shell_clear()` → `SYS_SHELL_CLEAR (213)` - same as the shell's `clear` builtin
+- `sys_uptime()` → `SYS_UPTIME (214)` - returns the 100 Hz PIT tick counter
 
 ## VFS API (`src/kernel/include/kernel/vfs.h`)
 
 **Unified namespace:**
-- `/` - virtual root; lists mount-points
+- `/` - virtual root; `vfs_complete()` enumerates the mount points so `cd /<TAB>`, `cat /*`, and `ls /p*` all work
 - `/hd/…` - FAT32 hard disk (mounted via `mount` command)
 - `/cdrom/…` - ISO9660 CD-ROM (auto-detected at init)
-- `/proc/…` - synthetic, always-present read-only view of kernel state (`cpuinfo`, `meminfo`, `tasks`, `uname`)
+- `/proc/…` - synthetic, always-present read-only view of kernel state. Backed by `arch/i386/fs/procfs.c`; mount path is the `PROCFS_MOUNT` constant in `include/kernel/procfs.h`. Entries: `cpuinfo`, `meminfo`, `tasks`, `uname` (content generated on each read; no caching)
 
 ### Lifecycle
 - `vfs_init()` - probe IDE for ISO9660; reset CWD to `/`

--- a/SURVEY.md
+++ b/SURVEY.md
@@ -36,7 +36,7 @@
 - **ktest** - Run all in-kernel unit tests
 
 ### Application Commands (`shell_cmd_apps.c`, lines 26–192)
-- **vics** - Launch VICS interactive text editor on a file
+- **vix** - Launch VIX interactive text editor on a file
 - **install** - Run OS installer from CD-ROM to HDD
 - **exec** - Execute userspace ELF from `/cdrom/apps/` or `/hd/apps/` (line 79)
 - **eject** - Eject HDD or CD-ROM
@@ -105,8 +105,8 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 - Groups: Display, System, Disk, Filesystem, Apps, Editor
 - Syscalls: `sys_write()` only
 
-### **vics.elf** (vics.c, lines 1–80)
-- VICS text editor (ported from kernel `proc/vics.c`)
+### **vix.elf** (vix.c, lines 1–80)
+- VIX text editor (ported from kernel `proc/vix.c`)
 - All kernel calls replaced with syscalls
 - Features: line editing, navigation, Ctrl+S save, Ctrl+Q quit
 - Supports: 256 lines × 80 chars, 64 KiB file max
@@ -225,7 +225,7 @@ Builds bootable ISO. Steps:
 
 1. Create `isodir/` structure with subdirs: `boot/grub/i386-pc`, `apps`, `src`, `docs`
 2. Copy kernel: `sysroot/boot/makar.kernel` → `isodir/boot/makar.kernel`
-3. **Copy source tree**: `src/. → isodir/src/` (readable via VICS on ISO)
+3. **Copy source tree**: `src/. → isodir/src/` (readable via VIX on ISO)
 4. **Copy docs**: `docs/. → isodir/docs/`
 5. Write GRUB config: `isodir/boot/grub/grub.cfg`
    - Sets `timeout=5` (5-second user prompt on CD-ROM boot)
@@ -249,8 +249,8 @@ Builds bootable ISO. Steps:
 | Shell filesystem commands | 14 | ✅ Complete (mount, umount, ls, cat, cd, mkdir, mkfs, isols, write, touch, cp, rm, rmdir, mv) |
 | Shell disk commands | 5 | ✅ Complete (lsdisks, lspart, mkpart, readsector, chainload) |
 | Shell system commands | 8 | ✅ Complete (echo, meminfo, uptime, tasks, shutdown, reboot, panic, ktest) |
-| Shell app commands | 5 | ✅ Complete (vics, install, exec, eject, ring3test) |
-| Userspace ELF apps | 10 | ✅ Complete (hello, diskinfo, ls, echo, calc, help, vics, rm, mv, cp) |
+| Shell app commands | 5 | ✅ Complete (vix, install, exec, eject, ring3test) |
+| Userspace ELF apps | 10 | ✅ Complete (hello, diskinfo, ls, echo, calc, help, vix, rm, mv, cp) |
 | VFS operations | 13 | ✅ Complete (init, mount, ls, cd, cat, mkdir, read, write, exists, complete, delete_file, delete_dir, rename) |
 | FAT32 read/write APIs | 12 | ✅ Complete (mount, umount, ls, cd, mkdir, read, write, mkfs, delete_file, delete_dir, rename_file, rename_dir) |
 | Userspace syscalls | 14 | ✅ Complete I/O + 6 Makar extensions (write_file, ls_dir, disk_info, delete_file, rename_file, delete_dir) |

--- a/docs/kernel/keyboard.md
+++ b/docs/kernel/keyboard.md
@@ -279,7 +279,7 @@ Three classes of latent bug in the previous driver:
 | `src/kernel/arch/i386/drivers/keyboard.c` | Driver implementation (this document) |
 | `src/kernel/arch/i386/proc/vtty.c` | Calls `keyboard_set_focus` / `keyboard_send_to` for TTY switching |
 | `src/kernel/arch/i386/shell/shell.c` | Consumes `keyboard_getchar`; observes arrow / focus / Ctrl-C sentinels |
-| `src/kernel/arch/i386/proc/vics.c` | Editor; consumes arrow sentinels |
+| `src/kernel/arch/i386/proc/vix.c` | Editor; consumes arrow sentinels |
 | `src/kernel/arch/i386/shell/shell_cmd_apps.c` | Uses `keyboard_sigint_consume` to force-kill children during `exec` |
 
 ---

--- a/docs/kernel/shell.md
+++ b/docs/kernel/shell.md
@@ -92,7 +92,7 @@ for a matching ELF and runs it via `elf_exec`.
 | Command | Description |
 |---|---|
 | `exec <path>` | Load and run a userspace ELF (Ctrl+C kills it) |
-| `vics <path>` | Launch VICS text editor |
+| `vix <path>` | Launch VIX text editor |
 | `install` | Run OS installer from CD-ROM to HDD |
 | `eject` | Eject HDD or CD-ROM |
 | `ring3test` | Ring-3 test harness |

--- a/docs/kernel/shell.md
+++ b/docs/kernel/shell.md
@@ -18,8 +18,13 @@ splitting it into tokens, and dispatching to a command handler.
 
 Handles inline editing: cursor movement, insert-at-point, Backspace, Enter,
 Ctrl+C (aborts line, prints `^C`), history navigation (↑/↓ up to 16 entries),
-and Tab completion (first token: command names; subsequent tokens: VFS paths
-via `vfs_complete()`).
+and Tab completion. First token completes against the union of built-in
+command names and `*.elf` basenames found in `s_app_path`. Subsequent
+tokens complete VFS paths via `vfs_complete()` - cross-filesystem, so
+`cd /<TAB>` enumerates mount points (`hd`, `cdrom`, `proc`),
+`cat /proc/c<TAB>` matches `cpuinfo`, and `ls /hd/<TAB>` walks the FAT32
+root. Globbing (`*`, `?`) on argv is expanded via `shell_glob.c`
+before dispatch using the same `vfs_complete()` enumerator.
 
 ### Parsing
 
@@ -38,8 +43,19 @@ static const shell_cmd_entry_t * const cmd_modules[] = {
 };
 ```
 
-If no built-in matches, the shell searches `/cdrom/apps/` then `/hd/apps/`
-for a matching ELF and runs it via `elf_exec`.
+Each entry is `{ name, fn, fullscreen }`. The `fullscreen` bit marks
+handlers that paint directly to the framebuffer (vix, install, exec) -
+after such a handler returns, `shell_dispatch` calls
+`shell_restore_screen()` which repaints the focused VT's backing grid
+plus the status bar. That puts the shell's history back without
+waiting for the next keystroke and removes the need for each
+"fullscreen" command to clean up after itself.
+
+If no built-in matches, the shell tries `try_exec_path()` on the
+literal argv[0] (if it's a path-style `/abs` or `./rel`), then walks
+the PATH list (`/cdrom/apps/`, `/hd/apps/`) appending `[.elf]`.
+Successful ELF execution is also followed by `shell_restore_screen()` -
+any ring-3 binary is treated as potentially-fullscreen.
 
 ---
 
@@ -80,12 +96,13 @@ for a matching ELF and runs it via `elf_exec`.
 |---|---|
 | `echo [args…]` | Print arguments to terminal |
 | `meminfo` | Heap used/free in bytes |
-| `uptime` | Ticks since boot |
-| `tasks` | List kernel tasks and their states |
+| `uptime` | Humanised h/m/s + raw 100 Hz tick count |
+| `tasks` | List kernel tasks and their states (`cat /proc/tasks` is the richer variant) |
 | `shutdown` | ACPI S5 power-off |
 | `reboot` | ACPI reboot |
 | `panic [msg]` | Trigger kernel panic |
 | `ktest` | Run all in-kernel unit tests interactively |
+| `verbose [on\|off]` | Toggle the `t_putchar` → COM1 mirror at runtime. Equivalent to flipping `console=ttyS0` on the kernel cmdline. Used by `tests/ui_test.sh` to grep shell output from serial. |
 
 ### Application (`shell_cmd_apps.c`)
 

--- a/docs/makar-medli.md
+++ b/docs/makar-medli.md
@@ -1,199 +1,243 @@
-# Makar × Medli - Co-operation roadmap
+# Makar × Medli — Co-operation roadmap
 
-Makar and [Medli](https://github.com/Arawn-Davies/Medli) are two independent
-implementations of the same operating system, developed in parallel by the
-same author:
+Makar and [Medli](https://github.com/Arawn-Davies/Medli) are two
+independent implementations of the same operating-system concept,
+developed in parallel by the same author. They are **siblings**, not
+layers: Makar is not a bootloader or HAL for Medli; it is a ground-up
+re-implementation of the same OS idea in a lower-level language, sharing
+UX conventions, command vocabulary, and (eventually) binary formats.
 
-| | Makar | Medli |
+|  | Makar | Medli |
 |---|---|---|
-| **Language** | C / C++ | C# / X# |
-| **Runtime** | Bare metal (no managed heap) | Cosmos / IL2CPU |
-| **Target** | i686, native ELF | x86, Cosmos PE |
-| **Kernel type** | Monolithic C kernel | Managed OS kernel |
-| **Repo** | [Arawn-Davies/untitled-os](https://github.com/Arawn-Davies/untitled-os) | [Arawn-Davies/Medli](https://github.com/Arawn-Davies/Medli) |
+| **Language** | C (i686-elf-gcc, `-std=gnu11`). No C++ anywhere — no `extern "C"`, no managed runtime. | C# / X#, .NET via Cosmos / IL2CPU |
+| **Runtime** | Bare metal — manual PMM + paging + heap | Cosmos managed kernel + GC |
+| **Target** | i686, ELF32, multiboot 2 (GRUB) | x86, Cosmos PE |
+| **Repo** | [Arawn-Davies/Makar](https://github.com/Arawn-Davies/Makar) | [Arawn-Davies/Medli](https://github.com/Arawn-Davies/Medli) |
+| **Path separator** | `/` (Unix) | `\` (DOS-style, `Paths.Separator = @"\"`) |
+| **Current version** | 0.5.0 | (see Medli repo) |
 
-They are **siblings**, not layers.  Makar is not a bootloader or hardware
-abstraction for Medli - it is a ground-up re-implementation of the same
-operating system idea in a lower-level language, sharing UX conventions,
-filesystem layout, service design, and (eventually) binary formats.
+The path-separator divergence is **intentional** — Makar follows
+Linux/Unix conventions because that is what the C tooling, FAT32 LFN
+support, and POSIX-shaped syscalls expect. A shared filesystem layout
+is still possible (see "Filesystem layout" below); paths are translated
+at the shell layer, not stored differently on disk.
 
 ---
 
 ## Shared identity
 
-Both OSes present the same conceptual environment to a user sitting at a
+Both OSes present the same conceptual environment to a user at a
 terminal or serial console:
 
-- A **command shell** with a consistent command vocabulary.
-- A **daemon/service model** (Medli uses `Daemon` objects; Makar will follow
-  the same model in C).
-- A common **filesystem layout** (see below).
-- The **VICS text editor** (currently Medli-only; to be ported to Makar).
-- A **user account system** (login, root, guest - currently Medli-only).
-
-The goal is that a user familiar with one OS is immediately at home on the
-other.
+- A **command shell** with a consistent command vocabulary (`ls`, `cd`,
+  `cat`, `mkdir`, `mount`, `ps`-equivalent, etc.).
+- A **daemon/service model** (Medli has `Daemon` objects; Makar has
+  preemptive kernel tasks today, will gain a daemon abstraction once a
+  service-registration API lands).
+- A **vi-style editor** (see VIX history below).
+- A common **filesystem layout** target.
+- A **user account system** (Medli only today; Makar deferred until
+  signals + per-task FD table land).
 
 ---
 
-## Filesystem layout
+## VIX history (was VICS)
 
-Medli defines the canonical directory structure.  Makar will adopt the same
-layout once a writable filesystem driver is in place.
+Medli's text editor was named **VICS** — a contraction of "vi C-Sharp".
+When the editor was ported to Makar it kept that name despite being
+written in straight C, which made the acronym a lie. In May 2026 the
+Makar port was renamed **VIX** to remove the language-specific
+reference and leave the name free for a future round-trip back to
+Medli without either project's acronym becoming stale.
+
+| Property | VICS (Medli, original) | VIX (Makar, current) | VICS (Medli, future) |
+|---|---|---|---|
+| Language | C# | C | C# (will be rebased on VIX semantics) |
+| Editor model | Single-file modal vi | Single-file modal vi | Same |
+| Status row | Bottom of pane | Bottom of pane | Same |
+| Line numbers | No | Yes (4-digit gutter, `~` past EOF) | Planned |
+| Word wrap | No | Yes (visual, in-pane) | Planned |
+| Cursor | Static block | Flashing block (`vesa_tty_set_caret_style(2)`) | Planned |
+| Source | Medli/Editors/Vics.cs | `src/userspace/vix.c`, `src/kernel/arch/i386/proc/vix.c` | — |
+
+When Medli's VICS is rewritten against VIX's behaviour the editor
+becomes identical on both OSes; the rename is the visible part of that
+joint specification.
+
+---
+
+## Filesystem layout target
+
+Medli defines the canonical directory structure; Makar adopts it modulo
+the path separator. The on-disk FAT32 layout is identical — the shell
+just presents `/` to the user instead of `\`.
 
 ```
-0:\                     (volume root)
-├── Users\
-│   └── Guest\
-├── root\
-├── Apps\
-│   ├── Temp\
-│   └── x86\            ← native Makar binaries live here
-├── System\
-│   ├── Data\
-│   ├── Logs\
-│   ├── Libraries\
-│   └── Modules\
-└── Temp\
+/                     (volume root,    0:\ on Medli)
+├── Users/
+│   └── Guest/
+├── root/
+├── Apps/
+│   ├── Temp/
+│   └── x86/          ← native Makar ELF binaries live here
+├── System/
+│   ├── Data/
+│   ├── Logs/
+│   ├── Libraries/
+│   └── Modules/
+└── Temp/
 ```
 
-The path separator is `\` on both systems, matching the Medli convention.
-`Paths.Separator` in Medli is already defined as `@"\"`.
+Makar currently uses a flatter `apps/` directory at FAT32 root (see
+`isodir/apps/` and `/hd/apps/` PATH lookup); the layout above is the
+target once the userspace catalogue grows past a handful of ELFs.
 
 ---
 
 ## Binary compatibility goals
 
-The aim is for a user-space program to run on either OS without recompilation
-where technically feasible.
+The aim is for a userspace program to run on either OS without
+recompilation where technically feasible.
 
-### Native Makar binaries (`Apps\x86\`)
-
-Makar targets i686 and produces ELF32 executables.  A thin ELF loader (to be
-implemented in Makar's kernel) will map and execute these binaries.  Medli
-may gain an ELF compatibility shim through `Medli.Plugs` or a native
-execution daemon.
+### Native Makar binaries (`/Apps/x86/`)
+Makar produces ELF32 statically-linked binaries. The kernel's
+`elf_exec` (`src/kernel/arch/i386/proc/elf.c`) maps and runs them. A
+Medli ELF-compat shim is plausible via `Medli.Plugs` or a native-exec
+daemon.
 
 ### Medli Executable Format (MEF)
+Medli supports two formats today:
+- **COM** — flat binary, fixed-address, DOS-compatible.
+- **MEF** — native managed format, Cosmos-runtime-dependent.
 
-Medli already supports two executable formats:
+COM is the lowest common denominator: a Makar COM loader could run
+simple Medli COM programs (and vice versa). MEF stays Medli-only.
 
-- **COM** - flat binary, loaded at a fixed address, DOS-compatible.
-- **MEF** - Medli Executable Format, the native managed format.
-
-COM binaries are the lowest common denominator: a COM loader in Makar can
-run simple Medli COM programs, and vice versa.  MEF requires the Cosmos
-managed runtime, so it is Medli-only for now.
-
-### Recommended path
-
-1. Implement a COM loader in Makar (simple flat binary execution).
-2. Define a shared **MXF (Makar/Medli Executable Format)** - a lightweight
-   ELF-inspired format with a common header that both kernels can parse,
-   containing native i686 code.
-3. Long-term: Medli hosts a Makar-native execution daemon that forks into
-   a sandboxed environment to run MXF binaries using its own scheduler.
+### Proposed shared format: MXF
+A lightweight ELF-inspired header with a common magic, a single text
+section of native i686 code, and (optionally) relocation tables. Both
+kernels would parse the header; each would execute the payload in its
+own sandboxing model.
 
 ---
 
-## Planned Makar kernel milestones
+## Makar kernel milestones
 
-These are the kernel features needed before higher-level co-operation with
-Medli is practical.
+Tracking is in `CLAUDE.md` under "Slice queue". Mapped to Medli
+co-operation:
 
-### Near-term
+### Shipped (relevant to Medli interop)
 
-- [x] **Keyboard driver** - PS/2 keyboard via IRQ 1; translate scan codes to
-  ASCII.
-- [x] **Shell** - minimal interactive command loop over the VGA/VESA terminal,
-  matching Medli's command vocabulary.
-- [x] **ATA/IDE driver** - PIO-mode disk access (28-bit LBA, read/write,
-  `lsdisks` and `readsector` shell commands).
-- [x] **MBR partition support** - read and write MBR partition tables; `lspart`
-  and `mkpart mbr` shell commands; MDFS type `0xFA` recognised.
-- [x] **GPT partition support** - protective MBR detection, full GPT header and
-  entry parsing, `mkpart gpt` creation with CRC32-signed headers and
-  auto-generated unique partition GUIDs.
-- [x] **FAT32 driver** - read/write access to FAT32 volumes; `mount`, `umount`,
-  `ls`, `cat`, `cd`, `mkdir`, `mkfs` shell commands; adopts Medli's filesystem
-  layout (`Users\`, `Apps\`, `System\` etc.).
+- [x] **PS/2 keyboard** — IRQ 1, full set-1 + `e0` decoder, layered
+      scancode→keycode→sentinel→router pipeline, per-task SPSC rings
+      (PR #124).
+- [x] **Shell** — interactive REPL on each of 4 TTYs, inline editing,
+      history, tab completion across all mounted filesystems, Ctrl+C
+      sigint.
+- [x] **ATA/IDE PIO** — 28-bit LBA, 4-drive scan, ATAPI eject.
+- [x] **MBR + GPT** — read and write; `lspart`, `mkpart mbr`,
+      `mkpart gpt`.
+- [x] **FAT32 R/W** — mount, ls, cat, cd, mkdir, mkfs, file
+      delete/rename, directory delete (PR #120).
+- [x] **ISO 9660** — read-only auto-mount at `/cdrom` from ATAPI.
+- [x] **Process model** — preemptive round-robin scheduler at 100 Hz
+      with `SCHED_QUANTUM = 4` ticks (40 ms slice), per-task page
+      directory, dead-task PD reaper (PRs #123, #128).
+- [x] **ELF loader** — loads and executes ring-3 static binaries with
+      argc/argv.
+- [x] **VIX text editor** — ported from Medli VICS; renamed during the
+      port (see "VIX history" above).
+- [x] **Per-TTY screen buffers** — `vt_buf_t` backing grid per TTY, FB
+      paint only when focused, repaint deferred out of IRQ context.
+      Status bar at bottom row (this PR series).
+- [x] **Synthetic `/proc`** — `/proc/{cpuinfo,meminfo,tasks,uname}` as
+      read-only files generated on demand.
+- [x] **Serial console** — Linux-style: `console=ttyS0` cmdline opts
+      into TTY-mirroring; default keeps COM1 quiet (dmesg-only).
+
+### In flight
+
+- [ ] **Per-task FD table** — replace global keyboard owner +
+      placeholder `fd_table` with a real per-task array (Slice 14;
+      see CLAUDE.md). Prerequisite for pipe(2), dup(2), and any libc port.
+- [ ] **Linux-style signals** — `task->sig_pending` exists; need
+      sigaction table, `kill()` syscall, default disposition (Slice 8).
+- [ ] **VFS `task->cwd` authoritative** — drop the global `s_cwd` in
+      `vfs.c` (Slice 15).
 
 ### Medium-term
 
-- [ ] **Process model** - a simple round-robin scheduler, `fork`-like
-  primitive, and per-process address spaces using the existing paging
-  infrastructure.
-- [ ] **ELF loader** - load and execute ELF32 static binaries from the FAT32
-  filesystem, starting with `Apps\x86\`.
-- [ ] **COM loader** - flat binary loader for Medli COM programs.
-- [ ] **Serial shell** - run the same shell over the UART, enabling headless
-  operation and Medli-style serial daemon interop.
-- [ ] **VICS port** - port the VICS text editor from Medli C# to a Makar C
-  implementation, sharing the same key bindings and file format.
+- [ ] **COM loader** — for cross-OS COM binaries.
+- [ ] **MXF executable format** — joint specification with Medli.
+- [ ] **fork() / posix_spawn** — COW page-table clone (Slice 12).
+- [ ] **User accounts** — `root`, `guest` stored in
+      `/System/Data/usrinfo.sys`, format compatible with Medli's
+      `usrinfo.sys`.
+- [ ] **VGA-fallback per-TTY buffers** — route `tty.c` writes through
+      `vt_buf` so VGA text mode gets the same per-TTY isolation as
+      VESA (Slice 16).
 
 ### Long-term
 
-- [ ] **MXF executable format** - joint specification with Medli; shared
-  header, native i686 code section, relocatable.
-- [ ] **Network stack** - IP/TCP over a NE2000-compatible NIC (or virtio-net
-  in QEMU), enabling the same HTTP/FTP/SSH/Telnet daemon model as Medli.
-- [ ] **User accounts** - `root` and `guest` accounts stored in
-  `System\Data\usrinfo.sys`, matching the Medli account file format.
-- [ ] **Inter-OS file exchange** - agreed-upon config and data file formats
-  (plain text, INI-style) readable by both OSes from a shared FAT32 partition.
+- [ ] **Network stack** — RTL8139 → lwIP → DHCP/DNS → minimal HTTP
+      client. Enables the same daemon-over-TCP model as Medli.
+- [ ] **Inter-OS file exchange** — agreed-upon plain-text / INI config
+      and log formats readable by both OSes from a shared FAT32 image.
 
 ---
 
 ## Shared UX conventions
 
-Both Makar and Medli should implement these user-facing conventions
-identically:
-
-| Convention | Medli status | Makar status |
+| Convention | Medli | Makar |
 |---|---|---|
-| Path separator `\` | ✅ implemented | planned |
-| Root volume `0:\` | ✅ implemented | planned (FAT32 driver) |
-| Command: `ls` / `dir` | ✅ implemented | ✅ implemented |
-| Command: `cd` | ✅ implemented | ✅ implemented |
-| VICS text editor | ✅ implemented | planned (port) |
-| User login prompt | ✅ implemented | planned |
-| Serial console | ✅ implemented | ✅ implemented (read-only) |
-| Daemon/service model | ✅ implemented | planned |
-| Kernel version string | ✅ `KernelVersion` | ✅ `SHELL_VERSION` |
-| Shell prompt (`user@host cwd~>`) | ✅ implemented | ✅ implemented |
-| Welcome / ASCII logo | ✅ implemented | ✅ implemented |
+| Volume root | `0:\` | `/` |
+| Path separator | `\` | `/` |
+| `ls` / `dir` listing | ✅ | ✅ (`ls`) |
+| `cd` | ✅ | ✅ |
+| `cat` | ✅ | ✅ |
+| `mkdir` | ✅ | ✅ |
+| Editor | VICS (C#) | VIX (C; port + rename) |
+| User login prompt | ✅ | ⏭ pending account system |
+| Serial console | ✅ | ✅ (linux-style; quiet by default) |
+| Daemon/service model | ✅ | ⏭ kernel tasks today, no service API yet |
+| Shell prompt `user@host /cwd>` | ✅ | ✅ |
+| Welcome banner | ✅ | ✅ |
+| Version string | `KernelVersion` constant | `MAKAR_VERSION` macro in `include/kernel/version.h` |
 
 ---
 
 ## Divergences by design
 
-Some differences are intentional and reflect the different natures of the two
-kernels:
+Some differences are intentional and reflect the different language
+choices rather than any disagreement about UX.
 
 | Aspect | Makar | Medli |
 |---|---|---|
 | Memory management | Manual (PMM + paging + heap) | Cosmos GC |
 | Interrupt handling | Bare IDT + ISR stubs | Cosmos abstraction |
-| Graphics | VESA linear framebuffer (direct pixel) | Cosmos `VGAScreen` / bitmap |
-| Build system | Makefile + cross-GCC | .NET SDK + IL2CPU |
+| Graphics | VESA linear framebuffer (direct pixel writes) | Cosmos `VGAScreen` / bitmap |
+| Build system | Makefile + cross-GCC + Docker | .NET SDK + IL2CPU |
 | Debug tooling | GDB over QEMU stub | Cosmos debugger / serial |
+| Testing | ktest in-kernel + GDB checkpoint suite + headless UI test via QEMU HMP sendkey | (Medli equivalent TBD) |
+| Path separator | `/` | `\` |
 
-These divergences do not affect the user-visible behaviour - they are
-implementation details hidden beneath the shared shell and filesystem layer.
+These divergences do not affect user-visible behaviour. They are
+implementation details hidden beneath the shared shell, filesystem, and
+(eventually) executable-format layer.
 
 ---
 
 ## How to contribute
 
-If you are working on either OS and want to ensure compatibility:
-
-1. **Agree on file formats early** - config files, log formats, and
+1. **Agree on file formats early.** Config files, log formats, and
    executable headers should be designed jointly so neither OS needs to
    change its format later.
-2. **Test on QEMU** - both OSes run under `qemu-system-i386`; use `-hda` with
-   a shared FAT32 disk image to test filesystem interoperability.
-3. **Keep the shell vocabulary in sync** - add new shell commands to both
-   implementations, or document which commands are OS-specific.
-4. **Use the serial port as the integration test bus** - both OSes write to
-   COM1; an automated test harness can validate that both produce the same
-   output for the same commands.
+2. **Test on QEMU.** Both OSes run under `qemu-system-i386`; use `-hda`
+   with a shared FAT32 image to test interop.
+3. **Keep the shell vocabulary in sync.** Add new commands to both
+   implementations, or document which commands are OS-specific. Makar's
+   command list is in `SURVEY.md`.
+4. **Use serial as the integration bus.** Both OSes write to COM1; a
+   simple test harness can grep both serial logs for the same expected
+   output. Makar's UI-test framework (`tests/ui_test.sh`) demonstrates
+   the pattern.

--- a/docs/userland-libc.md
+++ b/docs/userland-libc.md
@@ -19,7 +19,7 @@ Makar's userspace design is informed by the work of several FOSS projects:
   Makar's `src/userspace/` layout.
 - **FUZIX** (GPLv2, https://github.com/EtchedPixels/FUZIX) - Alan Cox's
   Unix-like OS for small systems.  FUZIX's vi implementation and its approach
-  to portable libc stubs across wildly different hardware influenced VICS.
+  to portable libc stubs across wildly different hardware influenced VIX.
 - **musl libc** (MIT, https://musl.libc.org) - the preferred libc target for
   Makar once the fd table and fork() are in place.  Clean, auditable, and does
   not pull in glibc's dynamic-linker complexity.

--- a/iso.sh
+++ b/iso.sh
@@ -17,7 +17,7 @@ mkdir -p isodir/boot/grub/i386-pc isodir/apps isodir/src isodir/docs
 
 cp sysroot/boot/makar.kernel isodir/boot/makar.kernel
 
-# Copy source tree and docs onto the ISO so they're readable via VICS.
+# Copy source tree and docs onto the ISO so they're readable via VIX.
 cp -r src/. isodir/src/
 cp -r docs/. isodir/docs/
 

--- a/run.sh
+++ b/run.sh
@@ -60,7 +60,7 @@ export DOCKER_PLATFORM
 MODE="${1:-}"
 if [ -z "$MODE" ]; then
     echo "Usage: $0 <mode>"
-    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build"
+    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build  ui-test"
     echo "       hdd-boot  hdd-test  hdd-release    hdd-build"
     echo "       ktest-run gdb-iso-run gdb-hdd-run  clean"
     exit 1
@@ -272,6 +272,26 @@ _make_fat32_disk() {
          echo '  FAT32 test disk ready.'"
 }
 
+# Run the black-box UI tests via QEMU HMP monitor (sendkey + screendump,
+# assert on serial output).  Needs host qemu-system-i386 + nc; if either
+# is missing we skip rather than fail so the wider CI suite is portable.
+_run_ui_test() {
+    if ! command -v qemu-system-i386 >/dev/null 2>&1; then
+        echo "==> UI tests skipped (no host qemu-system-i386)"
+        return 0
+    fi
+    if ! command -v nc >/dev/null 2>&1; then
+        echo "==> UI tests skipped (no nc on PATH)"
+        return 0
+    fi
+    if [ ! -f "$REPO_ROOT/makar.iso" ]; then
+        echo "==> UI tests skipped (no makar.iso)"
+        return 0
+    fi
+    echo "==> Running UI tests (sendkey + serial grep)..."
+    ( cd "$REPO_ROOT" && bash tests/ui_test.sh )
+}
+
 # Run the GDB ISO boot-checkpoint test.
 # Boots from CD-ROM only - verifies boot sequence, background ktest, and
 # CD-ROM filesystem content.
@@ -467,14 +487,25 @@ iso-boot)
 
 # ── iso-test ──────────────────────────────────────────────────────────────────
 # One kernel build, two ISO variants packaged from the same staged isodir:
-#   makar.iso       - interactive menu (also exercised by gdb_boot_test)
+#   makar.iso       - interactive menu (also exercised by gdb_boot_test, ui-test)
 #   makar-test.iso  - single auto-boot entry with test_mode cmdline
 iso-test)
     _clean
     _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
     _run_ktest
     _run_gdb_iso_test
+    _run_ui_test
     echo "==> All ISO tests PASSED."
+    ;;
+
+# ── ui-test ───────────────────────────────────────────────────────────────────
+# Black-box UI tests driven through QEMU's HMP monitor (sendkey + serial grep).
+# Requires host QEMU + nc.  See tests/ui_test.sh for the scenarios.
+ui-test)
+    if [ ! -f "$REPO_ROOT/makar.iso" ]; then
+        _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
+    fi
+    _run_ui_test
     ;;
 
 # ── iso-ktest-gui ─────────────────────────────────────────────────────────────
@@ -561,7 +592,7 @@ clean)
 
 *)
     echo "ERROR: unknown mode '$MODE'" >&2
-    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build" >&2
+    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build  ui-test" >&2
     echo "       hdd-boot  hdd-test  hdd-release    hdd-build" >&2
     echo "       ktest-run gdb-iso-run gdb-hdd-run  clean" >&2
     exit 1

--- a/run.sh
+++ b/run.sh
@@ -248,6 +248,21 @@ _run_ktest() {
 }
 
 _check_ktest() {
+    # Echo the per-test transcript so CI logs surface every group / PASS /
+    # FAIL line instead of just the overall verdict.  The kernel emits
+    # serial lines like "--- Running group: X ---", "PASS: <assert>",
+    # "GROUP PASS: X", "ktest summary: N/N passed".
+    # ktest format (see arch/i386/proc/ktest.c):
+    #   "[ktest] suite: <name>"
+    #   "  PASS: <assertion>" / "  FAIL: <assertion>"
+    #   "[ktest] results: N passed, M failed"
+    #   "KTEST_RESULT: PASS" / "KTEST_RESULT: FAIL"
+    # Plus any kernel panic / KPANIC line if a test corrupted state.
+    echo "---- ktest transcript ----"
+    grep -E "^(\[ktest\]|  PASS:|  FAIL:|KTEST_RESULT|KPANIC|kpanic)" \
+        "$REPO_ROOT/ktest.log" || true
+    echo "---- end ktest transcript ----"
+
     if grep -q "KTEST_RESULT: PASS" "$REPO_ROOT/ktest.log"; then
         echo "==> ktest: ALL PASSED"
     elif grep -q "KTEST_RESULT: FAIL" "$REPO_ROOT/ktest.log"; then

--- a/src/kernel/arch/i386/display/tty.c
+++ b/src/kernel/arch/i386/display/tty.c
@@ -67,7 +67,8 @@ void t_putentryat(char c, uint8_t color, size_t x, size_t y)
 
 void t_putchar(char c)
 {
-	Serial_WriteChar(c);
+	if (g_serial_verbose)
+		Serial_WriteChar(c);
 	vesa_tty_putchar(c);
 
 	if (c != '\n')

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -198,7 +198,7 @@ bool vesa_tty_init(void)
 
 	/* Default pane reserves the bottom row for the tmux-style status bar
 	 * painted by vesa_tty_paint_status().  Any pane-aware renderer
-	 * (shell vt_buf, vics) therefore stays out of that row by default.
+	 * (shell vt_buf, vix) therefore stays out of that row by default.
 	 * Direct framebuffer writes (vesa_clear, paint_cell etc) are
 	 * unaffected - the status painter itself bypasses the pane. */
 	default_pane.top_row = 0;
@@ -325,7 +325,7 @@ void vesa_tty_pane_set_cursor(vesa_pane_t *p, uint32_t col, uint32_t row)
 	if (row < p->rows) p->cur_row = row;
 
 	/* Visible caret only on the screen-spanning default pane (the active
-	 * shell input).  Other panes (vics editor, future tmux splitters) own
+	 * shell input).  Other panes (vix editor, future tmux splitters) own
 	 * their own caret rendering if/when they need one. */
 	if (!tty_ready || p != &default_pane)
 		return;

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -196,9 +196,15 @@ bool vesa_tty_init(void)
 	tty_cols = fb->width  / FONT_CELL_W;
 	tty_rows = fb->height / FONT_CELL_H;
 
+	/* Default pane reserves the bottom row for the tmux-style status bar
+	 * painted by vesa_tty_paint_status().  Any pane-aware renderer
+	 * (shell vt_buf, vics) therefore stays out of that row by default.
+	 * Direct framebuffer writes (vesa_clear, paint_cell etc) are
+	 * unaffected - the status painter itself bypasses the pane. */
 	default_pane.top_row = 0;
 	default_pane.cols    = tty_cols;
-	default_pane.rows    = tty_rows;
+	default_pane.rows    = (tty_rows > VESA_TTY_STATUS_ROWS)
+	                     ? (tty_rows - VESA_TTY_STATUS_ROWS) : tty_rows;
 	default_pane.cur_col = 0;
 	default_pane.cur_row = 0;
 	default_pane.fg = compose_colour(0xFF, 0xFF, 0xFF); /* white */

--- a/src/kernel/arch/i386/drivers/serial.c
+++ b/src/kernel/arch/i386/drivers/serial.c
@@ -15,6 +15,11 @@
 
 int PORT;
 
+/* See kernel/serial.h.  Defaults on so init/driver banners print to
+ * COM1 during boot; kernel_main flips it off (unless test_mode) right
+ * before the shell launches. */
+int g_serial_verbose = 1;
+
 enum ComPorts
 {
 	COMPort1 = 0x3f8,

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -647,6 +647,18 @@ int vfs_complete(const char *dir, const char *prefix,
 
     const char *drv;
     switch (vfs_route(abs, &drv)) {
+    case VFS_FS_ROOT: {
+        /* Enumerate present mount points so cd /<TAB>, ls /, glob /* all
+         * see the virtual root.  Mirrors ls_root()'s rules: hd and cdrom
+         * only when their backing devices are live; /proc is synthetic
+         * and always present. */
+        if (cb) {
+            if (fat32_mounted())    cb("hd",    1, ctx);
+            if (s_cdrom_drive >= 0) cb("cdrom", 1, ctx);
+            cb("proc",  1, ctx);
+        }
+        return 0;
+    }
     case VFS_FS_HD:
         if (!fat32_mounted()) return -1;
         return fat32_complete(drv, prefix, cb, ctx);

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -38,7 +38,7 @@ $(ARCHDIR)/proc/elf.o \
 $(ARCHDIR)/proc/usertest.o \
 $(ARCHDIR)/proc/ktest.o \
 $(ARCHDIR)/proc/installer.o \
-$(ARCHDIR)/proc/vics.o \
+$(ARCHDIR)/proc/vix.o \
 $(ARCHDIR)/proc/vtty.o \
 $(ARCHDIR)/shell/shell.o \
 $(ARCHDIR)/shell/shell_glob.o \

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -44,13 +44,17 @@ const    int ktest_bg_total     = 11;   /* keep in sync with RUN() calls below *
 /* When set, suppress VGA output for pass lines and suite headers. */
 int ktest_muted = 0;
 
-void ktest_begin(const char *suite)
+void ktest_begin(const char *suite, const char *desc)
 {
     ktest_pass_count = 0;
     ktest_fail_count = 0;
     if (!ktest_muted) {
         t_writestring("\n[ktest] suite: ");
         t_writestring(suite);
+        if (desc && *desc) {
+            t_writestring(" -- ");
+            t_writestring(desc);
+        }
         t_putchar('\n');
     }
 }
@@ -96,7 +100,7 @@ void ktest_summary(void)
 
 static void test_acpi_checksum(void)
 {
-    ktest_begin("acpi_checksum");
+    ktest_begin("acpi_checksum", "ACPI table byte-sum checksum invariants");
 
     /* A buffer whose byte sum is 0 - valid. */
     uint8_t good[4] = {0x01, 0x02, 0x03, 0xFA}; /* 1+2+3+250 = 256 → 0 mod 256 */
@@ -126,7 +130,7 @@ static void test_acpi_checksum(void)
 
 static void test_string(void)
 {
-    ktest_begin("string");
+    ktest_begin("string", "freestanding libc string ops (strlen/strcmp/strncmp/memset/strcpy)");
 
     KTEST_ASSERT(strlen("hello") == 5);
     KTEST_ASSERT(strlen("") == 0);
@@ -158,7 +162,7 @@ static void test_string(void)
 
 static void test_partition(void)
 {
-    ktest_begin("partition");
+    ktest_begin("partition", "MBR + GPT partition-type name lookups");
 
     /* MBR type name lookup */
     KTEST_ASSERT(strcmp(part_type_name(PART_MBR_EMPTY),     "Empty")          == 0);
@@ -203,7 +207,7 @@ static void test_partition(void)
 
 static void test_pmm(void)
 {
-    ktest_begin("pmm");
+    ktest_begin("pmm", "physical-memory allocator: 4 KiB frame alloc/free + free-count accounting");
 
     /* Alloc must return a 4 KiB-aligned non-error address. */
     uint32_t f1 = pmm_alloc_frame();
@@ -242,7 +246,7 @@ static void test_pmm(void)
 
 static void test_heap(void)
 {
-    ktest_begin("heap");
+    ktest_begin("heap", "kernel heap: kmalloc/kfree, bytes-written sanity, exhaustion path");
 
     /* kmalloc(0) must return NULL. */
     KTEST_ASSERT(kmalloc(0) == NULL);
@@ -310,7 +314,7 @@ static void test_heap(void)
 
 static void test_vmm(void)
 {
-    ktest_begin("vmm");
+    ktest_begin("vmm", "per-task page directory: create, map, switch, lookup, teardown");
 
     uint32_t *kpd = paging_kernel_pd();
 
@@ -386,7 +390,7 @@ static void noop_task(void) { noop_ran = 1; task_exit(); }
 
 static void test_task(void)
 {
-    ktest_begin("task");
+    ktest_begin("task", "scheduler primitives: task pool, state transitions, yield semantics");
 
     /* Disable interrupts across both creates so the timer cannot preempt
      * noop1 before noop2 exists - otherwise noop1 runs, dies, and its slot
@@ -420,7 +424,7 @@ static void test_task(void)
 
 static void test_syscall(void)
 {
-    ktest_begin("syscall");
+    ktest_begin("syscall", "int 0x80 syscall dispatcher: arg passing, return value, unknown-syscall guard");
 
     registers_t regs;
     memset(&regs, 0, sizeof(regs));
@@ -488,7 +492,7 @@ static void test_gdt(void)
 {
     extern gdt_entry_t gdt_entries[6];
 
-    ktest_begin("gdt");
+    ktest_begin("gdt", "GDT layout: kernel/user code+data, TSS selector, ring 3 DPLs");
 
     /* User code segment (index 3): DPL field (bits [6:5] of access) must be 3. */
     KTEST_ASSERT(((gdt_entries[3].access >> 5) & 0x3u) == 3u);
@@ -528,7 +532,7 @@ static void test_gdt(void)
 
 static void test_ring3_prereqs(void)
 {
-    ktest_begin("ring3_prereqs");
+    ktest_begin("ring3_prereqs", "ring-3 transition prerequisites: TSS, user PD, kernel stack");
 
     /* VMM flag constants must match the x86 PTE bit positions the CPU checks. */
     KTEST_ASSERT(VMM_FLAG_USER     == 0x4u);
@@ -583,7 +587,7 @@ static void test_ring3_prereqs(void)
 static void test_idt(void)
 {
     extern idt_entry_t idt_entries[256];
-    ktest_begin("idt");
+    ktest_begin("idt", "IDT: gate types, DPLs, syscall gate present with DPL=3");
 
     /* Exception gates: present, DPL=0, 32-bit interrupt gate (0x8E). */
     KTEST_ASSERT(idt_entries[0].flags  == 0x8E);  /* #DE divide error    */
@@ -627,7 +631,7 @@ extern void ring3_usertest_task(void);
 
 static void test_ring3_execution(void)
 {
-    ktest_begin("ring3_execution");
+    ktest_begin("ring3_execution", "ring-3 lifecycle end-to-end: iret to user, syscall back, exit");
 
     /* Reset the checkpoint so stale values from a prior run don't give a
      * false positive. */
@@ -678,7 +682,7 @@ static void elf_exec_task_entry(void)
 
 static void test_elf_exec(void)
 {
-    ktest_begin("elf_exec");
+    ktest_begin("elf_exec", "ELF32 loader: header parse, segment mapping, entry-point dispatch");
 
     static const char *candidates[] = {
         "/cdrom/apps/echo.elf",
@@ -761,7 +765,7 @@ static void hello_arg_entry(void)
 
 static void test_ring3_with_arg(void)
 {
-    ktest_begin("ring3_with_arg");
+    ktest_begin("ring3_with_arg", "argc/argv plumbing into a ring-3 binary; ESP-relative arg layout");
 
     Serial_WriteString("\n");
     Serial_WriteString("[ktest] ============================================================\n");
@@ -874,7 +878,7 @@ static void res_countdown(const char *name)
 
 static void test_vesa_resolution(void)
 {
-    ktest_begin("vesa_resolution");
+    ktest_begin("vesa_resolution", "VESA mode switching across 320x240 / 640x480 / 720p / 1080p");
 
     /* Save current fb geometry so we can restore it afterwards. */
     const vesa_fb_t *orig = vesa_get_fb();
@@ -969,7 +973,7 @@ static const ktest_colour_t ktest_palette[] = {
 
 static void test_vesa_colour(void)
 {
-    ktest_begin("vesa_colour");
+    ktest_begin("vesa_colour", "VESA fg/bg colour state, glyph rendering, framebuffer pixel layout");
 
     KTEST_ASSERT(vesa_tty_is_ready());
 
@@ -1041,7 +1045,7 @@ static uint32_t kb_test_drain_all(unsigned char *out, uint32_t cap)
 
 static void test_keyboard(void)
 {
-    ktest_begin("keyboard");
+    ktest_begin("keyboard", "PS/2 layered driver: decoder state machine, modifier tracking, SPSC ring");
 
     keyboard_test_begin();
 

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -13,6 +13,7 @@
 #include <kernel/keyboard.h>
 #include <kernel/heap.h>
 #include <kernel/vesa_tty.h>
+#include <kernel/vtty.h>
 #include <string.h>
 
 #define VICS_MAX_LINES   256
@@ -340,5 +341,11 @@ void vics_edit(const char *path, vesa_pane_t *pane)
         vesa_tty_setcolor(VICS_SHELL_FG, VICS_SHELL_BG);
         if (v_pane) vesa_tty_pane_clear(v_pane);
         else        vesa_tty_clear();
+        /* Repaint the global status bar immediately - the pane clear
+         * above only covers the text area, but VICS may have written
+         * stale ink to the status row before this commit shrunk the
+         * default pane.  Doing it here means the user sees the bar
+         * the moment we return to the shell, not on the next Alt+Fn. */
+        vesa_tty_paint_status(vtty_active(), vtty_count());
     }
 }

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -21,21 +21,31 @@
 #define VICS_FILE_MAX    (64u * 1024u)
 #define VICS_STATUS_BUF  256
 
+/* Left gutter: 4-digit right-aligned line number + 1 space separator.
+ * VIM-style.  Reduces usable text width by this many columns. */
+#define VICS_GUTTER_W    5
+
 #define VICS_CLR_TEXT    0x07u
 #define VICS_CLR_STATUS  0x70u
+#define VICS_CLR_GUTTER  0x08u  /* dim grey on black */
 #define VICS_CLR_WARN    make_color(COLOR_LIGHT_RED, COLOR_BLACK)
 #define VICS_SHELL_VGA   0x1Fu
 #define VICS_SHELL_FG    0xFFFFFFu
 #define VICS_SHELL_BG    0x0000AAu
+#define VICS_GUTTER_FG   0x808080u
+#define VICS_GUTTER_BG   0x000000u
+#define VICS_TEXT_FG     0xFFFFFFu
+#define VICS_TEXT_BG     0x000000u
 
 #define CTRL_S  '\x13'
 #define CTRL_Q  '\x11'
 
 /* Runtime screen geometry - set at entry from the active pane. */
 static vesa_pane_t *v_pane;
-static int v_cols;
-static int v_text_rows;
-static int v_status_row;
+static int v_cols;        /* total pane width */
+static int v_text_cols;   /* v_cols - VICS_GUTTER_W: usable for content */
+static int v_text_rows;   /* visible rows for content (status row excluded) */
+static int v_status_row;  /* status bar's pane-relative row */
 
 /* Editor buffer */
 static char v_lines[VICS_MAX_LINES][VICS_LINE_CAP + 1];
@@ -63,17 +73,67 @@ static inline void vics_put(int col, int row, char c, uint8_t clr)
     }
 }
 
-static void vics_draw_line(int screen_row, int line_idx)
+static void vics_uitoa(unsigned int v, char *buf);
+
+/* How many visible rows a logical line occupies when wrap is on.  A
+ * zero-length line still claims one row (so empty lines render an empty
+ * gutter slot and remain navigable). */
+static int line_vrows(int li)
 {
-    const char *s   = (line_idx < v_nlines) ? v_lines[line_idx] : NULL;
+    if (li < 0 || li >= v_nlines) return 1;
+    int L = v_len[li];
+    if (L == 0) return 1;
+    int w = (v_text_cols > 0) ? v_text_cols : 1;
+    return (L + w - 1) / w;
+}
+
+/* Render the left-gutter slot for one visible row.  `seg` is the wrap
+ * segment index inside the logical line; only the first segment gets
+ * the line number, continuation segments get a faint indent marker. */
+static void vics_draw_gutter(int screen_row, int line_one_based, int seg)
+{
+    char gut[VICS_GUTTER_W + 1];
+    /* Default: blank gutter. */
+    for (int i = 0; i < VICS_GUTTER_W; i++) gut[i] = ' ';
+    gut[VICS_GUTTER_W] = '\0';
+
+    if (line_one_based > 0 && seg == 0) {
+        /* Right-align the decimal number into the first 4 slots. */
+        char tmp[12];
+        vics_uitoa((unsigned int)line_one_based, tmp);
+        int len = (int)strlen(tmp);
+        if (len > 4) len = 4;
+        int start = 4 - len;
+        for (int i = 0; i < len; i++) gut[start + i] = tmp[i];
+        gut[4] = ' ';
+    } else if (line_one_based > 0 && seg > 0) {
+        /* Continuation marker: a small '+' to show this row is the wrap
+         * continuation of the line above.  Bash less calls these "fold". */
+        gut[3] = '+';
+        gut[4] = ' ';
+    }
+
+    if (vesa_tty_is_ready())
+        vesa_tty_setcolor(VICS_GUTTER_FG, VICS_GUTTER_BG);
+    for (int c = 0; c < VICS_GUTTER_W; c++)
+        vics_put(c, screen_row, gut[c], VICS_CLR_GUTTER);
+}
+
+/* Render one visible row's worth of text content for a logical line,
+ * pulling chars [seg_start .. seg_start+v_text_cols) and padding with
+ * spaces past EOL. */
+static void vics_draw_text(int screen_row, int line_idx, int seg_start)
+{
+    const char *s   = (line_idx >= 0 && line_idx < v_nlines) ? v_lines[line_idx] : NULL;
     int         len = s ? v_len[line_idx] : 0;
 
     if (vesa_tty_is_ready())
-        vesa_tty_setcolor(0xFFFFFFu, 0x000000u);
+        vesa_tty_setcolor(VICS_TEXT_FG, VICS_TEXT_BG);
 
-    for (int col = 0; col < v_cols; col++) {
-        char ch = (col < len) ? s[col] : ' ';
-        vics_put(col, screen_row, ch, VICS_CLR_TEXT);
+    for (int c = 0; c < v_text_cols; c++) {
+        int idx = seg_start + c;
+        char ch = (s && idx < len) ? s[idx] : ' ';
+        vics_put(VICS_GUTTER_W + c, screen_row, ch, VICS_CLR_TEXT);
     }
 }
 
@@ -136,13 +196,54 @@ static void vics_draw_status(void)
         vics_put(col, v_status_row, bar[col], clr);
 }
 
+/* Compute the visible row offset of the cursor relative to v_view_top,
+ * accounting for wrap of every line in between. */
+static int vics_cursor_vrow(void)
+{
+    int vr = 0;
+    for (int i = v_view_top; i < v_cur_row && i < v_nlines; i++)
+        vr += line_vrows(i);
+    return vr + (v_cur_col / (v_text_cols > 0 ? v_text_cols : 1));
+}
+
 static void vics_redraw(void)
 {
-    for (int r = 0; r < v_text_rows; r++)
-        vics_draw_line(r, v_view_top + r);
+    int vrow = 0;
+    int li   = v_view_top;
+
+    while (vrow < v_text_rows && li < v_nlines) {
+        int segs = line_vrows(li);
+        for (int seg = 0; seg < segs && vrow < v_text_rows; seg++) {
+            vics_draw_gutter(vrow, li + 1, seg);
+            vics_draw_text(vrow, li, seg * v_text_cols);
+            vrow++;
+        }
+        li++;
+    }
+
+    /* Vim-style empty-buffer indicator on lines past EOF: blank gutter,
+     * '~' in the first text column. */
+    while (vrow < v_text_rows) {
+        vics_draw_gutter(vrow, 0, 0);
+        if (vesa_tty_is_ready())
+            vesa_tty_setcolor(VICS_GUTTER_FG, VICS_TEXT_BG);
+        vics_put(VICS_GUTTER_W, vrow, '~', VICS_CLR_GUTTER);
+        for (int c = VICS_GUTTER_W + 1; c < v_cols; c++)
+            vics_put(c, vrow, ' ', VICS_CLR_TEXT);
+        vrow++;
+    }
+
     vics_draw_status();
-    int abs_row = (v_pane ? (int)v_pane->top_row : 0) + (v_cur_row - v_view_top);
-    update_cursor((size_t)abs_row, (size_t)v_cur_col);
+
+    /* Position the cursor at the wrap-adjusted visible row + column. */
+    int cur_vrow  = vics_cursor_vrow();
+    int cur_inseg = v_cur_col % (v_text_cols > 0 ? v_text_cols : 1);
+    int abs_row   = (v_pane ? (int)v_pane->top_row : 0) + cur_vrow;
+    update_cursor((size_t)abs_row, (size_t)(VICS_GUTTER_W + cur_inseg));
+    if (vesa_tty_is_ready() && v_pane)
+        vesa_tty_pane_set_cursor(v_pane,
+                                 (uint32_t)(VICS_GUTTER_W + cur_inseg),
+                                 (uint32_t)cur_vrow);
 }
 
 static void vics_clamp_col(void)
@@ -151,12 +252,17 @@ static void vics_clamp_col(void)
     if (v_cur_col > max) v_cur_col = max;
 }
 
+/* Keep the cursor visible.  With wrap, the cursor's visible row is the
+ * sum of v_view_top..cur_row line heights plus the in-line segment, so
+ * scrolling has to advance v_view_top until that sum fits. */
 static void vics_scroll(void)
 {
-    if (v_cur_row < v_view_top)
+    if (v_cur_row < v_view_top) {
         v_view_top = v_cur_row;
-    else if (v_cur_row >= v_view_top + v_text_rows)
-        v_view_top = v_cur_row - v_text_rows + 1;
+        return;
+    }
+    while (vics_cursor_vrow() >= v_text_rows && v_view_top < v_cur_row)
+        v_view_top++;
 }
 
 static void vics_insert_char(char c)
@@ -276,7 +382,13 @@ void vics_edit(const char *path, vesa_pane_t *pane)
         v_text_rows  = 49;   /* 50-row VGA, leave last for status */
         v_status_row = 49;
     }
-    if (v_cols > VICS_LINE_CAP) v_cols = VICS_LINE_CAP;
+    /* Derive text-area width after subtracting the gutter.  Guard against
+     * absurdly narrow panes (1-2 cols) by falling back to no gutter. */
+    if (v_cols > VICS_GUTTER_W + 1)
+        v_text_cols = v_cols - VICS_GUTTER_W;
+    else
+        v_text_cols = v_cols;
+    if (v_text_cols > VICS_LINE_CAP) v_text_cols = VICS_LINE_CAP;
 
     if (path && *path) {
         strncpy(v_path, path, VFS_PATH_MAX - 1);

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -235,7 +235,13 @@ static void vics_redraw(void)
 
     vics_draw_status();
 
-    /* Position the cursor at the wrap-adjusted visible row + column. */
+    /* Position the cursor at the wrap-adjusted visible row + column.
+     * Restore a bright fg first: vics_draw_status leaves p->fg at the
+     * status-bar text colour (black on the grey bar), and caret_paint
+     * draws using p->fg - black-on-black would be invisible. */
+    if (vesa_tty_is_ready())
+        vesa_tty_setcolor(VICS_TEXT_FG, VICS_TEXT_BG);
+
     int cur_vrow  = vics_cursor_vrow();
     int cur_inseg = v_cur_col % (v_text_cols > 0 ? v_text_cols : 1);
     int abs_row   = (v_pane ? (int)v_pane->top_row : 0) + cur_vrow;
@@ -373,11 +379,14 @@ void vics_edit(const char *path, vesa_pane_t *pane)
 {
     v_pane = pane ? pane : (vesa_tty_is_ready() ? vesa_tty_default_pane() : NULL);
 
-    /* Vim-style block caret while editing.  The default underscore is a
-     * 2-px sliver that disappears against the dark text background. */
+    /* Flashing block caret while editing.  The default underscore is a
+     * 2-px sliver that disappears against the dark text background; a
+     * static block can also get lost across redraws after arrow-key
+     * movement.  Flash mode (driven by vesa_tty_caret_blink_tick from
+     * the keyboard wait loop) makes the cursor unmistakable. */
     uint32_t saved_caret = vesa_tty_is_ready() ? vesa_tty_get_caret_style() : 0;
     if (vesa_tty_is_ready())
-        vesa_tty_set_caret_style(1);
+        vesa_tty_set_caret_style(2);
 
     if (v_pane && vesa_tty_is_ready()) {
         v_cols       = (int)v_pane->cols;
@@ -457,14 +466,10 @@ void vics_edit(const char *path, vesa_pane_t *pane)
     terminal_set_colorscheme(VICS_SHELL_VGA);
     if (vesa_tty_is_ready()) {
         vesa_tty_setcolor(VICS_SHELL_FG, VICS_SHELL_BG);
-        if (v_pane) vesa_tty_pane_clear(v_pane);
-        else        vesa_tty_clear();
-        /* Repaint the global status bar immediately - the pane clear
-         * above only covers the text area, but VICS may have written
-         * stale ink to the status row before this commit shrunk the
-         * default pane.  Doing it here means the user sees the bar
-         * the moment we return to the shell, not on the next Alt+Fn. */
-        vesa_tty_paint_status(vtty_active(), vtty_count());
         vesa_tty_set_caret_style(saved_caret);
+        /* No pane_clear / paint_buf / paint_status here - shell_dispatch
+         * calls shell_restore_screen() after any fullscreen command
+         * returns, which repaints the focused VT's backing grid and the
+         * status bar in one place. */
     }
 }

--- a/src/kernel/arch/i386/proc/vics.c
+++ b/src/kernel/arch/i386/proc/vics.c
@@ -373,6 +373,12 @@ void vics_edit(const char *path, vesa_pane_t *pane)
 {
     v_pane = pane ? pane : (vesa_tty_is_ready() ? vesa_tty_default_pane() : NULL);
 
+    /* Vim-style block caret while editing.  The default underscore is a
+     * 2-px sliver that disappears against the dark text background. */
+    uint32_t saved_caret = vesa_tty_is_ready() ? vesa_tty_get_caret_style() : 0;
+    if (vesa_tty_is_ready())
+        vesa_tty_set_caret_style(1);
+
     if (v_pane && vesa_tty_is_ready()) {
         v_cols       = (int)v_pane->cols;
         v_text_rows  = (int)v_pane->rows - 1;
@@ -459,5 +465,6 @@ void vics_edit(const char *path, vesa_pane_t *pane)
          * default pane.  Doing it here means the user sees the bar
          * the moment we return to the shell, not on the next Alt+Fn. */
         vesa_tty_paint_status(vtty_active(), vtty_count());
+        vesa_tty_set_caret_style(saved_caret);
     }
 }

--- a/src/kernel/arch/i386/proc/vix.c
+++ b/src/kernel/arch/i386/proc/vix.c
@@ -1,12 +1,12 @@
 /*
- * vics.c - VICS interactive text editor for Makar.
+ * vix.c - VIX interactive text editor for Makar.
  *
  * Renders into a vesa_pane_t so it works correctly at any VESA resolution.
- * Pass pane=NULL to vics_edit() and it falls back to the default full-screen
+ * Pass pane=NULL to vix_edit() and it falls back to the default full-screen
  * pane (or VGA dimensions when VESA is unavailable).
  */
 
-#include <kernel/vics.h>
+#include <kernel/vix.h>
 #include <kernel/vfs.h>
 #include <kernel/vga.h>
 #include <kernel/tty.h>
@@ -16,26 +16,26 @@
 #include <kernel/vtty.h>
 #include <string.h>
 
-#define VICS_MAX_LINES   256
-#define VICS_LINE_CAP    80
-#define VICS_FILE_MAX    (64u * 1024u)
-#define VICS_STATUS_BUF  256
+#define VIX_MAX_LINES   256
+#define VIX_LINE_CAP    80
+#define VIX_FILE_MAX    (64u * 1024u)
+#define VIX_STATUS_BUF  256
 
 /* Left gutter: 4-digit right-aligned line number + 1 space separator.
  * VIM-style.  Reduces usable text width by this many columns. */
-#define VICS_GUTTER_W    5
+#define VIX_GUTTER_W    5
 
-#define VICS_CLR_TEXT    0x07u
-#define VICS_CLR_STATUS  0x70u
-#define VICS_CLR_GUTTER  0x08u  /* dim grey on black */
-#define VICS_CLR_WARN    make_color(COLOR_LIGHT_RED, COLOR_BLACK)
-#define VICS_SHELL_VGA   0x1Fu
-#define VICS_SHELL_FG    0xFFFFFFu
-#define VICS_SHELL_BG    0x0000AAu
-#define VICS_GUTTER_FG   0x808080u
-#define VICS_GUTTER_BG   0x000000u
-#define VICS_TEXT_FG     0xFFFFFFu
-#define VICS_TEXT_BG     0x000000u
+#define VIX_CLR_TEXT    0x07u
+#define VIX_CLR_STATUS  0x70u
+#define VIX_CLR_GUTTER  0x08u  /* dim grey on black */
+#define VIX_CLR_WARN    make_color(COLOR_LIGHT_RED, COLOR_BLACK)
+#define VIX_SHELL_VGA   0x1Fu
+#define VIX_SHELL_FG    0xFFFFFFu
+#define VIX_SHELL_BG    0x0000AAu
+#define VIX_GUTTER_FG   0x808080u
+#define VIX_GUTTER_BG   0x000000u
+#define VIX_TEXT_FG     0xFFFFFFu
+#define VIX_TEXT_BG     0x000000u
 
 #define CTRL_S  '\x13'
 #define CTRL_Q  '\x11'
@@ -43,13 +43,13 @@
 /* Runtime screen geometry - set at entry from the active pane. */
 static vesa_pane_t *v_pane;
 static int v_cols;        /* total pane width */
-static int v_text_cols;   /* v_cols - VICS_GUTTER_W: usable for content */
+static int v_text_cols;   /* v_cols - VIX_GUTTER_W: usable for content */
 static int v_text_rows;   /* visible rows for content (status row excluded) */
 static int v_status_row;  /* status bar's pane-relative row */
 
 /* Editor buffer */
-static char v_lines[VICS_MAX_LINES][VICS_LINE_CAP + 1];
-static int  v_len  [VICS_MAX_LINES];
+static char v_lines[VIX_MAX_LINES][VIX_LINE_CAP + 1];
+static int  v_len  [VIX_MAX_LINES];
 static int  v_nlines;
 static int  v_cur_row;
 static int  v_cur_col;
@@ -60,7 +60,7 @@ static int  v_save_msg;   /* 1 = "Saved", -1 = "Save failed", 0 = none */
 static char v_path[VFS_PATH_MAX];
 
 /* Write one character at pane-relative (col, row). */
-static inline void vics_put(int col, int row, char c, uint8_t clr)
+static inline void vix_put(int col, int row, char c, uint8_t clr)
 {
     int abs_row = (v_pane ? (int)v_pane->top_row : 0) + row;
     if (col < VGA_WIDTH && abs_row < 50)
@@ -73,7 +73,7 @@ static inline void vics_put(int col, int row, char c, uint8_t clr)
     }
 }
 
-static void vics_uitoa(unsigned int v, char *buf);
+static void vix_uitoa(unsigned int v, char *buf);
 
 /* How many visible rows a logical line occupies when wrap is on.  A
  * zero-length line still claims one row (so empty lines render an empty
@@ -90,17 +90,17 @@ static int line_vrows(int li)
 /* Render the left-gutter slot for one visible row.  `seg` is the wrap
  * segment index inside the logical line; only the first segment gets
  * the line number, continuation segments get a faint indent marker. */
-static void vics_draw_gutter(int screen_row, int line_one_based, int seg)
+static void vix_draw_gutter(int screen_row, int line_one_based, int seg)
 {
-    char gut[VICS_GUTTER_W + 1];
+    char gut[VIX_GUTTER_W + 1];
     /* Default: blank gutter. */
-    for (int i = 0; i < VICS_GUTTER_W; i++) gut[i] = ' ';
-    gut[VICS_GUTTER_W] = '\0';
+    for (int i = 0; i < VIX_GUTTER_W; i++) gut[i] = ' ';
+    gut[VIX_GUTTER_W] = '\0';
 
     if (line_one_based > 0 && seg == 0) {
         /* Right-align the decimal number into the first 4 slots. */
         char tmp[12];
-        vics_uitoa((unsigned int)line_one_based, tmp);
+        vix_uitoa((unsigned int)line_one_based, tmp);
         int len = (int)strlen(tmp);
         if (len > 4) len = 4;
         int start = 4 - len;
@@ -114,30 +114,30 @@ static void vics_draw_gutter(int screen_row, int line_one_based, int seg)
     }
 
     if (vesa_tty_is_ready())
-        vesa_tty_setcolor(VICS_GUTTER_FG, VICS_GUTTER_BG);
-    for (int c = 0; c < VICS_GUTTER_W; c++)
-        vics_put(c, screen_row, gut[c], VICS_CLR_GUTTER);
+        vesa_tty_setcolor(VIX_GUTTER_FG, VIX_GUTTER_BG);
+    for (int c = 0; c < VIX_GUTTER_W; c++)
+        vix_put(c, screen_row, gut[c], VIX_CLR_GUTTER);
 }
 
 /* Render one visible row's worth of text content for a logical line,
  * pulling chars [seg_start .. seg_start+v_text_cols) and padding with
  * spaces past EOL. */
-static void vics_draw_text(int screen_row, int line_idx, int seg_start)
+static void vix_draw_text(int screen_row, int line_idx, int seg_start)
 {
     const char *s   = (line_idx >= 0 && line_idx < v_nlines) ? v_lines[line_idx] : NULL;
     int         len = s ? v_len[line_idx] : 0;
 
     if (vesa_tty_is_ready())
-        vesa_tty_setcolor(VICS_TEXT_FG, VICS_TEXT_BG);
+        vesa_tty_setcolor(VIX_TEXT_FG, VIX_TEXT_BG);
 
     for (int c = 0; c < v_text_cols; c++) {
         int idx = seg_start + c;
         char ch = (s && idx < len) ? s[idx] : ' ';
-        vics_put(VICS_GUTTER_W + c, screen_row, ch, VICS_CLR_TEXT);
+        vix_put(VIX_GUTTER_W + c, screen_row, ch, VIX_CLR_TEXT);
     }
 }
 
-static void vics_uitoa(unsigned int v, char *buf)
+static void vix_uitoa(unsigned int v, char *buf)
 {
     if (v == 0) { buf[0] = '0'; buf[1] = '\0'; return; }
     char tmp[12]; int i = 0;
@@ -147,44 +147,44 @@ static void vics_uitoa(unsigned int v, char *buf)
     buf[j] = '\0';
 }
 
-static void vics_append(char *buf, int cap, int *off, const char *s)
+static void vix_append(char *buf, int cap, int *off, const char *s)
 {
     while (*s && *off < cap - 1) buf[(*off)++] = *s++;
     buf[*off] = '\0';
 }
 
-static void vics_draw_status(void)
+static void vix_draw_status(void)
 {
-    char bar[VICS_STATUS_BUF];
+    char bar[VIX_STATUS_BUF];
     int  off = 0;
-    int  cap = (v_cols < VICS_STATUS_BUF - 1) ? v_cols + 1 : VICS_STATUS_BUF;
+    int  cap = (v_cols < VIX_STATUS_BUF - 1) ? v_cols + 1 : VIX_STATUS_BUF;
 
     if (v_quit_warn) {
-        vics_append(bar, cap, &off, " Unsaved changes! ^Q to discard, ^S to save. ");
+        vix_append(bar, cap, &off, " Unsaved changes! ^Q to discard, ^S to save. ");
     } else if (v_save_msg == 1) {
-        vics_append(bar, cap, &off, " Saved. | ");
-        vics_append(bar, cap, &off, v_path[0] ? v_path : "[new]");
-        vics_append(bar, cap, &off, " | ^S:Save  ^Q:Quit");
+        vix_append(bar, cap, &off, " Saved. | ");
+        vix_append(bar, cap, &off, v_path[0] ? v_path : "[new]");
+        vix_append(bar, cap, &off, " | ^S:Save  ^Q:Quit");
     } else if (v_save_msg == -1) {
-        vics_append(bar, cap, &off, " Save failed! | ^S:Retry  ^Q:Quit");
+        vix_append(bar, cap, &off, " Save failed! | ^S:Retry  ^Q:Quit");
     } else {
-        vics_append(bar, cap, &off, " VICS | ");
-        vics_append(bar, cap, &off, v_path[0] ? v_path : "[new]");
-        if (v_dirty) vics_append(bar, cap, &off, " [+]");
-        vics_append(bar, cap, &off, " | Ln ");
+        vix_append(bar, cap, &off, " VIX | ");
+        vix_append(bar, cap, &off, v_path[0] ? v_path : "[new]");
+        if (v_dirty) vix_append(bar, cap, &off, " [+]");
+        vix_append(bar, cap, &off, " | Ln ");
         char tmp[12];
-        vics_uitoa((unsigned int)(v_cur_row + 1), tmp);
-        vics_append(bar, cap, &off, tmp);
-        vics_append(bar, cap, &off, "/");
-        vics_uitoa((unsigned int)v_nlines, tmp);
-        vics_append(bar, cap, &off, tmp);
-        vics_append(bar, cap, &off, " | ^S:Save  ^Q:Quit");
+        vix_uitoa((unsigned int)(v_cur_row + 1), tmp);
+        vix_append(bar, cap, &off, tmp);
+        vix_append(bar, cap, &off, "/");
+        vix_uitoa((unsigned int)v_nlines, tmp);
+        vix_append(bar, cap, &off, tmp);
+        vix_append(bar, cap, &off, " | ^S:Save  ^Q:Quit");
     }
 
     while (off < v_cols) bar[off++] = ' ';
     bar[off] = '\0';
 
-    uint8_t clr = (v_quit_warn || v_save_msg == -1) ? VICS_CLR_WARN : VICS_CLR_STATUS;
+    uint8_t clr = (v_quit_warn || v_save_msg == -1) ? VIX_CLR_WARN : VIX_CLR_STATUS;
 
     if (vesa_tty_is_ready()) {
         if (v_quit_warn || v_save_msg == -1) vesa_tty_setcolor(0xFF0000u, 0x000000u);
@@ -193,12 +193,12 @@ static void vics_draw_status(void)
     }
 
     for (int col = 0; col < v_cols; col++)
-        vics_put(col, v_status_row, bar[col], clr);
+        vix_put(col, v_status_row, bar[col], clr);
 }
 
 /* Compute the visible row offset of the cursor relative to v_view_top,
  * accounting for wrap of every line in between. */
-static int vics_cursor_vrow(void)
+static int vix_cursor_vrow(void)
 {
     int vr = 0;
     for (int i = v_view_top; i < v_cur_row && i < v_nlines; i++)
@@ -206,7 +206,7 @@ static int vics_cursor_vrow(void)
     return vr + (v_cur_col / (v_text_cols > 0 ? v_text_cols : 1));
 }
 
-static void vics_redraw(void)
+static void vix_redraw(void)
 {
     int vrow = 0;
     int li   = v_view_top;
@@ -214,8 +214,8 @@ static void vics_redraw(void)
     while (vrow < v_text_rows && li < v_nlines) {
         int segs = line_vrows(li);
         for (int seg = 0; seg < segs && vrow < v_text_rows; seg++) {
-            vics_draw_gutter(vrow, li + 1, seg);
-            vics_draw_text(vrow, li, seg * v_text_cols);
+            vix_draw_gutter(vrow, li + 1, seg);
+            vix_draw_text(vrow, li, seg * v_text_cols);
             vrow++;
         }
         li++;
@@ -224,35 +224,35 @@ static void vics_redraw(void)
     /* Vim-style empty-buffer indicator on lines past EOF: blank gutter,
      * '~' in the first text column. */
     while (vrow < v_text_rows) {
-        vics_draw_gutter(vrow, 0, 0);
+        vix_draw_gutter(vrow, 0, 0);
         if (vesa_tty_is_ready())
-            vesa_tty_setcolor(VICS_GUTTER_FG, VICS_TEXT_BG);
-        vics_put(VICS_GUTTER_W, vrow, '~', VICS_CLR_GUTTER);
-        for (int c = VICS_GUTTER_W + 1; c < v_cols; c++)
-            vics_put(c, vrow, ' ', VICS_CLR_TEXT);
+            vesa_tty_setcolor(VIX_GUTTER_FG, VIX_TEXT_BG);
+        vix_put(VIX_GUTTER_W, vrow, '~', VIX_CLR_GUTTER);
+        for (int c = VIX_GUTTER_W + 1; c < v_cols; c++)
+            vix_put(c, vrow, ' ', VIX_CLR_TEXT);
         vrow++;
     }
 
-    vics_draw_status();
+    vix_draw_status();
 
     /* Position the cursor at the wrap-adjusted visible row + column.
-     * Restore a bright fg first: vics_draw_status leaves p->fg at the
+     * Restore a bright fg first: vix_draw_status leaves p->fg at the
      * status-bar text colour (black on the grey bar), and caret_paint
      * draws using p->fg - black-on-black would be invisible. */
     if (vesa_tty_is_ready())
-        vesa_tty_setcolor(VICS_TEXT_FG, VICS_TEXT_BG);
+        vesa_tty_setcolor(VIX_TEXT_FG, VIX_TEXT_BG);
 
-    int cur_vrow  = vics_cursor_vrow();
+    int cur_vrow  = vix_cursor_vrow();
     int cur_inseg = v_cur_col % (v_text_cols > 0 ? v_text_cols : 1);
     int abs_row   = (v_pane ? (int)v_pane->top_row : 0) + cur_vrow;
-    update_cursor((size_t)abs_row, (size_t)(VICS_GUTTER_W + cur_inseg));
+    update_cursor((size_t)abs_row, (size_t)(VIX_GUTTER_W + cur_inseg));
     if (vesa_tty_is_ready() && v_pane)
         vesa_tty_pane_set_cursor(v_pane,
-                                 (uint32_t)(VICS_GUTTER_W + cur_inseg),
+                                 (uint32_t)(VIX_GUTTER_W + cur_inseg),
                                  (uint32_t)cur_vrow);
 }
 
-static void vics_clamp_col(void)
+static void vix_clamp_col(void)
 {
     int max = (v_cur_row < v_nlines) ? v_len[v_cur_row] : 0;
     if (v_cur_col > max) v_cur_col = max;
@@ -261,31 +261,31 @@ static void vics_clamp_col(void)
 /* Keep the cursor visible.  With wrap, the cursor's visible row is the
  * sum of v_view_top..cur_row line heights plus the in-line segment, so
  * scrolling has to advance v_view_top until that sum fits. */
-static void vics_scroll(void)
+static void vix_scroll(void)
 {
     if (v_cur_row < v_view_top) {
         v_view_top = v_cur_row;
         return;
     }
-    while (vics_cursor_vrow() >= v_text_rows && v_view_top < v_cur_row)
+    while (vix_cursor_vrow() >= v_text_rows && v_view_top < v_cur_row)
         v_view_top++;
 }
 
-static void vics_insert_char(char c)
+static void vix_insert_char(char c)
 {
-    if (v_cur_row >= VICS_MAX_LINES) return;
+    if (v_cur_row >= VIX_MAX_LINES) return;
     while (v_nlines <= v_cur_row) {
         v_lines[v_nlines][0] = '\0'; v_len[v_nlines] = 0; v_nlines++;
     }
     char *line = v_lines[v_cur_row];
     int   len  = v_len[v_cur_row];
-    if (len >= VICS_LINE_CAP) return;
+    if (len >= VIX_LINE_CAP) return;
     for (int i = len; i > v_cur_col; i--) line[i] = line[i - 1];
     line[v_cur_col] = c; line[len + 1] = '\0';
     v_len[v_cur_row] = len + 1; v_cur_col++; v_dirty = 1;
 }
 
-static void vics_backspace(void)
+static void vix_backspace(void)
 {
     if (v_cur_row == 0 && v_cur_col == 0) return;
     if (v_cur_col > 0) {
@@ -294,7 +294,7 @@ static void vics_backspace(void)
         line[len - 1] = '\0'; v_len[v_cur_row] = len - 1; v_cur_col--;
     } else {
         int prev = v_cur_row - 1, prev_len = v_len[prev], cur_len = v_len[v_cur_row];
-        if (prev_len + cur_len > VICS_LINE_CAP) return;
+        if (prev_len + cur_len > VIX_LINE_CAP) return;
         memcpy(v_lines[prev] + prev_len, v_lines[v_cur_row], (size_t)(cur_len + 1));
         v_len[prev] = prev_len + cur_len;
         for (int i = v_cur_row; i < v_nlines - 1; i++) {
@@ -306,9 +306,9 @@ static void vics_backspace(void)
     v_dirty = 1;
 }
 
-static void vics_newline(void)
+static void vix_newline(void)
 {
-    if (v_nlines >= VICS_MAX_LINES) return;
+    if (v_nlines >= VIX_MAX_LINES) return;
     while (v_nlines <= v_cur_row) {
         v_lines[v_nlines][0] = '\0'; v_len[v_nlines] = 0; v_nlines++;
     }
@@ -323,18 +323,18 @@ static void vics_newline(void)
     v_nlines++; v_cur_row++; v_cur_col = 0; v_dirty = 1;
 }
 
-static void vics_parse(const char *buf, uint32_t size)
+static void vix_parse(const char *buf, uint32_t size)
 {
     v_nlines = 0; v_cur_row = 0; v_cur_col = 0;
     v_view_top = 0; v_dirty = 0; v_quit_warn = 0;
     uint32_t pos = 0;
-    while (v_nlines < VICS_MAX_LINES) {
+    while (v_nlines < VIX_MAX_LINES) {
         int out = 0;
         while (pos < size && buf[pos] != '\n') {
             if (buf[pos] == '\t') {
                 int sp = 4 - (out % 4);
-                while (sp-- > 0 && out < VICS_LINE_CAP) v_lines[v_nlines][out++] = ' ';
-            } else if (out < VICS_LINE_CAP) {
+                while (sp-- > 0 && out < VIX_LINE_CAP) v_lines[v_nlines][out++] = ' ';
+            } else if (out < VIX_LINE_CAP) {
                 v_lines[v_nlines][out++] = buf[pos];
             }
             pos++;
@@ -346,7 +346,7 @@ static void vics_parse(const char *buf, uint32_t size)
     if (v_nlines == 0) { v_lines[0][0] = '\0'; v_len[0] = 0; v_nlines = 1; }
 }
 
-static char *vics_flatten(uint32_t *out_size)
+static char *vix_flatten(uint32_t *out_size)
 {
     uint32_t total = 0;
     for (int i = 0; i < v_nlines; i++) total += (uint32_t)v_len[i] + 1u;
@@ -363,11 +363,11 @@ static char *vics_flatten(uint32_t *out_size)
     return buf;
 }
 
-static int vics_save(void)
+static int vix_save(void)
 {
     if (!v_path[0]) return -1;
     uint32_t size = 0;
-    char *buf = vics_flatten(&size);
+    char *buf = vix_flatten(&size);
     if (!buf) return -1;
     int err = vfs_write_file(v_path, buf, size);
     kfree(buf);
@@ -375,7 +375,7 @@ static int vics_save(void)
     return err;
 }
 
-void vics_edit(const char *path, vesa_pane_t *pane)
+void vix_edit(const char *path, vesa_pane_t *pane)
 {
     v_pane = pane ? pane : (vesa_tty_is_ready() ? vesa_tty_default_pane() : NULL);
 
@@ -399,11 +399,11 @@ void vics_edit(const char *path, vesa_pane_t *pane)
     }
     /* Derive text-area width after subtracting the gutter.  Guard against
      * absurdly narrow panes (1-2 cols) by falling back to no gutter. */
-    if (v_cols > VICS_GUTTER_W + 1)
-        v_text_cols = v_cols - VICS_GUTTER_W;
+    if (v_cols > VIX_GUTTER_W + 1)
+        v_text_cols = v_cols - VIX_GUTTER_W;
     else
         v_text_cols = v_cols;
-    if (v_text_cols > VICS_LINE_CAP) v_text_cols = VICS_LINE_CAP;
+    if (v_text_cols > VIX_LINE_CAP) v_text_cols = VIX_LINE_CAP;
 
     if (path && *path) {
         strncpy(v_path, path, VFS_PATH_MAX - 1);
@@ -412,22 +412,22 @@ void vics_edit(const char *path, vesa_pane_t *pane)
         v_path[0] = '\0';
     }
 
-    uint8_t *file_buf = (uint8_t *)kmalloc(VICS_FILE_MAX);
+    uint8_t *file_buf = (uint8_t *)kmalloc(VIX_FILE_MAX);
     if (file_buf) {
         uint32_t got = 0;
         if (v_path[0] &&
-            vfs_read_file(v_path, file_buf, VICS_FILE_MAX, &got) == 0 && got > 0)
-            vics_parse((const char *)file_buf, got);
+            vfs_read_file(v_path, file_buf, VIX_FILE_MAX, &got) == 0 && got > 0)
+            vix_parse((const char *)file_buf, got);
         else
-            vics_parse("", 0);
+            vix_parse("", 0);
         kfree(file_buf);
     } else {
-        vics_parse("", 0);
+        vix_parse("", 0);
     }
 
     for (;;) {
-        vics_scroll();
-        vics_redraw();
+        vix_scroll();
+        vix_redraw();
         v_save_msg = 0;
 
         unsigned char c = keyboard_getchar();
@@ -439,13 +439,13 @@ void vics_edit(const char *path, vesa_pane_t *pane)
         v_quit_warn = 0;
 
         if (c == CTRL_S) {
-            if (v_path[0]) v_save_msg = (vics_save() == 0) ? 1 : -1;
+            if (v_path[0]) v_save_msg = (vix_save() == 0) ? 1 : -1;
             else           v_save_msg = -1;
             continue;
         }
 
-        if (c == KEY_ARROW_UP)    { if (v_cur_row > 0) { v_cur_row--; vics_clamp_col(); } continue; }
-        if (c == KEY_ARROW_DOWN)  { if (v_cur_row < v_nlines - 1) { v_cur_row++; vics_clamp_col(); } continue; }
+        if (c == KEY_ARROW_UP)    { if (v_cur_row > 0) { v_cur_row--; vix_clamp_col(); } continue; }
+        if (c == KEY_ARROW_DOWN)  { if (v_cur_row < v_nlines - 1) { v_cur_row++; vix_clamp_col(); } continue; }
         if (c == KEY_ARROW_LEFT)  {
             if (v_cur_col > 0) v_cur_col--;
             else if (v_cur_row > 0) { v_cur_row--; v_cur_col = v_len[v_cur_row]; }
@@ -457,15 +457,15 @@ void vics_edit(const char *path, vesa_pane_t *pane)
             continue;
         }
 
-        if (c == '\b')              { vics_backspace(); continue; }
-        if (c == '\n' || c == '\r') { vics_newline();   continue; }
-        if (c == '\t') { for (int s = 0; s < 4; s++) vics_insert_char(' '); continue; }
-        if (c >= ' ' && c <= '~')   { vics_insert_char(c); continue; }
+        if (c == '\b')              { vix_backspace(); continue; }
+        if (c == '\n' || c == '\r') { vix_newline();   continue; }
+        if (c == '\t') { for (int s = 0; s < 4; s++) vix_insert_char(' '); continue; }
+        if (c >= ' ' && c <= '~')   { vix_insert_char(c); continue; }
     }
 
-    terminal_set_colorscheme(VICS_SHELL_VGA);
+    terminal_set_colorscheme(VIX_SHELL_VGA);
     if (vesa_tty_is_ready()) {
-        vesa_tty_setcolor(VICS_SHELL_FG, VICS_SHELL_BG);
+        vesa_tty_setcolor(VIX_SHELL_FG, VIX_SHELL_BG);
         vesa_tty_set_caret_style(saved_caret);
         /* No pane_clear / paint_buf / paint_status here - shell_dispatch
          * calls shell_restore_screen() after any fullscreen command

--- a/src/kernel/arch/i386/proc/vix.c
+++ b/src/kernel/arch/i386/proc/vix.c
@@ -135,6 +135,13 @@ static void vix_draw_text(int screen_row, int line_idx, int seg_start)
         char ch = (s && idx < len) ? s[idx] : ' ';
         vix_put(VIX_GUTTER_W + c, screen_row, ch, VIX_CLR_TEXT);
     }
+
+    /* Right-margin "dead zone": columns past v_text_cols up to v_cols.
+     * On wide displays (1080p → 120 cols, with VIX_LINE_CAP=80 capping
+     * v_text_cols) this region is unused but must be painted with the
+     * editor background or the shell's prior pixels show through. */
+    for (int c = VIX_GUTTER_W + v_text_cols; c < v_cols; c++)
+        vix_put(c, screen_row, ' ', VIX_CLR_TEXT);
 }
 
 static void vix_uitoa(unsigned int v, char *buf)

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -22,6 +22,7 @@
 #include <kernel/vtty.h>
 #include <kernel/keyboard.h>
 #include <kernel/vesa_tty.h>
+#include <kernel/heap.h>
 
 static int      vtty_nslots  = 0;
 static int      vtty_current = 0;
@@ -64,6 +65,16 @@ void vtty_init(void)
     if (cols == 0 || rows == 0) {
         cols = 80;
         rows = 50;
+    }
+
+    /* Idempotent: free any pre-existing cell allocations so re-running
+     * vtty_init after a setmode (which changes tty geometry) resizes
+     * the buffers rather than leaking the old grids. */
+    for (int i = 0; i < VTTY_MAX; i++) {
+        if (vtty_bufs[i].cells) {
+            kfree(vtty_bufs[i].cells);
+            vtty_bufs[i].cells = NULL;
+        }
     }
 
     vtty_bufs_ready = true;

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -42,11 +42,9 @@ static volatile int vtty_pending = -1;
 #define VTTY_DEFAULT_FG  0xFFFFFFFFu
 #define VTTY_DEFAULT_BG  0x00000000u
 
-/* Bottom-row status bar reservation.  When VESA is active we steal the
- * last character row so the tmux-style indicator can live there without
- * being scrolled away by shell output.  In VGA-text fallback the bar
- * isn't drawn (yet); the full 80x50 grid stays available. */
-#define VTTY_STATUS_ROWS 1
+/* Bottom-row status bar reservation lives in <kernel/vesa_tty.h> as
+ * VESA_TTY_STATUS_ROWS - one source of truth shared with the framebuffer
+ * renderer and with VICS. */
 
 void vtty_init(void)
 {
@@ -58,8 +56,8 @@ void vtty_init(void)
     if (vesa_tty_is_ready()) {
         cols = vesa_tty_get_cols();
         rows = vesa_tty_get_rows();
-        if (rows > VTTY_STATUS_ROWS) {
-            rows -= VTTY_STATUS_ROWS;
+        if (rows > VESA_TTY_STATUS_ROWS) {
+            rows -= VESA_TTY_STATUS_ROWS;
             reserve_status = true;
         }
     }

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -44,7 +44,7 @@ static volatile int vtty_pending = -1;
 
 /* Bottom-row status bar reservation lives in <kernel/vesa_tty.h> as
  * VESA_TTY_STATUS_ROWS - one source of truth shared with the framebuffer
- * renderer and with VICS. */
+ * renderer and with VIX. */
 
 void vtty_init(void)
 {

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -562,12 +562,27 @@ static int try_exec_path(const char *path, int argc, char **argv)
     return 0;
 }
 
+/* Repaint the focused VT's backing grid to the framebuffer.  Called
+ * after any command that may have painted directly to the FB (vics, any
+ * ELF launched via exec) so the shell's accumulated output comes back
+ * immediately instead of staying blank until the next keystroke. */
+static void shell_restore_screen(void)
+{
+    if (!vesa_tty_is_ready())
+        return;
+    vt_buf_t *vt = vtty_buf_current();
+    if (vt) vesa_tty_paint_buf(vt);
+    vesa_tty_paint_status(vtty_active(), vtty_count());
+}
+
 static int shell_dispatch(int argc, char **argv)
 {
     for (int m = 0; cmd_modules[m]; m++) {
         for (int i = 0; cmd_modules[m][i].name; i++) {
             if (strcmp(cmd_modules[m][i].name, argv[0]) == 0) {
                 cmd_modules[m][i].fn(argc, argv);
+                if (cmd_modules[m][i].fullscreen)
+                    shell_restore_screen();
                 return 1;
             }
         }
@@ -577,8 +592,11 @@ static int shell_dispatch(int argc, char **argv)
      * Resolved by the VFS so `./foo` is interpreted relative to the CWD. */
     const char *cmd = argv[0];
     if (cmd[0] == '/' || (cmd[0] == '.' && cmd[1] == '/')) {
-        if (try_exec_path(cmd, argc, argv))
+        if (try_exec_path(cmd, argc, argv)) {
+            /* Any ELF could have painted to the FB; restore unconditionally. */
+            shell_restore_screen();
             return 1;
+        }
         /* Fall through to "Unknown command" - the user explicitly named a
          * path; PATH lookup wouldn't make sense as a fallback. */
         return 0;
@@ -594,8 +612,10 @@ static int shell_dispatch(int argc, char **argv)
         strncpy(path_buf, s_app_path[p], VFS_PATH_MAX - 1);
         strncpy(path_buf + dlen, argv[0], VFS_PATH_MAX - 1 - dlen);
         path_buf[dlen + nlen] = '\0';
-        if (try_exec_path(path_buf, argc, argv))
+        if (try_exec_path(path_buf, argc, argv)) {
+            shell_restore_screen();
             return 1;
+        }
     }
 
     return 0;

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -563,7 +563,7 @@ static int try_exec_path(const char *path, int argc, char **argv)
 }
 
 /* Repaint the focused VT's backing grid to the framebuffer.  Called
- * after any command that may have painted directly to the FB (vics, any
+ * after any command that may have painted directly to the FB (vix, any
  * ELF launched via exec) so the shell's accumulated output comes back
  * immediately instead of staying blank until the next keystroke. */
 static void shell_restore_screen(void)

--- a/src/kernel/arch/i386/shell/shell_cmd_apps.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_apps.c
@@ -189,10 +189,10 @@ static void cmd_eject(int argc, char **argv)
  * --------------------------------------------------------------------------- */
 
 const shell_cmd_entry_t apps_cmds[] = {
-    { "vics",      cmd_vics      },
-    { "install",   cmd_install   },
-    { "exec",      cmd_exec      },
-    { "eject",     cmd_eject     },
-    { "ring3test", cmd_ring3test },
-    { NULL, NULL }
+    { "vics",      cmd_vics,      1 },  /* paints FB directly */
+    { "install",   cmd_install,   1 },  /* installer TUI paints FB */
+    { "exec",      cmd_exec,      1 },  /* ELF child may paint FB */
+    { "eject",     cmd_eject,     0 },
+    { "ring3test", cmd_ring3test, 0 },
+    { NULL, NULL, 0 }
 };

--- a/src/kernel/arch/i386/shell/shell_cmd_apps.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_apps.c
@@ -1,14 +1,14 @@
 /*
  * shell_cmd_apps.c -- application launcher shell commands.
  *
- * Commands: vics  install  exec  eject  ring3test
+ * Commands: vix  install  exec  eject  ring3test
  */
 
 #include "shell_priv.h"
 
 #include <kernel/tty.h>
 #include <kernel/vfs.h>
-#include <kernel/vics.h>
+#include <kernel/vix.h>
 #include <kernel/installer.h>
 #include <kernel/elf.h>
 #include <kernel/task.h>
@@ -23,10 +23,10 @@ void cmd_ring3test(int argc, char **argv);
  * Command handlers
  * --------------------------------------------------------------------------- */
 
-static void cmd_vics(int argc, char **argv)
+static void cmd_vix(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: vics <filename>\n");
+        t_writestring("Usage: vix <filename>\n");
         t_writestring("  Opens <filename> for editing. Creates the file on save if it does not exist.\n");
         t_writestring("  Key bindings: Arrow keys navigate | Ctrl+S save | Ctrl+Q quit\n");
         return;
@@ -43,7 +43,7 @@ static void cmd_vics(int argc, char **argv)
         size_t cwd_len = strlen(cwd);
         size_t arg_len = strlen(arg);
         if (cwd_len + 1 + arg_len >= VFS_PATH_MAX) {
-            t_writestring("vics: path too long\n");
+            t_writestring("vix: path too long\n");
             return;
         }
         size_t off = 0;
@@ -53,7 +53,7 @@ static void cmd_vics(int argc, char **argv)
         memcpy(full_path + off, arg, arg_len + 1);
     }
 
-    vics_edit(full_path, NULL);
+    vix_edit(full_path, NULL);
 }
 
 static void cmd_install(int argc, char **argv)
@@ -189,7 +189,7 @@ static void cmd_eject(int argc, char **argv)
  * --------------------------------------------------------------------------- */
 
 const shell_cmd_entry_t apps_cmds[] = {
-    { "vics",      cmd_vics,      1 },  /* paints FB directly */
+    { "vix",      cmd_vix,      1 },  /* paints FB directly */
     { "install",   cmd_install,   1 },  /* installer TUI paints FB */
     { "exec",      cmd_exec,      1 },  /* ELF child may paint FB */
     { "eject",     cmd_eject,     0 },

--- a/src/kernel/arch/i386/shell/shell_cmd_display.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_display.c
@@ -9,6 +9,7 @@
 #include <kernel/tty.h>
 #include <kernel/vesa.h>
 #include <kernel/vesa_tty.h>
+#include <kernel/vtty.h>
 #include <kernel/bochs_vbe.h>
 
 /* ---------------------------------------------------------------------------
@@ -165,9 +166,25 @@ static const vesa_mode_t vesa_modes[] = {
 static void cmd_setmode(int argc, char **argv)
 {
     if (argc < 2) {
-        t_writestring("Usage: setmode <mode>\n");
-        t_writestring("  Text : 80x25  80x50\n");
-        t_writestring("  VESA : 320x240  640x480  480p  720p  1080p\n");
+        /* No arg: report the current mode. */
+        t_writestring("Mode: ");
+        if (vesa_tty_is_ready()) {
+            const vesa_fb_t *fb = vesa_get_fb();
+            if (fb) {
+                t_dec(fb->width);  t_writestring("x");
+                t_dec(fb->height); t_writestring("x");
+                t_dec(fb->bpp);    t_writestring(" (VESA, ");
+                t_dec(vesa_tty_get_cols()); t_writestring("x");
+                t_dec(vesa_tty_get_rows()); t_writestring(" cells)\n");
+            } else {
+                t_writestring("VESA (geometry unknown)\n");
+            }
+        } else {
+            t_writestring("VGA text 80x");
+            t_dec((uint32_t)t_get_rows());
+            t_writestring("\n");
+        }
+        t_writestring("Usage: setmode <80x25|80x50|320x240|640x480|480p|720p|1080p>\n");
         return;
     }
 
@@ -216,6 +233,12 @@ static void cmd_setmode(int argc, char **argv)
         bochs_vbe_set_mode(w, h, 32);
         vesa_update_geometry(w, h, 32);
         vesa_tty_init();
+        /* Resize per-TTY backing grids to match the new tty geometry.
+         * Without this the buffers stay at the boot-time size; after a
+         * shell launches a fullscreen command, paint_buf only repaints
+         * the original-sized region and leaves stale pixels visible
+         * outside it. */
+        vtty_init();
         vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
         vesa_tty_clear();
 

--- a/src/kernel/arch/i386/shell/shell_cmd_man.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_man.c
@@ -52,7 +52,7 @@ static const man_entry_t man_table[] = {
       "Usage: setmode <WxH>\n\n"
       "Valid resolutions: 320x240  640x480  1280x720  1920x1080\n\n"
       "Switches the Bochs VBE framebuffer to the requested resolution and\n"
-      "re-initialises the VESA TTY.  VICS uses the new geometry automatically.\n"
+      "re-initialises the VESA TTY.  VIX uses the new geometry automatically.\n"
     },
     { "fgcol",
       "set foreground colour (hex RRGGBB)",
@@ -153,10 +153,10 @@ static const man_entry_t man_table[] = {
       "create a directory",
       "Usage: mkdir <path>\n\nCreates a directory on the FAT32 volume.\n"
     },
-    { "vics",
-      "open a file in the VICS editor",
-      "Usage: vics <file>\n\n"
-      "Opens the file in VICS (Visual Interactive Character Shell), a lightweight\n"
+    { "vix",
+      "open a file in the VIX editor",
+      "Usage: vix <file>\n\n"
+      "Opens the file in VIX (Visual Interactive Character Shell), a lightweight\n"
       "full-screen editor modelled on ELKS/FUZIX vi.  Adapts to the current VESA\n"
       "resolution automatically via the pane abstraction.\n\n"
       "Key bindings:\n"

--- a/src/kernel/arch/i386/shell/shell_cmd_system.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_system.c
@@ -13,6 +13,7 @@
 #include <kernel/acpi.h>
 #include <kernel/debug.h>
 #include <kernel/ktest.h>
+#include <kernel/serial.h>
 
 static void cmd_echo(int argc, char **argv)
 {
@@ -109,6 +110,22 @@ static void cmd_ktest(int argc, char **argv)
     ktest_run_all();
 }
 
+/* `verbose [on|off]` - toggle the tty-to-serial mirror.  Linux-equivalent
+ * to flipping `console=ttyS0` on the kernel cmdline at runtime.  Without
+ * an argument, just reports the current state.  Used both interactively
+ * (debugging a remote system over COM1) and by ui_test scenarios that
+ * need to grep shell output from the serial log. */
+static void cmd_verbose(int argc, char **argv)
+{
+    if (argc >= 2) {
+        if (strcmp(argv[1], "on") == 0)       g_serial_verbose = 1;
+        else if (strcmp(argv[1], "off") == 0) g_serial_verbose = 0;
+        else { t_writestring("Usage: verbose [on|off]\n"); return; }
+    }
+    t_writestring("serial verbose: ");
+    t_writestring(g_serial_verbose ? "on\n" : "off\n");
+}
+
 /* ---------------------------------------------------------------------------
  * Module table
  * --------------------------------------------------------------------------- */
@@ -122,5 +139,6 @@ const shell_cmd_entry_t system_cmds[] = {
     { "reboot",   cmd_reboot   },
     { "panic",    cmd_panic    },
     { "ktest",    cmd_ktest    },
+    { "verbose",  cmd_verbose  },
     { NULL, NULL }
 };

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -43,10 +43,16 @@
 /*
  * Command entry: all handlers share the same (int argc, char **argv) signature
  * for uniform dispatch.  A NULL name field terminates each module's table.
+ *
+ * fullscreen: set on handlers that paint over the framebuffer directly
+ * (VICS, future curses-style apps).  shell_dispatch repaints the focused
+ * VT's backing grid after such commands return so the shell's history
+ * comes back without waiting for the next keystroke.
  */
 typedef struct {
     const char *name;
     void (*fn)(int argc, char **argv);
+    unsigned char fullscreen;
 } shell_cmd_entry_t;
 
 /* Command module tables (NULL-name terminated). */

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -45,7 +45,7 @@
  * for uniform dispatch.  A NULL name field terminates each module's table.
  *
  * fullscreen: set on handlers that paint over the framebuffer directly
- * (VICS, future curses-style apps).  shell_dispatch repaints the focused
+ * (VIX, future curses-style apps).  shell_dispatch repaints the focused
  * VT's backing grid after such commands return so the shell's history
  * comes back without waiting for the next keystroke.
  */

--- a/src/kernel/include/kernel/ktest.h
+++ b/src/kernel/include/kernel/ktest.h
@@ -9,7 +9,7 @@
  * Minimal in-kernel unit-test harness.
  *
  * Usage:
- *   ktest_begin("suite name");
+ *   ktest_begin("suite name", "human-readable description of what this covers");
  *   KTEST_ASSERT(expr);          // fails if expr is false
  *   KTEST_ASSERT_EQ(a, b);       // fails if a != b
  *   ktest_summary();             // prints pass/fail counts
@@ -22,7 +22,7 @@
 extern int ktest_pass_count;
 extern int ktest_fail_count;
 
-void ktest_begin(const char *suite);
+void ktest_begin(const char *suite, const char *desc);
 void ktest_summary(void);
 void ktest_assert(int cond, const char *expr, const char *file, uint32_t line);
 

--- a/src/kernel/include/kernel/serial.h
+++ b/src/kernel/include/kernel/serial.h
@@ -17,6 +17,17 @@ void Serial_WriteDec(uint32_t n);
 void Serial_WriteHex(uint32_t n);
 
 /*
+ * g_serial_verbose - when nonzero, t_putchar mirrors every user-tty
+ * character to COM1.  Defaults to 1 so boot diagnostics are visible on
+ * serial.  kernel_main flips it to 0 just before launching the shell
+ * (Linux-style: dmesg shows boot+drivers+errors, not tty output) unless
+ * test_mode is set on the cmdline, in which case it stays 1 so CI can
+ * grep the mirror.  Explicit Serial_*, KLOG, kpanic etc. bypass this
+ * flag - they are kernel diagnostics, not tty output.
+ */
+extern int g_serial_verbose;
+
+/*
  * Lightweight serial-logging macros for development/debug builds.
  *
  * Include this header and compile with -DDEV_BUILD to enable verbose serial

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -6,6 +6,11 @@
 
 struct vt_buf;
 
+/* Rows reserved at the bottom of the framebuffer for the tmux-style status
+ * bar painted by vesa_tty_paint_status().  Default pane (and any pane-aware
+ * renderer like VICS) sizes itself to leave these rows untouched. */
+#define VESA_TTY_STATUS_ROWS 1
+
 /*
  * vesa_tty - text renderer over the VESA framebuffer.
  *

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -8,7 +8,7 @@ struct vt_buf;
 
 /* Rows reserved at the bottom of the framebuffer for the tmux-style status
  * bar painted by vesa_tty_paint_status().  Default pane (and any pane-aware
- * renderer like VICS) sizes itself to leave these rows untouched. */
+ * renderer like VIX) sizes itself to leave these rows untouched. */
 #define VESA_TTY_STATUS_ROWS 1
 
 /*
@@ -20,7 +20,7 @@ struct vt_buf;
  * (vesa_tty_putchar etc.) delegates to a screen-spanning default pane so
  * existing callers are unaffected.
  *
- * Future phases will allow the shell, VICS, and a tmux-style splitter to
+ * Future phases will allow the shell, VIX, and a tmux-style splitter to
  * each hold their own pane.  Side-by-side (column-split) panes are out of
  * scope; only horizontal stacking (top/bottom) is supported.
  */

--- a/src/kernel/include/kernel/vix.h
+++ b/src/kernel/include/kernel/vix.h
@@ -1,10 +1,10 @@
-#ifndef _KERNEL_VICS_H
-#define _KERNEL_VICS_H
+#ifndef _KERNEL_VIX_H
+#define _KERNEL_VIX_H
 
 #include <kernel/vesa_tty.h>
 
 /*
- * vics.h - VICS interactive text editor for Makar.
+ * vix.h - VIX interactive text editor for Makar.
  *
  * Key bindings:
  *   Arrow keys  - navigate
@@ -17,6 +17,6 @@
  *
  * Pass pane=NULL to use the default full-screen pane.
  */
-void vics_edit(const char *path, vesa_pane_t *pane);
+void vix_edit(const char *path, vesa_pane_t *pane);
 
-#endif /* _KERNEL_VICS_H */
+#endif /* _KERNEL_VIX_H */

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -132,6 +132,10 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 
 	/* Parse Multiboot 2 tags: boot device and kernel command line. */
 	int test_mode = 0;
+	int console_serial = 0;     /* "console=ttyS0" - keep g_serial_verbose
+	                             * on after boot so the shell mirrors to
+	                             * COM1.  Linux-style: dmesg + tty over
+	                             * serial.  Used by ui_test scenarios. */
 	{
 		uint32_t biosdev = 0xFFu;
 
@@ -153,6 +157,8 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 						(multiboot2_tag_cmdline_t *)tag;
 					if (strstr(cmd->string, "test_mode"))
 						test_mode = 1;
+					if (strstr(cmd->string, "console=ttyS0"))
+						console_serial = 1;
 				}
 				tag_ptr += (tag->size + 7u) & ~7u;
 			}
@@ -171,6 +177,19 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 	tasking_init();
 	vtty_init();
 	if (!test_mode) {
+		/* Switch to Linux-style serial behaviour: from here on COM1
+		 * only carries explicit kernel diagnostics (KLOG, panic,
+		 * driver banners that use Serial_*).  Shell/user TTY output
+		 * goes to the framebuffer only, mirroring dmesg semantics.
+		 * `console=ttyS0` on the kernel cmdline opts back in so the
+		 * shell mirrors to COM1 - used by ui_test scenarios.
+		 *
+		 * Emit a final boot marker before the flip so external
+		 * tooling (CI, debugging shells) can detect "boot complete"
+		 * regardless of the mirror policy. */
+		Serial_WriteString("kernel: boot complete\n");
+		if (!console_serial)
+			g_serial_verbose = 0;
 		task_create("shell0", shell_run);
 		task_create("shell1", shell_run);
 		task_create("shell2", shell_run);

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -14,7 +14,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf echo.elf help.elf calc.elf vics.elf ls.elf diskinfo.elf rm.elf mv.elf cp.elf kbtester.elf
+PROGS=hello.elf echo.elf help.elf calc.elf vix.elf ls.elf diskinfo.elf rm.elf mv.elf cp.elf kbtester.elf
 
 
 all: $(PROGS)
@@ -31,7 +31,7 @@ help.elf: crt0.o help.o
 calc.elf: crt0.o calc.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
-vics.elf: crt0.o vics.o
+vix.elf: crt0.o vix.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 ls.elf: crt0.o ls.o

--- a/src/userspace/help.c
+++ b/src/userspace/help.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
     PUTS("\n");
     PUTS("Apps:\n");
     PUTS("  exec <path> [args..]         run an ELF32 executable\n");
-    PUTS("  vics <file>                  interactive text editor\n");
+    PUTS("  vix <file>                  interactive text editor\n");
     PUTS("  eject hdd|cdrom              unmount and eject\n");
     PUTS("\n");
     PUTS("Userland apps (exec /apps/<name>):\n");

--- a/src/userspace/vix.c
+++ b/src/userspace/vix.c
@@ -1,7 +1,7 @@
 /*
- * vics.c - VICS interactive text editor (userland port).
+ * vix.c - VIX interactive text editor (userland port).
  *
- * Ported from src/kernel/arch/i386/proc/vics.c.
+ * Ported from src/kernel/arch/i386/proc/vix.c.
  * All kernel calls replaced with int 0x80 syscalls.
  */
 
@@ -10,21 +10,21 @@
 #define VFS_PATH_MAX   128
 #define VGA_WIDTH       80
 
-#define VICS_TEXT_ROWS  24
-#define VICS_STATUS_ROW 24
-#define VICS_MAX_LINES  256
-#define VICS_LINE_CAP    80
-#define VICS_FILE_MAX   (64u * 1024u)
+#define VIX_TEXT_ROWS  24
+#define VIX_STATUS_ROW 24
+#define VIX_MAX_LINES  256
+#define VIX_LINE_CAP    80
+#define VIX_FILE_MAX   (64u * 1024u)
 
 /* VGA colour attributes */
-#define VICS_CLR_TEXT    VGA_CLR(VGA_LGREY,    VGA_BLACK)
-#define VICS_CLR_STATUS  VGA_CLR(VGA_BLACK,    VGA_LGREY)
-#define VICS_CLR_WARN    VGA_CLR(VGA_LRED,     VGA_BLACK)
-#define VICS_SHELL_CLR   VGA_CLR(VGA_WHITE,    VGA_BLUE)
+#define VIX_CLR_TEXT    VGA_CLR(VGA_LGREY,    VGA_BLACK)
+#define VIX_CLR_STATUS  VGA_CLR(VGA_BLACK,    VGA_LGREY)
+#define VIX_CLR_WARN    VGA_CLR(VGA_LRED,     VGA_BLACK)
+#define VIX_SHELL_CLR   VGA_CLR(VGA_WHITE,    VGA_BLUE)
 
 /* Editor state */
-static char v_lines[VICS_MAX_LINES][VICS_LINE_CAP + 1];
-static int  v_len  [VICS_MAX_LINES];
+static char v_lines[VIX_MAX_LINES][VIX_LINE_CAP + 1];
+static int  v_len  [VIX_MAX_LINES];
 static int  v_nlines;
 static int  v_cur_row;
 static int  v_cur_col;
@@ -34,10 +34,10 @@ static int  v_quit_warn;
 static char v_path[VFS_PATH_MAX];
 
 /* Cell batch buffer - flushed once per redraw. */
-static tty_cell_t g_cells[VGA_WIDTH * (VICS_TEXT_ROWS + 1)];
+static tty_cell_t g_cells[VGA_WIDTH * (VIX_TEXT_ROWS + 1)];
 static int        g_ncells;
 
-static inline void vics_put(int col, int row, char c, unsigned char clr)
+static inline void vix_put(int col, int row, char c, unsigned char clr)
 {
     if (g_ncells < (int)(sizeof(g_cells) / sizeof(g_cells[0]))) {
         g_cells[g_ncells].col = (unsigned char)col;
@@ -48,7 +48,7 @@ static inline void vics_put(int col, int row, char c, unsigned char clr)
     }
 }
 
-static void vics_flush(void)
+static void vix_flush(void)
 {
     if (g_ncells > 0) {
         sys_putch_at(g_cells, (unsigned int)g_ncells);
@@ -57,7 +57,7 @@ static void vics_flush(void)
 }
 
 /* Simple unsigned-integer → decimal string (buf must be ≥ 12 bytes). */
-static void vics_uitoa(unsigned int v, char *buf)
+static void vix_uitoa(unsigned int v, char *buf)
 {
     if (v == 0) { buf[0] = '0'; buf[1] = '\0'; return; }
     char tmp[12]; int i = 0;
@@ -67,92 +67,92 @@ static void vics_uitoa(unsigned int v, char *buf)
     buf[j] = '\0';
 }
 
-static unsigned int vics_strlen(const char *s)
+static unsigned int vix_strlen(const char *s)
 {
     unsigned int n = 0;
     while (s[n]) n++;
     return n;
 }
 
-static void vics_append(char *buf, int cap, int *off, const char *s)
+static void vix_append(char *buf, int cap, int *off, const char *s)
 {
     while (*s && *off < cap - 1) buf[(*off)++] = *s++;
     buf[*off] = '\0';
 }
 
-static void vics_draw_line(int screen_row, int line_idx)
+static void vix_draw_line(int screen_row, int line_idx)
 {
     const char *s   = (line_idx < v_nlines) ? v_lines[line_idx] : 0;
     int         len = s ? v_len[line_idx] : 0;
 
     for (int col = 0; col < VGA_WIDTH; col++) {
         char ch = (col < len) ? s[col] : ' ';
-        vics_put(col, screen_row, ch, VICS_CLR_TEXT);
+        vix_put(col, screen_row, ch, VIX_CLR_TEXT);
     }
 }
 
-static void vics_draw_status(void)
+static void vix_draw_status(void)
 {
     char bar[VGA_WIDTH + 1];
     int  off = 0;
 
     if (v_quit_warn) {
-        vics_append(bar, (int)sizeof(bar), &off,
+        vix_append(bar, (int)sizeof(bar), &off,
                     " Unsaved! Press ^Q again to quit, or ^S to save. ");
     } else {
-        vics_append(bar, (int)sizeof(bar), &off, " VICS | ");
+        vix_append(bar, (int)sizeof(bar), &off, " VIX | ");
         if (v_path[0])
-            vics_append(bar, (int)sizeof(bar), &off, v_path);
+            vix_append(bar, (int)sizeof(bar), &off, v_path);
         else
-            vics_append(bar, (int)sizeof(bar), &off, "[new]");
-        if (v_dirty) vics_append(bar, (int)sizeof(bar), &off, " *");
-        vics_append(bar, (int)sizeof(bar), &off, " | Ln ");
+            vix_append(bar, (int)sizeof(bar), &off, "[new]");
+        if (v_dirty) vix_append(bar, (int)sizeof(bar), &off, " *");
+        vix_append(bar, (int)sizeof(bar), &off, " | Ln ");
         char num[12];
-        vics_uitoa((unsigned int)(v_cur_row + 1), num);
-        vics_append(bar, (int)sizeof(bar), &off, num);
-        vics_append(bar, (int)sizeof(bar), &off, " Col ");
-        vics_uitoa((unsigned int)(v_cur_col + 1), num);
-        vics_append(bar, (int)sizeof(bar), &off, num);
-        vics_append(bar, (int)sizeof(bar), &off, " | ^S save  ^Q quit");
+        vix_uitoa((unsigned int)(v_cur_row + 1), num);
+        vix_append(bar, (int)sizeof(bar), &off, num);
+        vix_append(bar, (int)sizeof(bar), &off, " Col ");
+        vix_uitoa((unsigned int)(v_cur_col + 1), num);
+        vix_append(bar, (int)sizeof(bar), &off, num);
+        vix_append(bar, (int)sizeof(bar), &off, " | ^S save  ^Q quit");
     }
 
-    unsigned int blen = vics_strlen(bar);
+    unsigned int blen = vix_strlen(bar);
     while (blen < VGA_WIDTH) { bar[blen++] = ' '; }
     bar[VGA_WIDTH] = '\0';
 
-    unsigned char clr = v_quit_warn ? VICS_CLR_WARN : VICS_CLR_STATUS;
+    unsigned char clr = v_quit_warn ? VIX_CLR_WARN : VIX_CLR_STATUS;
     for (int col = 0; col < VGA_WIDTH; col++)
-        vics_put(col, VICS_STATUS_ROW, bar[col], clr);
+        vix_put(col, VIX_STATUS_ROW, bar[col], clr);
 }
 
-static void vics_redraw(void)
+static void vix_redraw(void)
 {
     g_ncells = 0;
-    for (int r = 0; r < VICS_TEXT_ROWS; r++)
-        vics_draw_line(r, v_view_top + r);
-    vics_draw_status();
-    vics_flush();
+    for (int r = 0; r < VIX_TEXT_ROWS; r++)
+        vix_draw_line(r, v_view_top + r);
+    vix_draw_status();
+    vix_flush();
     sys_set_cursor((unsigned int)v_cur_col,
                    (unsigned int)(v_cur_row - v_view_top));
 }
 
-static void vics_clamp_col(void)
+static void vix_clamp_col(void)
 {
     int max = (v_cur_row < v_nlines) ? v_len[v_cur_row] : 0;
     if (v_cur_col > max) v_cur_col = max;
 }
 
-static void vics_scroll(void)
+static void vix_scroll(void)
 {
     if (v_cur_row < v_view_top)
         v_view_top = v_cur_row;
-    else if (v_cur_row >= v_view_top + VICS_TEXT_ROWS)
-        v_view_top = v_cur_row - VICS_TEXT_ROWS + 1;
+    else if (v_cur_row >= v_view_top + VIX_TEXT_ROWS)
+        v_view_top = v_cur_row - VIX_TEXT_ROWS + 1;
 }
 
-static void vics_insert_char(char c)
+static void vix_insert_char(char c)
 {
-    if (v_cur_row >= VICS_MAX_LINES) return;
+    if (v_cur_row >= VIX_MAX_LINES) return;
     while (v_nlines <= v_cur_row) {
         v_lines[v_nlines][0] = '\0';
         v_len[v_nlines]       = 0;
@@ -160,7 +160,7 @@ static void vics_insert_char(char c)
     }
     char *line = v_lines[v_cur_row];
     int   len  = v_len[v_cur_row];
-    if (len >= VICS_LINE_CAP) return;
+    if (len >= VIX_LINE_CAP) return;
     for (int i = len; i > v_cur_col; i--)
         line[i] = line[i - 1];
     line[v_cur_col]  = c;
@@ -170,7 +170,7 @@ static void vics_insert_char(char c)
     v_dirty = 1;
 }
 
-static void vics_backspace(void)
+static void vix_backspace(void)
 {
     if (v_cur_row == 0 && v_cur_col == 0) return;
     if (v_cur_col > 0) {
@@ -185,7 +185,7 @@ static void vics_backspace(void)
         int prev     = v_cur_row - 1;
         int prev_len = v_len[prev];
         int cur_len  = v_len[v_cur_row];
-        if (prev_len + cur_len > VICS_LINE_CAP) return;
+        if (prev_len + cur_len > VIX_LINE_CAP) return;
         /* Manual memcpy */
         for (int i = 0; i <= cur_len; i++)
             v_lines[prev][prev_len + i] = v_lines[v_cur_row][i];
@@ -202,9 +202,9 @@ static void vics_backspace(void)
     v_dirty = 1;
 }
 
-static void vics_newline(void)
+static void vix_newline(void)
 {
-    if (v_nlines >= VICS_MAX_LINES) return;
+    if (v_nlines >= VIX_MAX_LINES) return;
     while (v_nlines <= v_cur_row) {
         v_lines[v_nlines][0] = '\0';
         v_len[v_nlines]       = 0;
@@ -228,19 +228,19 @@ static void vics_newline(void)
     v_dirty   = 1;
 }
 
-static void vics_parse(const char *buf, unsigned int size)
+static void vix_parse(const char *buf, unsigned int size)
 {
     v_nlines = 0; v_cur_row = 0; v_cur_col = 0;
     v_view_top = 0; v_dirty = 0; v_quit_warn = 0;
     unsigned int pos = 0;
-    while (v_nlines < VICS_MAX_LINES) {
+    while (v_nlines < VIX_MAX_LINES) {
         int out = 0;
         while (pos < size && buf[pos] != '\n') {
             if (buf[pos] == '\t') {
                 int spaces = 4 - (out % 4);
-                while (spaces-- > 0 && out < VICS_LINE_CAP)
+                while (spaces-- > 0 && out < VIX_LINE_CAP)
                     v_lines[v_nlines][out++] = ' ';
-            } else if (out < VICS_LINE_CAP) {
+            } else if (out < VIX_LINE_CAP) {
                 v_lines[v_nlines][out++] = buf[pos];
             }
             pos++;
@@ -255,16 +255,16 @@ static void vics_parse(const char *buf, unsigned int size)
 }
 
 /* Flat file buffer for load/save (64 KiB static). */
-static char v_filebuf[VICS_FILE_MAX];
+static char v_filebuf[VIX_FILE_MAX];
 
-static int vics_save(void)
+static int vix_save(void)
 {
     if (!v_path[0]) return -1;
     unsigned int off = 0;
     for (int i = 0; i < v_nlines; i++) {
-        for (int j = 0; j < v_len[i] && off < VICS_FILE_MAX - 2; j++)
+        for (int j = 0; j < v_len[i] && off < VIX_FILE_MAX - 2; j++)
             v_filebuf[off++] = v_lines[i][j];
-        if (i < v_nlines - 1 && off < VICS_FILE_MAX - 1)
+        if (i < v_nlines - 1 && off < VIX_FILE_MAX - 1)
             v_filebuf[off++] = '\n';
     }
     v_filebuf[off] = '\0';
@@ -276,7 +276,7 @@ static int vics_save(void)
 int main(int argc, char **argv)
 {
     if (argc < 2) {
-        const char *msg = "Usage: vics <filename>\n";
+        const char *msg = "Usage: vix <filename>\n";
         sys_write(1, msg, 23);
         sys_exit(1);
     }
@@ -290,24 +290,24 @@ int main(int argc, char **argv)
     /* Load file. */
     int fd = sys_open(v_path, O_RDONLY);
     if (fd >= 0) {
-        long got = sys_read(fd, v_filebuf, VICS_FILE_MAX - 1);
+        long got = sys_read(fd, v_filebuf, VIX_FILE_MAX - 1);
         sys_close(fd);
         if (got > 0) {
             v_filebuf[got] = '\0';
-            vics_parse(v_filebuf, (unsigned int)got);
+            vix_parse(v_filebuf, (unsigned int)got);
         } else {
-            vics_parse("", 0);
+            vix_parse("", 0);
         }
     } else {
-        vics_parse("", 0);
+        vix_parse("", 0);
     }
 
     /* Clear to editor background. */
-    sys_tty_clear(VICS_CLR_TEXT);
+    sys_tty_clear(VIX_CLR_TEXT);
 
     for (;;) {
-        vics_scroll();
-        vics_redraw();
+        vix_scroll();
+        vix_redraw();
 
         int c = sys_getkey();
 
@@ -319,16 +319,16 @@ int main(int argc, char **argv)
         v_quit_warn = 0;
 
         if (c == KEY_CTRL_S) {
-            if (v_path[0]) vics_save();
+            if (v_path[0]) vix_save();
             continue;
         }
 
         if (c == KEY_ARROW_UP) {
-            if (v_cur_row > 0) { v_cur_row--; vics_clamp_col(); }
+            if (v_cur_row > 0) { v_cur_row--; vix_clamp_col(); }
             continue;
         }
         if (c == KEY_ARROW_DOWN) {
-            if (v_cur_row < v_nlines - 1) { v_cur_row++; vics_clamp_col(); }
+            if (v_cur_row < v_nlines - 1) { v_cur_row++; vix_clamp_col(); }
             continue;
         }
         if (c == KEY_ARROW_LEFT) {
@@ -350,16 +350,16 @@ int main(int argc, char **argv)
             continue;
         }
 
-        if (c == '\b')              { vics_backspace(); continue; }
-        if (c == '\n' || c == '\r') { vics_newline();   continue; }
+        if (c == '\b')              { vix_backspace(); continue; }
+        if (c == '\n' || c == '\r') { vix_newline();   continue; }
         if (c == '\t') {
-            for (int s = 0; s < 4; s++) vics_insert_char(' ');
+            for (int s = 0; s < 4; s++) vix_insert_char(' ');
             continue;
         }
-        if (c >= ' ' && c <= '~') { vics_insert_char((char)c); continue; }
+        if (c >= ' ' && c <= '~') { vix_insert_char((char)c); continue; }
     }
 
     /* Restore shell colour scheme. */
-    sys_tty_clear(VICS_SHELL_CLR);
+    sys_tty_clear(VIX_SHELL_CLR);
     return 0;
 }

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -28,8 +28,15 @@ if ! command -v "$QEMU" >/dev/null 2>&1; then
     exit 2
 fi
 
-LOGDIR=$(mktemp -d -t makar-ui)
-trap 'rm -rf "$LOGDIR"' EXIT
+# Allow CI to capture logs by passing $UI_TEST_LOGDIR; otherwise use a
+# scratch dir and clean up on exit.
+if [ -n "${UI_TEST_LOGDIR:-}" ]; then
+    LOGDIR=$UI_TEST_LOGDIR
+    mkdir -p "$LOGDIR"
+else
+    LOGDIR=$(mktemp -d -t makar-ui)
+    trap 'rm -rf "$LOGDIR"' EXIT
+fi
 
 run_scenario() {
     local name=$1

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# ui_test.sh - black-box UI tests driven through QEMU's HMP monitor.
+#
+# Each scenario boots the test ISO headless, feeds keyboard input via
+# `sendkey` over the monitor socket, and asserts on substrings in the
+# kernel's serial log (mirror of every t_writestring call).  No PPM
+# parsing - the serial mirror catches everything any command echoes.
+# Cases that depend on visual-only state (cursor position, gutter
+# rendering) are out of scope; manual sendkey + screendump for those.
+#
+# Usage:
+#   tests/ui_test.sh                # run all scenarios
+#   tests/ui_test.sh <name>...      # run named scenarios only
+#
+# Exit codes: 0 = all passed, 1 = at least one failed.
+
+set -u
+
+ISO=${ISO:-makar.iso}
+if [ ! -f "$ISO" ]; then
+    echo "ui_test: $ISO not found - build first with './run.sh iso-build'" >&2
+    exit 2
+fi
+
+QEMU=${QEMU:-qemu-system-i386}
+if ! command -v "$QEMU" >/dev/null 2>&1; then
+    echo "ui_test: $QEMU not on PATH; this target needs host qemu" >&2
+    exit 2
+fi
+
+LOGDIR=$(mktemp -d -t makar-ui)
+trap 'rm -rf "$LOGDIR"' EXIT
+
+run_scenario() {
+    local name=$1
+    local script=$2
+    shift 2
+    local expects=("$@")
+
+    local serial=$LOGDIR/$name.serial
+    local mon=$LOGDIR/$name.mon
+    local dump=$LOGDIR/$name.ppm
+
+    rm -f "$serial" "$mon" "$dump"
+
+    "$QEMU" \
+        -cdrom "$ISO" \
+        -m 256 \
+        -vga std \
+        -display none \
+        -serial "file:$serial" \
+        -monitor "unix:$mon,server,nowait" \
+        &
+    local pid=$!
+
+    # Wait up to 30s for "kernel: boot complete" - emitted by kernel.c
+    # right before it switches to Linux-style quiet serial.  Reliable
+    # whether or not g_serial_verbose is on; reaches serial via direct
+    # Serial_WriteString, not the t_putchar mirror.
+    local waited=0
+    while [ $waited -lt 60 ]; do
+        if grep -q "kernel: boot complete" "$serial" 2>/dev/null; then break; fi
+        sleep 0.5
+        waited=$((waited + 1))
+    done
+    if [ $waited -ge 60 ]; then
+        echo "FAIL [$name]: boot-complete marker never appeared" >&2
+        kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+        return 1
+    fi
+    # Small grace period for the shell tasks (created after the marker)
+    # to register their kbd slots and print their prompts.
+    sleep 1
+
+    # Wait for monitor socket.
+    waited=0
+    while [ $waited -lt 30 ] && [ ! -S "$mon" ]; do
+        sleep 0.2
+        waited=$((waited + 1))
+    done
+
+    # Prepend `verbose on` so the shell mirrors output to COM1 for the
+    # duration of the test.  By default (Linux-style) the shell only
+    # writes to the framebuffer, which the serial log wouldn't see.
+    # The verbose toggle itself writes its confirmation to serial only
+    # AFTER the flag flips, so we can also assert that the toggle ran.
+    local preamble='sendkey v
+sendkey e
+sendkey r
+sendkey b
+sendkey o
+sendkey s
+sendkey e
+sendkey spc
+sendkey o
+sendkey n
+sendkey ret'
+    nc -U "$mon" <<< "$preamble" >/dev/null
+    sleep 0.8
+
+    # Drive scenario keystrokes.
+    nc -U "$mon" <<< "$script" >/dev/null
+
+    # Let commands drain.  Three seconds covers any current scenario;
+    # bump if a test starts running anything slow.
+    sleep 3
+
+    # Snapshot the screen (handy for triage; not asserted on here).
+    echo "screendump $dump" | nc -U "$mon" >/dev/null
+    sleep 0.3
+    echo "quit" | nc -U "$mon" >/dev/null
+    wait "$pid" 2>/dev/null
+
+    # Assert every expected substring appears in serial.
+    local missing=()
+    for needle in "${expects[@]}"; do
+        if ! grep -qF -- "$needle" "$serial"; then
+            missing+=("$needle")
+        fi
+    done
+
+    if [ ${#missing[@]} -eq 0 ]; then
+        echo "PASS [$name]"
+        return 0
+    else
+        echo "FAIL [$name]: missing in serial: ${missing[*]}"
+        echo "       serial: $serial"
+        echo "       dump:   $dump"
+        return 1
+    fi
+}
+
+# --- Scenarios ---------------------------------------------------------------
+#
+# Each scenario is named; selecting a subset on the command line filters by
+# name.  Scripts are HMP `sendkey` commands; the framework appends a `ret` if
+# the script doesn't already end with one - reduces boilerplate.
+
+scenario_glob_proc() {
+    run_scenario "glob-proc" \
+"sendkey c
+sendkey a
+sendkey t
+sendkey spc
+sendkey slash
+sendkey p
+sendkey r
+sendkey o
+sendkey c
+sendkey slash
+sendkey shift-8
+sendkey ret" \
+        "vendor_id" "MemFree" "Makar 0.5.0"
+}
+
+scenario_tab_path() {
+    # `cat<TAB>/proc/c<TAB><Enter>` should expand to `cat /proc/cpuinfo`
+    # and dump the cpuinfo content.  Verifies: visible-feedback tab on
+    # unique cmd match (`cat ` with trailing space), path-style tab
+    # completion extension, and that the resulting command runs.
+    run_scenario "tab-complete-path" \
+"sendkey c
+sendkey a
+sendkey t
+sendkey tab
+sendkey slash
+sendkey p
+sendkey r
+sendkey o
+sendkey c
+sendkey slash
+sendkey c
+sendkey tab
+sendkey ret" \
+        "vendor_id" "GenuineIntel"
+}
+
+scenario_cd_root() {
+    # `cd /<TAB><TAB><Enter>` then `pwd` - tab on /<TAB><TAB> lists the
+    # mount points; the trailing Enter commits the half-typed `cd /`,
+    # leaving us at the virtual root.  Then verify with pwd.
+    run_scenario "cd-root-listing" \
+"sendkey c
+sendkey d
+sendkey spc
+sendkey slash
+sendkey tab
+sendkey tab
+sendkey ret
+sendkey p
+sendkey w
+sendkey d
+sendkey ret" \
+        "cdrom"
+}
+
+# --- Driver ------------------------------------------------------------------
+
+ALL_SCENARIOS=(glob_proc tab_path cd_root)
+
+declare -a TO_RUN
+if [ $# -eq 0 ]; then
+    TO_RUN=("${ALL_SCENARIOS[@]}")
+else
+    for arg in "$@"; do
+        TO_RUN+=("${arg//-/_}")
+    done
+fi
+
+fails=0
+total=0
+for s in "${TO_RUN[@]}"; do
+    total=$((total + 1))
+    if ! "scenario_${s}"; then
+        fails=$((fails + 1))
+    fi
+done
+
+echo
+echo "ui_test: $((total - fails))/$total passed"
+[ $fails -eq 0 ] || exit 1
+exit 0

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -50,29 +50,37 @@ run_scenario() {
 
     rm -f "$serial" "$mon" "$dump"
 
+    # -no-reboot + -no-shutdown keep a triple fault or kernel panic from
+    # turning into an infinite reboot loop that hangs CI.
     "$QEMU" \
         -cdrom "$ISO" \
         -m 256 \
         -vga std \
         -display none \
+        -no-reboot -no-shutdown \
         -serial "file:$serial" \
         -monitor "unix:$mon,server,nowait" \
         &
     local pid=$!
 
-    # Wait up to 30s for "kernel: boot complete" - emitted by kernel.c
-    # right before it switches to Linux-style quiet serial.  Reliable
-    # whether or not g_serial_verbose is on; reaches serial via direct
-    # Serial_WriteString, not the t_putchar mirror.
+    # Wait up to ${BOOT_TIMEOUT:-90}s for "kernel: boot complete".  TCG
+    # under CI containers can take 30-60s to reach this marker on its
+    # own; bump UI_BOOT_TIMEOUT in the workflow if you see false fails.
+    local boot_timeout=${UI_BOOT_TIMEOUT:-90}
     local waited=0
-    while [ $waited -lt 60 ]; do
+    local max_ticks=$((boot_timeout * 2))   # 0.5s ticks
+    while [ $waited -lt $max_ticks ]; do
         if grep -q "kernel: boot complete" "$serial" 2>/dev/null; then break; fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "FAIL [$name]: QEMU exited before boot-complete" >&2
+            return 1
+        fi
         sleep 0.5
         waited=$((waited + 1))
     done
-    if [ $waited -ge 60 ]; then
-        echo "FAIL [$name]: boot-complete marker never appeared" >&2
-        kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+    if [ $waited -ge $max_ticks ]; then
+        echo "FAIL [$name]: boot-complete marker never appeared (waited ${boot_timeout}s)" >&2
+        kill -9 "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
         return 1
     fi
     # Small grace period for the shell tasks (created after the marker)
@@ -116,6 +124,19 @@ sendkey ret'
     echo "screendump $dump" | nc -U "$mon" >/dev/null
     sleep 0.3
     echo "quit" | nc -U "$mon" >/dev/null
+
+    # Bounded shutdown.  If QEMU doesn't honour the HMP `quit` within
+    # 5s (monitor socket lost, kernel wedged, etc.) escalate to SIGKILL
+    # so a single hang can't burn the whole CI minute budget.
+    local exit_waited=0
+    while [ $exit_waited -lt 50 ] && kill -0 "$pid" 2>/dev/null; do
+        sleep 0.1
+        exit_waited=$((exit_waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "WARN [$name]: QEMU did not exit on quit; killing" >&2
+        kill -9 "$pid" 2>/dev/null
+    fi
     wait "$pid" 2>/dev/null
 
     # Assert every expected substring appears in serial.

--- a/work-in-progress/shell.md
+++ b/work-in-progress/shell.md
@@ -1,27 +1,23 @@
-# Shell - interactive kernel command loop
+# Shell — historical WIP note (archived)
 
-> **Status:** complete (ongoing: new commands added with each feature)
-> **Branch:** landed on `main`
+> **Status:** ✅ Shipped on main. This note is kept for git-blame
+> context only; the live reference is [`docs/kernel/shell.md`](../docs/kernel/shell.md).
 
-## Summary
+The shell described here landed long before the multi-TTY refactor.
+Everything in the original checklist is now implemented and surpassed:
 
-Minimal interactive shell reading PS/2 keyboard input, dispatching built-in
-commands, and executing ELF userspace apps from the VFS.
+- Inline editing, history (↑/↓ + `!!`), Ctrl+C sigint
+- Module-table dispatch with a `fullscreen` flag for FB-restoring builtins
+- VFS-aware tab completion across `/hd`, `/cdrom`, `/proc`, and the
+  virtual root
+- Glob expansion (`*`, `?`) on argv via `shell_glob.c`
+- PATH lookup for ELFs (`/cdrom/apps/`, `/hd/apps/`)
+- `exec <path>` plus 5 builtins that paint over the framebuffer
+- Per-TTY shells (`shell0`–`shell3`) running as preemptive kernel tasks
 
-## Implemented
+The renamed VIX editor (was VICS — see `docs/makar-medli.md`) is
+launched via the `vix` builtin.
 
-- [x] Line editor with echo, backspace, arrow-key history, Ctrl+C cancel
-- [x] Command dispatch via registry table (`shell_cmds.c` modules)
-- [x] Welcome banner and version string at boot
-- [x] Prompt matching Medli UX: `user@makar /path> `
-- [x] VFS-aware commands: `ls`, `cd`, `cat`, `mount`, `lspart`, `mkpart`
-- [x] Disk commands: `lsdisks`, `readsector`
-- [x] System commands: `help`, `clear`, `echo`, `meminfo`, `uptime`, `shutdown`
-- [x] Debug/test commands: `ktest`, `ring3test`, `vicstest`, `splitscreen`
-- [x] ELF userspace execution: `exec <path>` launches ring-3 ELF binaries
-- [x] Userspace apps: `hello`, `calc` (bc-style expression evaluator)
-
-## Source
-
-- `src/kernel/arch/i386/shell/`
-- `docs/kernel/shell.md`
+See [`docs/kernel/shell.md`](../docs/kernel/shell.md) for the current
+implementation reference and [`SURVEY.md`](../SURVEY.md) for the full
+command inventory.

--- a/work-in-progress/split-panes.md
+++ b/work-in-progress/split-panes.md
@@ -1,40 +1,34 @@
-# Split panes - tmux-style VESA terminal splitting
+# Split panes — historical WIP note (archived)
 
-> **Status:** Phase 1 complete; Phases 2–3 in progress
-> **Branch:** `feat/split-panes`
+> **Status:** Phase 1 shipped. Phase 2/3 superseded — see below.
 
-## Summary
+## What shipped
 
-Horizontal split-pane support in the VESA framebuffer renderer.
-Each pane owns its cursor, colours, and a row sub-rectangle of the screen.
-VGA text mode falls back to virtual-console switching via the same Ctrl-A prefix.
+**Phase 1** — pane abstraction landed on main:
 
-## Phase 1 - Pane abstraction (complete)
+- `vesa_pane_t` (`top_row`, `cols`, `rows`, pane-relative cursor, fg/bg)
+- `vesa_tty_pane_init`, `vesa_tty_pane_putchar`, `vesa_tty_pane_clear`,
+  `vesa_tty_pane_setcolor`, `vesa_tty_pane_put_at`,
+  `vesa_tty_pane_set_cursor`, `vesa_tty_pane_get_col/row`
+- `vesa_tty_default_pane()` for legacy callers
+- `pane_scroll_up` (in-pane memmove, no cross-pane interference)
+- Used by VIX (`src/kernel/arch/i386/proc/vix.c`) to derive col/row
+  counts at runtime.
 
-- [x] `vesa_pane_t` struct: `top_row`, `cols`, `rows`, pane-relative cursor, fg/bg
-- [x] `vesa_tty_pane_init`, `vesa_tty_pane_putchar`, `vesa_tty_pane_clear`,
-      `vesa_tty_pane_setcolor`, `vesa_tty_pane_put_at`, `vesa_tty_pane_set_cursor`,
-      `vesa_tty_pane_get_col`, `vesa_tty_pane_get_row`
-- [x] `vesa_tty_default_pane()` - legacy callers unaffected (screen-spanning pane)
-- [x] `pane_scroll_up` - in-pane memmove, does not disturb other panes
-- [x] Full ktest + GDB boot suite passes
+## What replaced phases 2 & 3
 
-## Phase 2 - Keyboard dispatcher (TODO)
+The tmux-style `Ctrl-A` pane prefix was implemented inside the keyboard
+driver (`keyboard.c`, search for `KB_PANE_TOP` / `KB_PANE_BOTTOM`), but
+the wider "two shells side-by-side in one TTY" model was dropped in
+favour of **independent TTYs**: `shell0`–`shell3` each get a full
+screen, switched via `Alt+F1`–`Alt+F4`. The per-TTY backing buffer
+(`vt_buf_t`, PR #129) makes Alt+Fn lossless; switching is functionally
+better than a split because each TTY has its own kernel task, page
+directory, and keyboard ring.
 
-- [ ] Ctrl-A prefix dispatcher: Ctrl-A,U / Ctrl-A,J switch top/bottom pane focus
-- [ ] VGA/low-res fallback: Ctrl-A,1/2/3 switch full-screen virtual consoles
-- [ ] Per-task input queues; `keyboard_getchar()` dequeues from the calling
-      task's bound queue
-- [ ] Focus pointer; Ctrl-A prefix consumed by dispatcher, not forwarded
+Pane API is still live — VIX uses it, future curses-style ELFs can
+use it, but the shell itself is one-pane-per-TTY now.
 
-## Phase 3 - VICS pane integration (TODO)
-
-- [ ] Refactor `vics.c` to accept `(top_row, text_rows, status_row)` instead
-      of hard-coding rows 0–23 + 24 + raw `VGA_MEMORY` writes
-- [ ] `splitscreen` shell command: spawn VICS in top pane, shell in bottom
-- [ ] Mode detection: `vesa_tty_is_ready() && vesa_tty_get_rows() >= 30`
-
-## Constraints
-
-- Horizontal splits only (top/bottom); side-by-side column splits are out of scope
-- Split mode is VESA-only; VGA text mode uses virtual-console switching
+See [`docs/kernel/shell.md`](../docs/kernel/shell.md) for the live
+shell reference and [`docs/kernel/keyboard.md`](../docs/kernel/keyboard.md)
+for the input routing (Alt+Fn / Ctrl-A handling).


### PR DESCRIPTION
## Summary

Polish pass on the editor, a rename, a serial-console cleanup, a shell-side framebuffer-restore refactor, and a doc audit. 12 commits, all bounded to this branch.

## Headlines

- **VIX rename** — the editor (was `VICS` = "vi C-Sharp") is now `VIX`, language-neutral so a future round-trip back to Medli's C# editor doesn't make the acronym a lie. Files renamed: `vics.c` → `vix.c` (kernel + userspace), `vics.h` → `vix.h`. Origin story preserved in `docs/makar-medli.md`.
- **VIX editor polish** — vim-style 4-digit line-number gutter, `~` markers past EOF, visual word wrap, flashing block caret (was an invisible 2-px underscore at scale=2), tmux-style status row reservation so the global VTTY status bar stays put, right-margin fill on wide resolutions (1080p no longer leaks blue past column 85).
- **Cross-FS tab completion + glob on `/`** — `vfs_complete()` learnt `VFS_FS_ROOT`. `cd /<TAB>`, `cat /*`, `ls /p*` now enumerate mount points (`hd`, `cdrom`, `proc`) instead of returning nothing.
- **Shell-side FB restore** — added a `fullscreen` bit to `shell_cmd_entry_t`; `shell_dispatch` calls `shell_restore_screen()` after any fullscreen builtin (vix, install, exec) or ELF returns. Knowledge of "I painted over the framebuffer" lives in one place at the dispatch boundary instead of being scattered through each fullscreen command. Fixes the post-vix blank screen; same fix automatically covers `kbtester` and any future TUI ELF.
- **VT-buf resize on setmode** — `vtty_init` is now idempotent (frees existing cells); `cmd_setmode` calls it after `vesa_tty_init` so the per-TTY backing grids match the new geometry. Before this, switching to 1080p left the buffers at boot-time size and `paint_buf` only repainted a prefix of the screen.
- **`setmode` with no args** — reports the current mode + cell-grid dimensions instead of just printing usage.
- **Linux-like serial** — `g_serial_verbose` flips off after boot so COM1 stays quiet (dmesg + explicit diagnostics only). `console=ttyS0` on the kernel cmdline opts back in for the boot session; new `verbose [on|off]` shell builtin toggles at runtime. Used by the UI tests.
- **UI-test framework** — `tests/ui_test.sh` drives the shell through QEMU HMP `sendkey` and asserts on serial substrings. Scenarios: `glob-proc`, `tab-complete-path`, `cd-root-listing`. Bounded shutdown, fail-fast on early QEMU exit, configurable `UI_BOOT_TIMEOUT`. Runnable locally via `./run.sh ui-test`; intentionally NOT in CI because TCG-only QEMU on shared GHA infra is slow and hang-prone (see comment in `build-test.yml`).
- **Verbose ktest in CI** — `ktest_begin` gained a `desc` parameter; each of the 17 suites now declares what it covers. `run.sh` echoes the full transcript so the GHA "Run ktest" step shows every suite + per-assertion PASS instead of just `ALL PASSED`.
- **Doc audit** — rewrote `docs/makar-medli.md` (dropped the "C / C++" claim, fixed milestone checkboxes, added VIX history table), refreshed `docs/kernel/shell.md` (fullscreen flag, restore-screen helper, cross-FS tab completion), expanded `SURVEY.md` (added Testing-harness section, syscalls 208–214, `/proc` paths, `kbtester.elf`, `verbose` builtin), refreshed `README.md` and `CLAUDE.md` (slice 10 marked shipped, this PR added under Recently merged). Archived `work-in-progress/{shell,split-panes}.md` to point at live docs.

## Commits

| | |
|---|---|
| `583dc5b` | fix(vfs): enumerate mount points for / in vfs_complete |
| `dcf9402` | fix(vics): respect status row, repaint it on exit |
| `020dd1c` | feat(vics): line-number gutter, visible cursor, wrap |
| `960d04b` | feat(serial+ci): linux-like serial, ui-test framework |
| `ab4af69` | fix(vics): block caret for visibility |
| `50ce6a3` | ci(ui-test): wire sendkey suite into build-test workflow |
| `24f1dd5` | feat(shell): centralise FB restore after fullscreen commands |
| `9fc8d71` | rename: VICS → VIX |
| `8f81f85` | fix(vix+vtty): wide-resolution right margin + post-setmode resize |
| `df8b8e6` | test(ui): bounded shutdown, fail-fast on early QEMU exit |
| `a9b7474` | ci: drop UI test job; keep the script for local use |
| `0debf11` | test(ktest): per-suite descriptions |

## Out of scope

- **Tab-completion cycling (zsh-style)** — completing the argument inline + cycling on repeat tab. Deferred to the next PR.
- **kbtester sendkey scenario** — discussed; the shell-side restore-screen fix automatically covers kbtester so no extra scenario was added.

## Test plan

- [x] `./run.sh iso-test` green (ktest + GDB ISO + GDB HDD, all locally and on CI)
- [x] `./run.sh hdd-test` green
- [x] `./run.sh ui-test` green locally (3/3 scenarios; ~35s total)
- [x] Manual at 720p and 1080p: gutter / wrap / flashing caret / status bar / right-margin fill / clean post-exit screen / `cd /<TAB>` enumerates mount points / `verbose on/off` toggles serial mirror / `setmode` no-arg reports current mode