### PR TITLE
docs(pages): jekyll site, dark-mode theme, history page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,54 @@
+title: Makar
+description: >-
+  A bare-metal i686 hobby OS in C — preemptive 100 Hz scheduler, 4-TTY
+  multitasking shell, FAT32 + ISO9660 + synthetic /proc, ring-3 ELF
+  userspace, VIX editor.  Sibling project of Medli (C# / Cosmos).
+
+# Remote theme so we're not pinned to GitHub Pages' bundled-themes
+# list.  just-the-docs is a documentation-shaped theme with a sidebar,
+# search, and a light/dark/auto colour-scheme toggle.
+remote_theme: just-the-docs/just-the-docs@v0.10.0
+
+# Auto follows the visitor's OS preference; "light" / "dark" overrides
+# are exposed via the toggle button in the top right.
+color_scheme: auto
+
+# Search across every rendered page.
+search_enabled: true
+
+# Per-page edit link (handy for hobby docs).
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/Arawn-Davies/Makar"
+gh_edit_branch: "main"
+gh_edit_source: docs
+gh_edit_view_mode: "tree"
+
+# Top-right header link to the source repo.
+aux_links:
+  "GitHub":
+    - "https://github.com/Arawn-Davies/Makar"
+  "Sibling: Medli":
+    - "https://github.com/Arawn-Davies/Medli"
+
+aux_links_new_tab: true
+
+# Footer.
+footer_content: >-
+  Makar - © Arawn Davies.  BSD-3-Clause Clear.  Built with Jekyll +
+  just-the-docs.  Sibling project: <a href="https://github.com/Arawn-Davies/Medli">Medli</a>.
+
+# Convert .md links to .html so the existing relative links keep working.
+plugins:
+  - jekyll-relative-links
+  - jekyll-seo-tag
+  - jekyll-sitemap
+relative_links:
+  enabled: true
+  collections: true
+
+# Anything in /docs is fair game; nothing to exclude from /docs itself.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,3 +1,8 @@
+---
+title: Building & running
+nav_order: 2
+---
+
 # Building & Running Makar
 
 The entire build and test toolchain runs inside Docker - no cross-compiler or

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,114 @@
+---
+title: History
+nav_order: 7
+---
+
+# History
+
+A diary of how Makar got here, drawn from the git log and PR archive.
+Dates are commit/merge dates; PR numbers link to the merge that
+shipped each milestone.
+
+## 2019 — First strokes
+
+**August 2019.** First commit, display driver newline fix, libc
+stubs. By the end of the week: IDT, GDT, basic IRQ handling, a serial
+debug interface. The project was unnamed and the build was driven by
+a hand-rolled QEMU shell script.
+
+> Then the project sat dormant for almost five years.
+
+## 2020 — A brief return
+
+**August 2020.** Editorconfig, code-style consolidation, a switch
+from GAS-style inline assembly to standalone NASM files. Nothing
+shipped beyond the existing scaffold. Repo went quiet again after
+about a week.
+
+## 2025 — Single-commit hiatus
+
+**January 2025.** One commit: "fix assembly comments." A drive-by
+fix while the rest of the codebase still slept.
+
+## 2026-04 — Rebirth
+
+**April 9–10.** Project rename to "Untitled OS." GitHub Actions wired
+up, push triggers, a Copilot-assisted PR cadence begins (#1–#17). The
+build acquires real CI, the kernel acquires real structure.
+
+**April 11.** Repo reshuffle: source tree moves to `src/`, kernel
+under `src/kernel/arch/i386/`. Cooperative multitasking and an `int
+0x80` syscall stub land (#42). First ATA PIO IDE driver (#41).
+
+**April 12.** Memory work: paging cleanup, ACPI, on-demand ktest
+harness (#44). ATA + MBR + GPT partitions, `mkpart` shell command
+(#45). The Makar name takes shape — shell vocabulary deliberately
+mirrors Medli (#48). Build-timestamp banner at boot, shell split into
+focused source files (#46). FAT32 + Medli filesystem layout (#26 /
+#47). Universal VFS, ↑/↓ shell history, installer (#49). Docker
+image swapped for the i686-elf cross-compiler.
+
+**April 25.** VMM lands. Ring-3 trampoline, comprehensive ktest
+suites (#53). Cross-platform build fix for macOS arm64.
+
+**April 26–27.** Panic screen + startup logo (#110). Display fixes +
+VESA ktest (#111). Readline inline editing, file-I/O commands, ring-3
+stdin, `exec` wait (#112).
+
+**April 29–30.** VESA pane abstraction (#113, "split-panes phase 1").
+Installed-HDD boot path: image generation, interactive boot, GDB test
+(#114). Auto-release workflow on main merge (#115). `run.sh`
+consolidation — one entrypoint for build, test, boot (#116).
+
+## 2026-05 — The big runway
+
+**May 1.** GRUB menu + 720p default + sigint + tab completion + calc
++ ktest improvements (#117). Linux i386 ABI userspace with `exec`
+shell command (#118).
+
+**May 2.** Multi-TTY shell, pane-aware VICS editor, `lsman` + `man`
+pages (#119). FAT32 userspace fileops — delete, rename, syscalls
+208–210, ELF apps `rm.elf` / `mv.elf` / `cp.elf` (#120).
+
+**May 8.** Preemptive 100 Hz scheduler. Per-task `task_t`
+plumbing (`pid`, `cwd`, `tty`, signal bitmasks, fd-table placeholder),
+ring-3 lifecycle proof via ktest, user-PD reaper (#123).
+
+**May 12.** Layered PS/2 keyboard rewrite: scancode → keycode →
+sentinel → router pipeline, IRQ-driven per-task SPSC rings,
+`kbtester.elf` ring-3 diagnostic (#124).
+
+**May 13.** Build/CI overhaul: ccache, single-kernel/two-ISO emit,
+build-once fan-out CI with 4 parallel jobs, KVM auto-detect (off by
+default), local `act` validation (#125).
+
+**May 14.** Per-TTY backing buffers (`vt_buf_t`), deferred FB repaint
+on Alt+Fn, tmux-style status bar at the bottom row, synthetic
+`/proc` filesystem with `cpuinfo`/`meminfo`/`tasks`/`uname`, glob +
+tab completion across the VFS, `MAKAR_VERSION` single-source, tagged
+v0.5.0 (#129).
+
+**May 15.** VIX rename (was VICS — "vi C-Sharp" no longer applied,
+language-neutral now). vim-style line-number gutter, word wrap,
+flashing block caret. Cross-FS root enumeration in `vfs_complete`
+(`cd /<TAB>` finally works). Linux-style serial console
+(`g_serial_verbose`, `console=ttyS0` cmdline, `verbose` shell
+builtin). UI-test framework via QEMU HMP `sendkey` (3 scenarios).
+Shell-side framebuffer restore after fullscreen commands. Per-suite
+ktest descriptions (#130).
+
+## Next
+
+Tracked in [CLAUDE.md "Slice queue"](https://github.com/Arawn-Davies/Makar/blob/main/CLAUDE.md#slice-queue-feat-tty-multitasking--follow-ups)
+on the live repo. Headline:
+
+- **Slice 14 (NEXT)** — Per-task FD table. Replaces the global
+  keyboard owner + placeholder `fd_table` with a real per-task
+  array. Prerequisite for any libc port.
+- **Slice 8** — Linux-style signal subsystem (sigaction, `kill()`).
+- **Slice 9** — Preemption hardening (interrupt-safe `schedule()`).
+- **Slice 15** — VFS `task->cwd` authoritative.
+- **Slice 16** — VGA-text fallback per-TTY backing buffers.
+
+Long term: musl libc port → dash → in-kernel TCC for write-compile-
+run on bare metal. See [Userland libc](userland-libc.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,54 @@
-# Makar - Documentation
+---
+title: Home
+layout: default
+nav_order: 1
+permalink: /
+---
 
-Makar is a bare-metal i686 operating system written in C, booted via GRUB
-Multiboot 2.  It is the C/C++ sibling of
-[Medli](https://github.com/Arawn-Davies/Medli) - both implement the same OS
-concept, sharing UX conventions, filesystem design, and long-term binary
-format goals.  See [Makar × Medli](makar-medli.md) for the full co-operation
-roadmap.
+# Makar
 
-## Kernel subsystems
+A **bare-metal i686 hobby OS** written in straight C (no C++, no managed
+runtime), booted via GRUB Multiboot 2. Targets 32-bit protected mode,
+ships in QEMU, runs on real hardware once installed to disk.
+
+Sibling of [Medli](https://github.com/Arawn-Davies/Medli) — the
+C# / Cosmos counterpart. The two share a command vocabulary,
+filesystem layout, and long-term binary-format goals while exploring
+how language choice shapes the implementation.
+
+**Current version:** 0.5.0 (see
+[`include/kernel/version.h`](https://github.com/Arawn-Davies/Makar/blob/main/src/kernel/include/kernel/version.h)).
+
+## Quick links
+
+- **[Building & running](building.md)** — toolchain, Docker, QEMU
+- **[Testing](testing.md)** — ktest, GDB checkpoint suite, UI sendkey tests
+- **[Userland libc](userland-libc.md)** — porting roadmap toward musl/dash
+- **[Makar × Medli](makar-medli.md)** — sibling-project co-operation roadmap and VIX→VICS history
+- **[Repo on GitHub](https://github.com/Arawn-Davies/Makar)**
+
+## What works today
+
+| Subsystem | State |
+|---|---|
+| **Boot** | GRUB Multiboot 2, 5 s menu (Makar OS / chainload next device). Cmdline parsed for `test_mode` + `console=ttyS0`. |
+| **Display** | VESA framebuffer (Bochs VBE, 720p default); VGA 80×50 fallback. `vesa_pane_t` pane abstraction. |
+| **Multi-TTY** | 4 preemptive shell tasks `shell0`–`shell3`, **Alt+F1–F4** to switch. Per-TTY `vt_buf_t` backing grid; FB painted only when focused; tmux-style status bar at bottom row. |
+| **VIX editor** | vim-style line-number gutter, word wrap, flashing block caret, status row, runtime-resolution agnostic. Renamed from VICS during the port — see [Makar × Medli](makar-medli.md). |
+| **Storage** | FAT32 (HDD/USB) + ISO 9660 (CD-ROM) over IDE PIO. Auto-mount at `/hd` and `/cdrom`. Read + write + delete + rename on FAT32. |
+| **`/proc`** | Synthetic filesystem with `cpuinfo`, `meminfo`, `tasks`, `uname` — content generated on each read. |
+| **Memory** | PMM bitmap allocator, paging (256 MiB identity + per-task 4 KiB user pages), kernel heap. |
+| **Tasking** | Preemptive round-robin scheduler. PIT 100 Hz, `SCHED_QUANTUM = 4` ticks (40 ms slice). Per-task `pid`, `cwd`, `tty`, fd-table placeholder, signal bitmasks. User PD reaped on task exit. |
+| **Userspace** | Ring-3 via `iret`. ELF loader (`elf_exec`) with argc/argv. Apps: `hello`, `echo`, `calc`, `ls`, `vix`, `diskinfo`, `rm`, `mv`, `cp`, `kbtester`. |
+| **Syscalls** | Linux i386 ABI subset over `int 0x80` + Makar extensions (211–214). |
+| **Shell** | Inline editing, 16-entry history, cross-FS tab completion, glob expansion, Ctrl+C sigint, `lsman`/`man <cmd>`. Fullscreen-command dispatch with auto FB restore. |
+| **Drivers** | 16550 UART, PIT, layered PS/2 keyboard (full set-1 + e0 with per-task SPSC rings), ATA/IDE PIO 28-bit LBA, MBR + GPT partition tables. |
+| **Debug** | INT 1 / INT 3 GDB-friendly handlers, kernel panic screen, ktest harness with per-suite descriptions and VGA + serial output. |
+| **Serial** | Linux-style: dmesg + explicit diagnostics by default. `console=ttyS0` cmdline or `verbose [on\|off]` shell builtin opts into TTY-mirroring. |
+
+## Kernel subsystem reference
+
+Per-driver and per-module documentation:
 
 | Document | Description |
 |---|---|
@@ -30,39 +71,50 @@ roadmap.
 | [vtty](kernel/vtty.md) | Virtual TTY manager (focus, Alt+Fn switch, deferred repaint, status bar) |
 | [debug](kernel/debug.md) | INT 1 / INT 3 debug-exception handlers |
 | [multiboot](kernel/multiboot.md) | Multiboot 2 structure definitions |
-| [keyboard](kernel/keyboard.md) | PS/2 keyboard driver (IRQ 1, scan-code set 1, ring buffer) |
+| [keyboard](kernel/keyboard.md) | PS/2 keyboard driver (layered, IRQ 1, set 1 + e0, per-task SPSC rings) |
 | [ide](kernel/ide.md) | ATA/IDE PIO driver (28-bit LBA read/write) |
 | [partition](kernel/partition.md) | MBR and GPT partition table driver |
-| [shell](kernel/shell.md) | Interactive multi-TTY kernel command shell (rm, mv, cp, …) |
+| [procfs](kernel/procfs.md) | Synthetic `/proc` filesystem |
+| [shell](kernel/shell.md) | Interactive multi-TTY kernel command shell |
 
-| [fat32](kernel/fat32.md) | FAT32 filesystem driver (read, write, delete, rename) |
-| [vfs](kernel/vfs.md) | Virtual filesystem layer (unified path namespace) |
-| [procfs](kernel/procfs.md) | Synthetic `/proc` filesystem (`cpuinfo`, `meminfo`, `tasks`, `uname`) |
-| [syscall](kernel/syscall.md) | int 0x80 syscall dispatcher and userspace ABI |
-| [vmm](kernel/vmm.md) | Per-task page directory and ring-3 memory management |
-| [task](kernel/task.md) | Cooperative round-robin task scheduler |
-
-## Standard library (libc)
+## Standard library
 
 | Document | Description |
 |---|---|
-| [libc overview](libc/index.md) | Overview of the freestanding libc |
+| [libc overview](libc/index.md) | Freestanding libc (`libk.a`) |
 | [stdio](libc/stdio.md) | `printf`, `putchar`, `puts` |
 | [stdlib](libc/stdlib.md) | `abort` |
 | [string](libc/string.md) | Memory and string utilities |
 
-## Makar × Medli
+## Source map
 
-| Document | Description |
-|---|---|
-| [makar-medli](makar-medli.md) | Co-operation roadmap, shared filesystem layout, binary compatibility goals, and planned milestones |
+```
+src/kernel/arch/i386/
+  boot/       Multiboot 2 entry, crti/crtn
+  core/       GDT/IDT, ISR stub, interrupt dispatch
+  mm/         pmm.c, paging.c, vmm.c, heap.c
+  drivers/    serial, keyboard, timer, IDE, ACPI, partition
+  fs/         fat32.c, iso9660.c, procfs.c, vfs.c
+  display/    tty.c, vesa.c + vesa_tty.c, vt.c
+  proc/       task.c + task_asm.S, syscall.c, ring3.S, vix.c, vtty.c
+  shell/      shell.c, shell_cmd_*.c
+  debug/      exception handlers
+src/kernel/kernel/kernel.c    kernel_main
+src/kernel/include/kernel/    public headers
+src/libc/                     freestanding libc → libk.a
+src/userspace/                ring-3 ELF apps
+tests/                        gdb_boot_test.py, ui_test.sh
+```
 
-## Build & run
+## Acknowledgements
 
-| Document | Description |
-|---|---|
-| [Building & running](building.md) | Full build guide - native, Docker scripts, Docker Compose, environment variables, QEMU drive layout |
-| [Testing](testing.md) | Serial smoke test, GDB boot-test suite, debugging with GDB |
-| [WSL2 guide](wsl2.md) | Building and running on Windows via WSL2 + Docker Desktop, including QEMU GUI options |
+Makar draws on the work of many FOSS projects. Full attribution in
+[LICENSES/THANKS.md](https://github.com/Arawn-Davies/Makar/blob/main/LICENSES/THANKS.md)
+and per-file source-level credits. Key influences:
 
-For a quick-start see the repository [README](../README.md).
+- **Linux kernel** (GPLv2) — syscall ABI, ELF loading model, process memory layout
+- **ELKS / FUZIX** (GPLv2) — minimal-libc / crt0 approach; vi-style editor design
+- **CP/M** — terminal-owns-screen philosophy; self-contained program model
+- **musl libc** (MIT) — target libc for the userspace porting roadmap
+- **GRUB** (GPLv2) — bootloader and Multiboot 2 tag format
+- **OSDev wiki** (CC-BY-SA) — cross-compiler setup, paging, descriptor tables

--- a/docs/kernel/asm.md
+++ b/docs/kernel/asm.md
@@ -1,3 +1,8 @@
+---
+title: asm
+parent: Kernel subsystems
+---
+
 # asm - Inline x86 port I/O and CPU-control helpers
 
 **Header:** `kernel/include/kernel/asm.h`

--- a/docs/kernel/debug.md
+++ b/docs/kernel/debug.md
@@ -1,3 +1,8 @@
+---
+title: debug
+parent: Kernel subsystems
+---
+
 # debug - INT 1 / INT 3 debug-exception handlers
 
 **Header:** `kernel/include/kernel/debug.h`  

--- a/docs/kernel/descr_tbl.md
+++ b/docs/kernel/descr_tbl.md
@@ -1,3 +1,8 @@
+---
+title: descr_tbl
+parent: Kernel subsystems
+---
+
 # descr_tbl - GDT and IDT initialisation
 
 **Header:** `kernel/include/kernel/descr_tbl.h`  

--- a/docs/kernel/heap.md
+++ b/docs/kernel/heap.md
@@ -1,3 +1,8 @@
+---
+title: heap
+parent: Kernel subsystems
+---
+
 # heap - Kernel heap allocator
 
 **Header:** `kernel/include/kernel/heap.h`  

--- a/docs/kernel/ide.md
+++ b/docs/kernel/ide.md
@@ -1,3 +1,8 @@
+---
+title: ide
+parent: Kernel subsystems
+---
+
 # IDE Driver (`ide.c` / `ide.h`)
 
 ## Overview

--- a/docs/kernel/index.md
+++ b/docs/kernel/index.md
@@ -1,0 +1,37 @@
+---
+title: Kernel subsystems
+nav_order: 10
+has_children: true
+permalink: /kernel/
+---
+
+# Kernel subsystems
+
+Per-driver and per-module reference documentation for Makar's kernel.
+
+| Document | Description |
+|---|---|
+| [kernel](kernel.md) | Boot entry point and post-boot heartbeat |
+| [system](system.md) | Panic, halt, and assertion helpers |
+| [asm](asm.md) | Inline x86 port I/O and CPU-control helpers |
+| [types](types.md) | Common type aliases and geometric structs |
+| [vga](vga.md) | VGA text-mode constants and low-level helpers |
+| [tty](tty.md) | VGA text terminal driver |
+| [serial](serial.md) | Serial port (UART) driver |
+| [descr_tbl](descr_tbl.md) | GDT and IDT initialisation |
+| [isr](isr.md) | Interrupt and IRQ dispatch |
+| [timer](timer.md) | PIT timer driver |
+| [pmm](pmm.md) | Physical memory manager |
+| [paging](paging.md) | Paging and virtual memory |
+| [heap](heap.md) | Kernel heap allocator |
+| [vesa](vesa.md) | VESA linear framebuffer |
+| [vesa_tty](vesa_tty.md) | VESA bitmap-font text renderer |
+| [vt](vt.md) | Per-TTY logical character grid |
+| [vtty](vtty.md) | Virtual TTY manager (Alt+Fn, focus, status bar) |
+| [debug](debug.md) | Debug-exception handlers |
+| [multiboot](multiboot.md) | Multiboot 2 structures |
+| [keyboard](keyboard.md) | Layered PS/2 keyboard driver |
+| [ide](ide.md) | ATA/IDE PIO driver |
+| [partition](partition.md) | MBR + GPT partition tables |
+| [procfs](procfs.md) | Synthetic `/proc` filesystem |
+| [shell](shell.md) | Interactive multi-TTY kernel command shell |

--- a/docs/kernel/isr.md
+++ b/docs/kernel/isr.md
@@ -1,3 +1,8 @@
+---
+title: isr
+parent: Kernel subsystems
+---
+
 # isr - Interrupt and IRQ dispatch
 
 **Header:** `kernel/include/kernel/isr.h`  

--- a/docs/kernel/kernel.md
+++ b/docs/kernel/kernel.md
@@ -1,3 +1,8 @@
+---
+title: kernel
+parent: Kernel subsystems
+---
+
 # kernel - Boot entry point
 
 **Source:** `kernel/kernel/kernel.c`

--- a/docs/kernel/keyboard.md
+++ b/docs/kernel/keyboard.md
@@ -1,3 +1,8 @@
+---
+title: keyboard
+parent: Kernel subsystems
+---
+
 # keyboard - PS/2 keyboard driver
 
 **Header:** `src/kernel/include/kernel/keyboard.h`

--- a/docs/kernel/multiboot.md
+++ b/docs/kernel/multiboot.md
@@ -1,3 +1,8 @@
+---
+title: multiboot
+parent: Kernel subsystems
+---
+
 # multiboot - Multiboot 2 structure definitions
 
 **Header:** `kernel/include/kernel/multiboot.h`

--- a/docs/kernel/paging.md
+++ b/docs/kernel/paging.md
@@ -1,3 +1,8 @@
+---
+title: paging
+parent: Kernel subsystems
+---
+
 # paging - Paging and virtual memory
 
 **Header:** `kernel/include/kernel/paging.h`  

--- a/docs/kernel/partition.md
+++ b/docs/kernel/partition.md
@@ -1,3 +1,8 @@
+---
+title: partition
+parent: Kernel subsystems
+---
+
 # Partition Driver (`partition.c` / `partition.h`)
 
 ## Overview

--- a/docs/kernel/pmm.md
+++ b/docs/kernel/pmm.md
@@ -1,3 +1,8 @@
+---
+title: pmm
+parent: Kernel subsystems
+---
+
 # pmm - Physical memory manager
 
 **Header:** `kernel/include/kernel/pmm.h`  

--- a/docs/kernel/procfs.md
+++ b/docs/kernel/procfs.md
@@ -1,3 +1,8 @@
+---
+title: procfs
+parent: Kernel subsystems
+---
+
 # procfs - synthetic /proc filesystem
 
 `src/kernel/include/kernel/procfs.h` + `src/kernel/arch/i386/fs/procfs.c`.

--- a/docs/kernel/serial.md
+++ b/docs/kernel/serial.md
@@ -1,3 +1,8 @@
+---
+title: serial
+parent: Kernel subsystems
+---
+
 # serial - Serial port (UART) driver
 
 **Header:** `kernel/include/kernel/serial.h`  

--- a/docs/kernel/shell.md
+++ b/docs/kernel/shell.md
@@ -1,3 +1,8 @@
+---
+title: shell
+parent: Kernel subsystems
+---
+
 # shell - Interactive kernel command shell
 
 **Header:** `kernel/include/kernel/shell.h`  

--- a/docs/kernel/system.md
+++ b/docs/kernel/system.md
@@ -1,3 +1,8 @@
+---
+title: system
+parent: Kernel subsystems
+---
+
 # system - Panic, halt, and assertion helpers
 
 **Headers:** `kernel/include/kernel/system.h`  

--- a/docs/kernel/timer.md
+++ b/docs/kernel/timer.md
@@ -1,3 +1,8 @@
+---
+title: timer
+parent: Kernel subsystems
+---
+
 # timer - PIT timer driver and `ksleep`
 
 **Header:** `kernel/include/kernel/timer.h`  

--- a/docs/kernel/tty.md
+++ b/docs/kernel/tty.md
@@ -1,3 +1,8 @@
+---
+title: tty
+parent: Kernel subsystems
+---
+
 # tty - VGA text terminal driver
 
 **Header:** `kernel/include/kernel/tty.h`  

--- a/docs/kernel/types.md
+++ b/docs/kernel/types.md
@@ -1,3 +1,8 @@
+---
+title: types
+parent: Kernel subsystems
+---
+
 # types - Common type aliases and geometric structs
 
 **Header:** `kernel/include/kernel/types.h`

--- a/docs/kernel/vesa.md
+++ b/docs/kernel/vesa.md
@@ -1,3 +1,8 @@
+---
+title: vesa
+parent: Kernel subsystems
+---
+
 # vesa - VESA linear framebuffer driver
 
 **Header:** `kernel/include/kernel/vesa.h`  

--- a/docs/kernel/vesa_tty.md
+++ b/docs/kernel/vesa_tty.md
@@ -1,3 +1,8 @@
+---
+title: vesa_tty
+parent: Kernel subsystems
+---
+
 # vesa_tty - VESA bitmap-font text renderer
 
 **Header:** `kernel/include/kernel/vesa_tty.h`  

--- a/docs/kernel/vga.md
+++ b/docs/kernel/vga.md
@@ -1,3 +1,8 @@
+---
+title: vga
+parent: Kernel subsystems
+---
+
 # vga - VGA text-mode constants and low-level helpers
 
 **Header:** `kernel/include/kernel/vga.h`

--- a/docs/kernel/vt.md
+++ b/docs/kernel/vt.md
@@ -1,3 +1,8 @@
+---
+title: vt
+parent: Kernel subsystems
+---
+
 # vt - virtual console backing grid
 
 `src/kernel/include/kernel/vt.h` + `src/kernel/arch/i386/display/vt.c`.

--- a/docs/kernel/vtty.md
+++ b/docs/kernel/vtty.md
@@ -1,3 +1,8 @@
+---
+title: vtty
+parent: Kernel subsystems
+---
+
 # vtty - virtual TTY manager
 
 `src/kernel/include/kernel/vtty.h` + `src/kernel/arch/i386/proc/vtty.c`.

--- a/docs/libc/index.md
+++ b/docs/libc/index.md
@@ -1,3 +1,10 @@
+---
+title: libc
+nav_order: 11
+has_children: true
+permalink: /libc/
+---
+
 # libc - Freestanding standard library
 
 Makar ships a minimal freestanding C library (`libc/`) that provides just

--- a/docs/libc/stdio.md
+++ b/docs/libc/stdio.md
@@ -1,3 +1,8 @@
+---
+title: stdio
+parent: libc
+---
+
 # stdio - Standard I/O
 
 **Header:** `libc/include/stdio.h`  

--- a/docs/libc/stdlib.md
+++ b/docs/libc/stdlib.md
@@ -1,3 +1,8 @@
+---
+title: stdlib
+parent: libc
+---
+
 # stdlib - Standard utilities
 
 **Header:** `libc/include/stdlib.h`  

--- a/docs/libc/string.md
+++ b/docs/libc/string.md
@@ -1,3 +1,8 @@
+---
+title: string
+parent: libc
+---
+
 # string - Memory and string utilities
 
 **Header:** `libc/include/string.h`  

--- a/docs/makar-medli.md
+++ b/docs/makar-medli.md
@@ -1,3 +1,8 @@
+---
+title: Makar × Medli
+nav_order: 5
+---
+
 # Makar × Medli — Co-operation roadmap
 
 Makar and [Medli](https://github.com/Arawn-Davies/Medli) are two

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,8 @@
+---
+title: Testing
+nav_order: 3
+---
+
 # Testing Makar
 
 This guide covers the automated test infrastructure. For build and run

--- a/docs/userland-libc.md
+++ b/docs/userland-libc.md
@@ -1,3 +1,8 @@
+---
+title: Userland libc
+nav_order: 4
+---
+
 # Userland libc for Makar
 
 This document covers how to build a freestanding libc for Makar userspace and

--- a/docs/wsl2.md
+++ b/docs/wsl2.md
@@ -1,3 +1,8 @@
+---
+title: WSL2
+nav_order: 6
+---
+
 # Building Makar on WSL2
 
 This guide explains how to build (and optionally run) Makar from a WSL2


### PR DESCRIPTION
## Summary

GitHub Pages is now serving from \`/docs\` on \`main\`. This PR wires up
a proper Jekyll site over the existing markdown so the docs become an
explorable mini-handbook instead of one-file-at-a-time on the GH file UI.

**Live URL** (post-merge): http://arawn-davies.co.uk/Makar/

## What's in it

- \`docs/_config.yml\` — Jekyll config using the \`just-the-docs\` remote
  theme: sidebar navigation, search box, light/dark/auto colour-scheme
  toggle in the header, aux links to the GitHub repo + sibling Medli.
- Front-matter on every doc so the sidebar groups properly:
  - Top-level docs (\`building\`, \`testing\`, \`userland-libc\`,
    \`makar-medli\`, \`wsl2\`, \`history\`) get \`nav_order\`.
  - \`kernel/*.md\` declare \`parent: Kernel subsystems\` and roll up
    under \`docs/kernel/index.md\`.
  - \`libc/*.md\` declare \`parent: libc\` under \`docs/libc/index.md\`.
- \`docs/index.md\` rewritten as a real landing page — banner, current-
  state table, kernel/libc reference, source map, FOSS thanks. Dropped
  the stale 'C / C++' claim (Makar has only ever been straight C).
- \`docs/kernel/index.md\` added as the kernel-subsystems section index.
- \`docs/history.md\` — diary-style log of the project arc from the very
  first commit (2019-08-25) through v0.5.0 (May 2026), with PR numbers
  and dates lifted from the git log. Forward-looking 'Next' section
  links the slice queue in CLAUDE.md.

## Why just-the-docs

You asked for dark-mode support. Cayman / Slate / Hacker are GitHub
Pages' bundled themes but all are light-only or have no toggle.
just-the-docs is shaped for documentation: sidebar nav, search,
proper light/dark/auto via \`color_scheme: auto\` plus the in-header
toggle. Pulled as a remote theme so we're not forking it.

## Test plan

- [x] \`gh api repos/Arawn-Davies/Makar/pages\` returns \`source.path: /docs\` and \`status: built\`
- [ ] After merge, http://arawn-davies.co.uk/Makar/ renders the new landing with the dark-mode toggle in the header
- [ ] Sidebar collapses 'Kernel subsystems' and 'libc' as parent groups
- [ ] \`docs/history.md\` shows under 'History' in nav order 7