### PR TITLE
feat(vfs): per-task cwd authoritative (slice 15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Round-robin scheduler with timer-driven preemption (PIT 100 Hz; IRQ 0 yields eve
 
 Per-task state (`task_t` in `kernel/task.h`):
 - `pid` - monotonically assigned (idle = 1, others from 2)
-- `cwd[VFS_PATH_MAX]` - inherited from creator; not yet authoritative (VFS still uses `s_cwd`)
+- `cwd[VFS_PATH_MAX]` - authoritative per-task working directory; inherited from creator on `task_create`; `vfs_getcwd()` / `vfs_cd()` route here through `task_current()`. Pre-tasking-init, `vfs.c` falls back to `s_boot_cwd`, which `tasking_init` then hands off to `idle->cwd`. VT0 at `/proc` and VT1 at `/cdrom/apps` are fully independent.
 - `tty` - TTY index (TASK_TTY_NONE for unbound); not yet authoritative (vtty.c still uses `vtty_tasks[]`)
 - `sig_pending` / `sig_mask`  Linux-style signal bitmasks (subsystem to follow)
 - `fd_table` - per-task fd table (`kernel/fd.h`); fds 0/1/2 pre-bound to stdin/stdout/stderr at `task_create`
@@ -314,7 +314,7 @@ Tracked here, pulled into branches one at a time so each PR stays focused.
 | 5 | **Keyboard rewrite** - full PS/2 set-1 + e0, layered decoder (scancode→keycode→ASCII/sentinel→router), IRQ-driven per-TTY rings with proper SPSC memory ordering, strict make/break separation, modifier state at decoder, key repeat / rollover / lost-IRQ recovery, `unsigned char` end-to-end (no sign-extension hazard for sentinel compares), escape-clean sentinels | ✅ shipped (#124) |
 | 5b | **Keyboard hardening** - `unsigned char` audit, typematic-repeat filter for modifiers, PS/2 LED sync, boot-time LED state read | ✅ shipped (#127) |
 | 6 | **Test-infra cleanup** - ccache, single-kernel/two-ISO, build-once fan-out CI, KVM gate | ✅ shipped (#125) |
-| 7 | **Per-task consumer migration** - vtty `task->tty` authoritative (drop `vtty_tasks[]` parallel array). VFS `task->cwd` and real per-task FD table remain on the queue. | ✅ partial (vtty done) |
+| 7 | **Per-task consumer migration** - vtty `task->tty` authoritative (drop `vtty_tasks[]` parallel array). FD table done (slice 14), cwd done (slice 15). | ✅ complete |
 | 8 | **Linux-style signal subsystem** - full sigaction table, `kill()` syscall, htop-style picker | ⏭ |
 | 9 | **Preemption hardening** - interrupt-safe `schedule()`, per-task tick accounting, runtime-tunable quantum, busy-loop ktest | ⏭ |
 | 10 | **Per-TTY screen buffers** - `vt_buf_t` backing grid per TTY, write-through to FB only when focused, repaint on Alt+Fn (deferred out of IRQ). tmux-style status bar at bottom row. `/proc` synthetic FS with `cpuinfo/meminfo/tasks/uname`. VGA-text fallback path stays on shared buffer (deferred). | ✅ shipped (this PR) |
@@ -322,7 +322,7 @@ Tracked here, pulled into branches one at a time so each PR stays focused.
 | 12 | **fork() readiness** - PD clone (CoW), fd dup, PID alloc, return-value split | ⏭ |
 | 13 | **UTF-8 terminal** with ASCII fallback / runtime mode switch | ⏭ deferred |
 | 14 | **Per-task FD table** - replace opaque `fd_table` placeholder with a real `fd_table_t` (kernel/fd.h); fds 0/1/2 pre-bound, SYS_READ/WRITE/OPEN/CLOSE/LSEEK route through the calling task's table. Foundation for pipe(2)/dup(2) and fork's fd dup. | ✅ shipped (this PR) |
-| 15 | **VFS `task->cwd` authoritative** - drop the `s_cwd` global in `vfs.c`; resolve relative paths against the calling task's cwd | ⏭ |
+| 15 | **VFS `task->cwd` authoritative** - drop the `s_cwd` global in `vfs.c`; resolve relative paths against the calling task's cwd | ✅ shipped (this PR) |
 | 16 | **VGA-fallback per-TTY** - route `tty.c` writes through `vt_buf` so VGA-text mode gets the same per-TTY isolation that VESA already has | ⏭ |
 
 ### Userspace / libc porting

--- a/docs/sideport-to-medli.md
+++ b/docs/sideport-to-medli.md
@@ -1,0 +1,211 @@
+---
+title: Sideporting to Medli
+nav_order: 6
+---
+
+# Sideporting Makar features to Medli
+
+**"Sideporting"** — the cousin of backporting: instead of carrying a fix
+across versions, we carry a feature *sideways* between sibling projects
+that share the same UX target but live on different stacks.
+
+- [Makar](https://github.com/Arawn-Davies/Makar) — bare-metal C on
+  i686-elf, GRUB Multiboot 2, manual paging/IRQs.
+- [Medli](https://github.com/Arawn-Davies/Medli) — C# on
+  [Cosmos](https://github.com/CosmosOS/Cosmos), which uses IL2CPU to
+  compile CIL → x86 and owns the boot, kernel, GC, IRQs, and memory.
+
+The two never share binaries.  What they *can* share is **behaviour,
+vocabulary, and visible UX** — the things a user notices first.  Each
+candidate below is rated on how cleanly it crosses the
+C↔C#/managed-kernel boundary.
+
+---
+
+## Sideport scoring rubric
+
+| Rating | Meaning |
+|---|---|
+| Easy | Logic is pure data-shuffling. Translate idiom-for-idiom in C#. |
+| Moderate | Needs a Cosmos / IL2CPU equivalent (timer, IRQ hook, ATA) that already exists in Cosmos. |
+| Hard | Requires a Cosmos plugin or extending IL2CPU. Doable, but a real subproject. |
+| Blocked | Tied to bare-metal mechanics Cosmos owns (paging, ring switches, custom GDT/IDT). Not portable; reinvent the *outcome* differently. |
+
+---
+
+## High-value candidates
+
+### 1. Shell UX — Easy
+
+Makar shell features that are pure string-manipulation + line-buffer
+state and would translate directly to Medli's existing C# shell:
+
+- **Inline editing** (cursor movement, insert at point) — `src/kernel/arch/i386/shell/shell.c`.
+- **History ring + Up/Down navigation** + `!!` recall (16 entries, echo-then-run).
+- **Tab completion** — two-phase (command name first, then path) with the unique-match space, ambiguity-list, and visible-feedback semantics from `feat/vics-vim-polish` (#130).
+- **Wildcard glob expansion** across VFS (#129) — `src/kernel/arch/i386/shell/shell_glob.c`. Pattern is `*`/`?`/`[…]` against a directory listing; trivially expressible in C# using `Directory.EnumerateFileSystemEntries`-style enumeration over the Cosmos VFS.
+- **Prompt format** — `root@<host> <cwd>~> ` (with the distinctive `~>` suffix that doubles as a reliable scrape marker).
+- **`Ctrl+C` abort-input** semantics (clear line, print `^C`, redraw prompt).
+
+These are pure ergonomic ports.  Pick one feature per PR; each lands as
+~50-200 lines of C#.
+
+### 2. Command vocabulary — Easy
+
+Aligning the two shells on the same builtins makes the projects feel
+like one OS.  Makar today has: `ls`, `cd`, `cat`, `mkdir`, `rm`,
+`rmdir`, `mv`, `cp`, `mount`, `umount`, `clear`, `uptime`, `setmode`,
+`lsman`, `man`, `exec`, `ktest`, `diskinfo`.
+
+Cross-check against Medli's command set; for each that exists on both,
+pick the Makar name as canonical (because it tracks
+[POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/)).  Names
+that diverge today (Medli's DOS-ish path separator is the canonical
+example) should converge towards the Makar/Unix spelling at the *shell*
+layer, even if storage stays DOS-style underneath.
+
+### 3. `/proc` synthetic filesystem — Easy
+
+Makar's `/proc` (#129) is just an enum-dispatched switch:
+`cpuinfo`, `meminfo`, `tasks`, `uname`, generated on demand by
+`procfs_read_file()`.  No on-disk state.
+
+In Medli this is a `VirtualFolder`-style class that returns a `byte[]`
+per entry, computed from the Cosmos kernel's existing CPU/memory/task
+APIs.  Filesystem readers (`cat`, `more`) see it as a normal file.
+The exact `cpuinfo` field layout (vendor_id, model name, flags) is
+worth keeping byte-compatible with Linux so any tooling that scrapes
+either OS gets the same fields.
+
+### 4. VIX editor UX — Moderate
+
+VIX (Makar's vi-style editor, ELKS/FUZIX lineage) is already
+philosophically Medli's `vics`.  The *behavior* is portable:
+
+- Pane-derived terminal size (`vesa_pane_t` ↔ whatever Medli's TTY
+  abstraction is).
+- Modal: normal / insert / command-line.
+- Movement: `h j k l`, `w b`, `0 $`, `gg G`.
+- Persistent on-screen `:` command line that knows about `:w`, `:q`,
+  `:wq`, `:q!`.
+- Optional vim-polish behaviours from #130.
+
+What does *not* port: Makar's `SYS_PUTCH_AT` / `SYS_SET_CURSOR` syscalls
+and the ring-3 ELF model.  Medli runs the editor in-process under
+Cosmos, so it can call the Cosmos terminal API directly — simpler, not
+harder.
+
+### 5. Layered keyboard model — Moderate
+
+The slice 5/5b layered driver — **scancode → keycode → ASCII/sentinel
+→ per-TTY ring** — is genuinely a good design and Medli would benefit.
+The C code (`src/kernel/arch/i386/drivers/keyboard.c`) is reference
+material, not a literal port.  What matters in Medli:
+
+- Decoder owns modifier state; consumers see only logical events.
+- Sentinel bytes for non-ASCII keys (arrows, F-keys, modifier change)
+  use the high half of the byte range so an `unsigned char` cast can't
+  sign-extend them into negative ints.  Pin the exact range
+  (`0x80`-`0x8F`) so future userspace tooling sees identical events on
+  both OSes.
+- IRQ handler enqueues, consumer dequeues — single-producer / single-
+  consumer ring per TTY.
+
+Cosmos already owns the PS/2 IRQ in C#; the port is "rewrite the
+decoder as a C# state machine that emits the same sentinel events."
+
+### 6. Loading-screen + boot-time ktest pattern — Moderate
+
+The "loading spinner ticks alongside background self-tests; bar only
+advances after each suite passes; FAIL→panic, PASS→silent" pattern
+(#128) is a generally good boot UX.  The Medli equivalent is a Cosmos
+boot screen running self-checks against the Cosmos kernel's own
+internals (heap, GC handle table, file-system mount status).  Same
+*shape*, different checks.
+
+---
+
+## Things that can't be sideported (and why)
+
+### Ring-3 ELF userspace — Blocked
+
+Makar's `iret` to user mode, per-task page directory, ELF32 loader,
+`int 0x80` syscall ABI, and `crt0.S`/`link.ld` toolchain are all tied
+to running un-managed code on real ring transitions.  Cosmos owns the
+ring transitions and runs everything as managed CIL after IL2CPU.  The
+equivalent in Medli is **AppDomain-like isolation between managed
+assemblies**, not ring 3.
+
+Don't try to sideport `exec(2)` — design Medli's app-launch UX to look
+identical (`exec <name>`, argv, exit status) but back it with managed
+assembly loading.
+
+### Per-task page directory + reaper — Blocked
+
+The slice 1 reaper pattern (defer-free a dead task's user PD until CR3
+has switched away) is specific to manual paging.  Cosmos's GC handles
+the equivalent reclamation problem differently — no port needed.
+
+### `SYS_BRK` / `SYS_MMAP` / manual heap extension — Blocked
+
+The libc-porting work in `docs/userland-libc.md` exists because Makar
+needs to feed musl/uClibc-ng a real syscall surface.  Medli has the
+.NET BCL — `String`, `Stream`, `Dictionary` are already there.  The
+sideport here is *not* a syscall but **shared semantics**: if Makar
+ships a userland `ls` whose argv parsing matches a Medli `ls`, that's
+the win.
+
+### GRUB Multiboot 2 boot path — Blocked
+
+Cosmos builds its own bootloader.  No sideport.
+
+---
+
+## Things to sideport *from* Medli *into* Makar
+
+Sideporting goes both ways.  Medli is older and has features Makar
+hasn't built yet:
+
+- **User account system** — Makar deferred this until signals + per-task
+  FD table landed (#134 / this PR closed both).  Medli's account model
+  is the reference: log-in prompt, per-user home dir, prompt
+  user-segment (`<user>@<host>`).  Makar already echoes `root@makar` —
+  the structure is there, just no second user.
+- **Daemon / service model** — Medli has `Daemon` objects with
+  registration/start/stop.  Makar currently has bare preemptive kernel
+  tasks; promoting them to "named services with a status/restart
+  command" is the obvious port.
+- **Anything in Medli's docs that has already worked through "what does
+  a user expect here?"** for shared territory (mount UX, error
+  message wording, history behaviour quirks).
+
+---
+
+## Recommended first sideport
+
+If picking one to start: **wildcard glob + tab completion semantics**
+(#130 in Makar).  Reasons:
+
+1. Pure logic — no Cosmos plugin needed.
+2. Immediately visible to anyone using either shell.
+3. The Makar test surface (`tests/ui_test.sh` scenarios `glob_proc`,
+   `tab_complete_path`) is a literal spec — a Medli C# port can mirror
+   the same assertions against its own shell harness, giving both
+   projects a single behaviour contract that's been wire-tested.
+
+---
+
+## Process
+
+Each sideport should be one PR per side, both linking to a single
+tracking issue ("Sideport: wildcard glob").  The PR description on each
+side cites the other.  Avoid "shared code submodule" or any compile-
+time coupling — the projects gain more from disciplined parallelism
+than from forced sharing.
+
+## See also
+
+- [Makar × Medli — Co-operation roadmap](makar-medli.html) — broader
+  positioning of the two projects.
+- [Userland libc porting](userland-libc.html) — Makar-specific syscall
+  work that frees the shell to move userside.

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -7,7 +7,13 @@
  *   /cdrom/…   ISO9660 CD-ROM
  *
  * All VFS paths are absolute after normalisation.  Relative paths are
- * resolved against the current working directory (s_cwd).
+ * resolved against the calling task's cwd (task_current()->cwd).
+ *
+ * During boot (before tasking_init), there is no task_current().  Writers
+ * fall back to s_boot_cwd, which is then handed off to idle->cwd inside
+ * tasking_init via vfs_getcwd().  Post-tasking, every cwd read/write is
+ * per-task, so VT0 may sit in /hd/apps while VT1 sits in /cdrom/boot
+ * without cross-contamination.
  *
  * Path normalisation handles:
  *   - Multiple consecutive '/' characters  → collapsed to one
@@ -23,6 +29,7 @@
 #include <kernel/partition.h>
 #include <kernel/tty.h>
 #include <kernel/heap.h>
+#include <kernel/task.h>
 #include <string.h>
 #include <stddef.h>
 
@@ -30,9 +37,24 @@
  * Internal state
  * ---------------------------------------------------------------------- */
 
-static char s_cwd[VFS_PATH_MAX];   /* current working directory  */
+/*
+ * Pre-tasking-init scratch cwd.  vfs_init() / vfs_auto_mount() run before
+ * tasking_init() and need somewhere to record the initial cwd.  Once idle
+ * exists, cwd_buf() switches to task_current()->cwd and this buffer becomes
+ * the source for the one-time handoff inside tasking_init.
+ */
+static char s_boot_cwd[VFS_PATH_MAX] = "/";
 static int  s_cdrom_drive = -1;    /* IDE drive index of CD-ROM, -1 = none */
 static uint32_t s_boot_biosdev = 0xFFu; /* BIOS drive we booted from (0xFF = unknown) */
+
+/* Resolve the cwd backing store for the calling context.  Pre-tasking
+ * (vfs_init, vfs_auto_mount) returns the boot scratch buffer; once tasking
+ * is up every reader and writer hits the calling task's own cwd field. */
+static char *cwd_buf(void)
+{
+    task_t *t = task_current();
+    return t ? t->cwd : s_boot_cwd;
+}
 
 /* -------------------------------------------------------------------------
  * Filesystem identifiers returned by vfs_route()
@@ -110,14 +132,16 @@ static void path_normalize(const char *in, char *out, int outsz)
 /* -------------------------------------------------------------------------
  * path_resolve – resolve 'path' to an absolute VFS path stored in 'out'.
  *
- * Relative paths are joined to s_cwd.  NULL or empty path → CWD.
+ * Relative paths are joined to the calling task's cwd (or the boot scratch
+ * cwd if invoked before tasking_init).  NULL or empty path → CWD.
  * ---------------------------------------------------------------------- */
 static void path_resolve(const char *path, char *out)
 {
     char tmp[VFS_PATH_MAX * 2];
+    const char *cwd = cwd_buf();
 
     if (!path || !*path) {
-        path_normalize(s_cwd, out, VFS_PATH_MAX);
+        path_normalize(cwd, out, VFS_PATH_MAX);
         return;
     }
 
@@ -127,11 +151,11 @@ static void path_resolve(const char *path, char *out)
     }
 
     /* Relative: prepend CWD. */
-    int clen = (int)strlen(s_cwd);
+    int clen = (int)strlen(cwd);
     int plen = (int)strlen(path);
     /* Need clen + '/' + plen + NUL bytes total. */
     if (clen + 1 + plen + 1 <= (int)sizeof(tmp)) {
-        memcpy(tmp, s_cwd, (size_t)clen);
+        memcpy(tmp, cwd, (size_t)clen);
         tmp[clen] = '/';
         memcpy(tmp + clen + 1, path, (size_t)(plen + 1));
     } else {
@@ -200,8 +224,8 @@ static void ls_root(void)
 
 void vfs_init(void)
 {
-    s_cwd[0] = '/';
-    s_cwd[1] = '\0';
+    s_boot_cwd[0] = '/';
+    s_boot_cwd[1] = '\0';
     s_cdrom_drive = -1;
 
     /* Scan IDE bus for an ATAPI drive that contains a valid ISO9660 volume. */
@@ -218,37 +242,66 @@ void vfs_init(void)
 
 const char *vfs_getcwd(void)
 {
-    return s_cwd;
+    return cwd_buf();
 }
 
-void vfs_notify_hd_mounted(void)
+/*
+ * vfs_notify_hd_mounted / _unmounted / _cdrom_ejected
+ *
+ * Mount-state transitions can leave individual tasks parked under a mount
+ * point that just disappeared (or, for the hd-mounted case, sitting on "/"
+ * when /hd just became browsable).  Walk every live task and fix up each
+ * one's cwd independently - using cwd_buf() here would only mutate the
+ * caller's cwd, which is rarely the task that needs the adjustment.
+ *
+ * Pre-tasking-init this loop is a no-op (task_get returns NULL), and
+ * s_boot_cwd is rewritten directly so the same rules apply during the
+ * vfs_init / vfs_auto_mount window.
+ */
+static void fixup_cwd_hd_mounted(char *cwd)
 {
-    if (strcmp(s_cwd, "/") == 0)
-        memcpy(s_cwd, "/hd", 4);  /* includes NUL */
+    if (strcmp(cwd, "/") == 0)
+        memcpy(cwd, "/hd", 4);  /* includes NUL */
 }
 
-void vfs_notify_hd_unmounted(void)
+static void fixup_cwd_hd_unmounted(char *cwd)
 {
-    /* Reset CWD to "/" if it was somewhere under "/hd". */
-    if (s_cwd[1] == 'h' && s_cwd[2] == 'd' &&
-        (s_cwd[3] == '/' || s_cwd[3] == '\0')) {
-        s_cwd[0] = '/';
-        s_cwd[1] = '\0';
+    if (cwd[1] == 'h' && cwd[2] == 'd' &&
+        (cwd[3] == '/' || cwd[3] == '\0')) {
+        cwd[0] = '/';
+        cwd[1] = '\0';
     }
 }
+
+static void fixup_cwd_cdrom_ejected(char *cwd)
+{
+    if (cwd[1] == 'c' && cwd[2] == 'd' && cwd[3] == 'r' &&
+        cwd[4] == 'o' && cwd[5] == 'm' &&
+        (cwd[6] == '/' || cwd[6] == '\0')) {
+        cwd[0] = '/';
+        cwd[1] = '\0';
+    }
+}
+
+typedef void (*cwd_fixup_fn)(char *);
+
+static void apply_cwd_fixup(cwd_fixup_fn fn)
+{
+    fn(s_boot_cwd);
+    for (int i = 0; ; i++) {
+        task_t *t = task_get(i);
+        if (!t) break;
+        fn(t->cwd);
+    }
+}
+
+void vfs_notify_hd_mounted(void)   { apply_cwd_fixup(fixup_cwd_hd_mounted); }
+void vfs_notify_hd_unmounted(void) { apply_cwd_fixup(fixup_cwd_hd_unmounted); }
 
 void vfs_notify_cdrom_ejected(void)
 {
-    /* Mark the CD-ROM as gone so /cdrom paths are no longer served. */
     s_cdrom_drive = -1;
-
-    /* Reset CWD to "/" if it was somewhere under "/cdrom". */
-    if (s_cwd[1] == 'c' && s_cwd[2] == 'd' && s_cwd[3] == 'r' &&
-        s_cwd[4] == 'o' && s_cwd[5] == 'm' &&
-        (s_cwd[6] == '/' || s_cwd[6] == '\0')) {
-        s_cwd[0] = '/';
-        s_cwd[1] = '\0';
-    }
+    apply_cwd_fixup(fixup_cwd_cdrom_ejected);
 }
 
 /* -------------------------------------------------------------------------
@@ -344,9 +397,10 @@ void vfs_auto_mount(void)
     /* Report CD-ROM status (always registered by vfs_init if present). */
     if (s_cdrom_drive >= 0) {
         t_writestring("CD-ROM detected, accessible at /cdrom\n");
-        /* If no HDD was mounted, navigate CWD to /cdrom. */
+        /* If no HDD was mounted, navigate CWD to /cdrom.  Pre-tasking, this
+         * lands in s_boot_cwd; tasking_init then seeds idle->cwd from it. */
         if (!hd_mounted)
-            memcpy(s_cwd, "/cdrom", 7);   /* 7 includes the NUL terminator */
+            memcpy(cwd_buf(), "/cdrom", 7);   /* 7 includes NUL */
     }
 
     if (!hd_mounted && s_cdrom_drive < 0) {
@@ -401,11 +455,12 @@ int vfs_cd(const char *path)
 
     const char *drv;
     int fs = vfs_route(abs, &drv);
+    char *cwd = cwd_buf();
 
     switch (fs) {
     case VFS_FS_ROOT:
         /* Always valid. */
-        memcpy(s_cwd, abs, (size_t)(strlen(abs) + 1u));
+        memcpy(cwd, abs, (size_t)(strlen(abs) + 1u));
         return 0;
 
     case VFS_FS_HD:
@@ -418,8 +473,8 @@ int vfs_cd(const char *path)
             t_writestring("cd: directory not found\n");
             return -1;
         }
-        strncpy(s_cwd, abs, VFS_PATH_MAX - 1);
-        s_cwd[VFS_PATH_MAX - 1] = '\0';
+        strncpy(cwd, abs, VFS_PATH_MAX - 1);
+        cwd[VFS_PATH_MAX - 1] = '\0';
         return 0;
 
     case VFS_FS_CDROM:
@@ -428,16 +483,16 @@ int vfs_cd(const char *path)
             return -1;
         }
         /* No cheap directory check for ISO9660; optimistically update CWD. */
-        strncpy(s_cwd, abs, VFS_PATH_MAX - 1);
-        s_cwd[VFS_PATH_MAX - 1] = '\0';
+        strncpy(cwd, abs, VFS_PATH_MAX - 1);
+        cwd[VFS_PATH_MAX - 1] = '\0';
         return 0;
 
     case VFS_FS_PROC:
         /* /proc is flat: only "/proc" itself is a directory.  Reject
          * any deeper cd. */
         if (drv[0] == '/' && drv[1] == '\0') {
-            strncpy(s_cwd, abs, VFS_PATH_MAX - 1);
-            s_cwd[VFS_PATH_MAX - 1] = '\0';
+            strncpy(cwd, abs, VFS_PATH_MAX - 1);
+            cwd[VFS_PATH_MAX - 1] = '\0';
             return 0;
         }
         t_writestring("cd: not a directory\n");
@@ -643,7 +698,7 @@ int vfs_complete(const char *dir, const char *prefix,
                  fat32_complete_cb_t cb, void *ctx)
 {
     char abs[VFS_PATH_MAX];
-    path_resolve(dir ? dir : s_cwd, abs);
+    path_resolve(dir ? dir : cwd_buf(), abs);
 
     const char *drv;
     switch (vfs_route(abs, &drv)) {

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -556,6 +556,73 @@ static void test_fd_table(void)
 }
 
 /* ---------------------------------------------------------------------------
+ * Suite: per-task cwd
+ *
+ * Slice 15 migrated the VFS cwd off the global s_cwd onto task_t.cwd.
+ * These asserts pin the migration:
+ *   - vfs_getcwd() returns the calling task's cwd (pointer identity).
+ *   - vfs_cd() writes through to task_current()->cwd.
+ *   - Mutating a peer task's cwd does NOT change vfs_getcwd().
+ *   - Round-trip restores the original cwd cleanly.
+ * --------------------------------------------------------------------------- */
+static void test_cwd(void)
+{
+    ktest_begin("cwd",
+                "per-task cwd: vfs_getcwd routes to task_current, vfs_cd writes "
+                "through, peer-task cwd is isolated");
+
+    task_t *cur = task_current();
+    KTEST_ASSERT(cur != NULL);
+
+    /* vfs_getcwd points into the calling task's storage. */
+    KTEST_ASSERT(vfs_getcwd() == cur->cwd);
+
+    /* Snapshot so we can restore. */
+    char saved[VFS_PATH_MAX];
+    size_t n = strlen(cur->cwd);
+    if (n >= VFS_PATH_MAX) n = VFS_PATH_MAX - 1;
+    memcpy(saved, cur->cwd, n);
+    saved[n] = '\0';
+
+    /* Write through: vfs_cd("/") lands in cur->cwd. */
+    KTEST_ASSERT(vfs_cd("/") == 0);
+    KTEST_ASSERT(strcmp(cur->cwd, "/") == 0);
+    KTEST_ASSERT(strcmp(vfs_getcwd(), "/") == 0);
+
+    /* Isolation: poke a peer task's cwd; vfs_getcwd must not reflect it.
+     * task_get(0) is idle; if we're not idle, use index 0 as the peer.
+     * If we *are* idle (test_mode boot), reach for any other live slot.
+     * Falling back to skip if no peer exists keeps the test safe in
+     * minimal boot configurations. */
+    task_t *peer = NULL;
+    for (int i = 0; ; i++) {
+        task_t *t = task_get(i);
+        if (!t) break;
+        if (t != cur) { peer = t; break; }
+    }
+    if (peer) {
+        char peer_saved[VFS_PATH_MAX];
+        size_t pn = strlen(peer->cwd);
+        if (pn >= VFS_PATH_MAX) pn = VFS_PATH_MAX - 1;
+        memcpy(peer_saved, peer->cwd, pn);
+        peer_saved[pn] = '\0';
+
+        memcpy(peer->cwd, "/cdrom", 7);
+        KTEST_ASSERT(strcmp(vfs_getcwd(), "/") == 0);   /* unchanged */
+        KTEST_ASSERT(strcmp(peer->cwd, "/cdrom") == 0); /* but peer did change */
+
+        /* Restore peer cwd. */
+        memcpy(peer->cwd, peer_saved, strlen(peer_saved) + 1);
+    }
+
+    /* Restore caller's cwd via vfs_cd to exercise the full path. */
+    KTEST_ASSERT(vfs_cd(saved) == 0);
+    KTEST_ASSERT(strcmp(cur->cwd, saved) == 0);
+
+    ktest_summary();
+}
+
+/* ---------------------------------------------------------------------------
  * Suite: GDT
  *
  * Verifies that the GDT segment descriptors ring-3 entry depends on are
@@ -1444,6 +1511,10 @@ int ktest_run_all(void)
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 
+    test_cwd();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
     test_gdt();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
@@ -1525,6 +1596,7 @@ void ktest_bg_task(void)
     RUN(test_task);
     RUN(test_syscall);
     RUN(test_fd_table);
+    RUN(test_cwd);
     RUN(test_gdt);
     RUN(test_ring3_prereqs);
     RUN(test_idt);

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -20,6 +20,7 @@
 #include <kernel/tty.h>
 #include <kernel/asm.h>
 #include <kernel/serial.h>
+#include <kernel/vfs.h>
 #include <string.h>
 
 /* -------------------------------------------------------------------------
@@ -89,8 +90,17 @@ void tasking_init(void)
     idle->next     = idle;               /* circular list of one for now             */
     idle->pid      = 1;
     idle->user_brk = 0;
-    idle->cwd[0]   = '/';
-    idle->cwd[1]   = '\0';
+    /* Seed idle->cwd from the boot-time scratch cwd that vfs_init() /
+     * vfs_auto_mount() populated (e.g. "/cdrom" on a CD-ROM boot).  This
+     * is the one-shot handoff: from this point onward vfs_getcwd() routes
+     * to task_current()->cwd, and the boot scratch buffer is unused. */
+    {
+        const char *boot_cwd = vfs_getcwd();
+        size_t n = strlen(boot_cwd);
+        if (n >= VFS_PATH_MAX) n = VFS_PATH_MAX - 1;
+        memcpy(idle->cwd, boot_cwd, n);
+        idle->cwd[n] = '\0';
+    }
     idle->tty      = TASK_TTY_NONE;
     idle->sig_pending = 0;
     idle->sig_mask    = 0;

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -37,9 +37,11 @@ typedef struct task {
     uint32_t      user_brk;  /* current user-space heap break (0 = not a user process) */
 
     /* --- per-task working directory ---
-     * Owned by the task; resolved against by VFS calls when the per-task CWD
-     * slice migrates `vfs_getcwd()` off the global `s_cwd`. Until then this
-     * field is plumbed but not yet authoritative. */
+     * Authoritative storage for the task's cwd.  vfs_getcwd() / vfs_cd()
+     * read and write this field for the calling task; relative-path resolution
+     * in path_resolve() joins against it.  When the shell moves to userspace,
+     * SYS_GETCWD / SYS_CHDIR will become thin wrappers over the same field -
+     * no special-casing required. */
     char          cwd[VFS_PATH_MAX];
 
     /* --- TTY binding ---

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -333,6 +333,50 @@ sendkey ret" \
         "Hello," "tester" "status=0"
 }
 
+scenario_per_tty_cwd() {
+    # Per-task cwd isolation across TTYs (slice 15).
+    #
+    # Layout: each shell0..3 task owns task_t.cwd; vfs_getcwd/vfs_cd route
+    # through task_current()->cwd.  We:
+    #   1. On VT0 (default focus): cd /proc          -> prompt becomes "/proc~>"
+    #   2. Alt+F2 → VT1, cd /cdrom/apps               -> "/cdrom/apps~>"
+    #   3. Alt+F1 → VT0 (re-render its prompt)        -> still "/proc~>"
+    # The shell re-prints its prompt on every focus switch (per-TTY backing
+    # grid replays into the framebuffer), so seeing /proc~> appear in serial
+    # AFTER /cdrom/apps~> is direct evidence that VT0's cwd survived VT1's
+    # excursion - which is exactly what slice 15 guarantees.  Asserting on
+    # the "~>" suffix makes the matches unambiguous (only prompts end that
+    # way; raw command echo does not).
+    run_scenario "per-tty-cwd" \
+"sendkey c
+sendkey d
+sendkey spc
+sendkey slash
+sendkey p
+sendkey r
+sendkey o
+sendkey c
+sendkey ret
+sendkey alt-f2
+sendkey c
+sendkey d
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey ret
+sendkey alt-f1" \
+        "/proc~>" "/cdrom/apps~>"
+}
+
 scenario_cd_root() {
     # `cd /<TAB><TAB><Enter>` then `pwd` - tab on /<TAB><TAB> lists the
     # mount points; the trailing Enter commits the half-typed `cd /`,
@@ -354,7 +398,7 @@ sendkey ret" \
 
 # --- Driver ------------------------------------------------------------------
 
-ALL_SCENARIOS=(glob_proc tab_path exec_hello cd_root)
+ALL_SCENARIOS=(glob_proc tab_path exec_hello cd_root per_tty_cwd)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary

Drops the global `s_cwd` in `vfs.c`.  Each task now owns its working
directory in `task_t.cwd`, so VT0 can sit in `/proc` while VT1 sits in
`/cdrom/apps` without cross-talk - exactly the isolation slice 15 set
out to deliver.

Public API (`vfs_getcwd` / `vfs_cd`) is unchanged.  When the shell
moves to userspace, `SYS_GETCWD` / `SYS_CHDIR` become thin wrappers
over the same `task_current()->cwd` field with no special-casing.

## Mechanics

- `s_cwd` → `s_boot_cwd`, used only before `tasking_init` runs (i.e. by
  `vfs_init` and `vfs_auto_mount`).  `tasking_init` seeds `idle->cwd`
  from it once via `vfs_getcwd()`, after which `cwd_buf()` always
  resolves to `task_current()->cwd`.
- Mount-state notifications (`vfs_notify_hd_mounted` /
  `_hd_unmounted` / `_cdrom_ejected`) walk every live task and fix up
  each cwd independently, instead of mutating a single global.
- `task_create` cwd inheritance was already in place from slice 2 - no
  change there.

## Tests

- **ktest `test_cwd` suite** (registered in `ktest_run_all` and
  `ktest_bg_task`): pointer identity, write-through via `vfs_cd`,
  peer-task isolation by poking `task_get(other)->cwd` and asserting
  `vfs_getcwd()` is unaffected, round-trip restore.  9 asserts; total
  ktest count now 236.
- **ui_test `per-tty-cwd` scenario**: cd /proc on VT0, Alt+F2,
  cd /cdrom/apps on VT1, Alt+F1.  Asserts on the `~>` prompt suffix
  prove `/proc~>` reappears after the VT1 excursion - direct evidence
  VT0's cwd survived.
- iso-test: 236/236 ktest assertions + 4/4 GDB groups.
- ui_test: 5/5 scenarios.

## Roadmap status

| Slice | Status |
|---|---|
| 14 (per-task fd table) | ✅ #134 |
| **15 (per-task cwd authoritative)** | ✅ this PR |
| 7 (per-task consumer migration) | ✅ complete (tty + fd + cwd all migrated) |

## Test plan

- [x] `./run.sh iso-test`
- [x] `./run.sh ui-test`
- [x] CI: build-test workflow green