### PR TITLE
feat(display): hide VT status bar during loading screen

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -14,6 +14,114 @@ this file is the trail of how the current state got there.
 
 ## Unreleased
 
+### Added — signals + preemption hardening (PR #154, slices 8 + 9)
+
+- **Per-task signal subsystem** (`src/kernel/include/kernel/signal.h`,
+  `src/kernel/arch/i386/proc/signal.c`).  Linux i386 signal numbers,
+  `sig_handler_t` typedef, `SIG_DFL`/`SIG_IGN` sentinels.  Per-task
+  handler table held in a static array indexed by task-pool slot.
+  Default-action classifier follows Linux defaults; SIGKILL bypasses
+  mask + handler; SIGKILL/SIGSTOP can't have their disposition
+  overridden.  Delivery hooks at `schedule()` (for default-terminate
+  and SIG_IGN) and at the return-to-ring-3 path in `isr_handler` /
+  `irq_handler` / `syscall_dispatch` (for user-installed handlers via
+  a sigframe trampoline on the user stack).
+- **Syscalls**:
+    - `SYS_KILL(37)` — `kill(pid, signo)`.  Linux i386 number.
+    - `SYS_SIGNAL(48)` — `signal(signo, handler)`.  Returns the
+      previous handler.
+    - `SYS_SIGRETURN(119)` — sigframe restore; invoked indirectly by
+      the trampoline embedded at the bottom of every sigframe.
+    - `SYS_FCNTL(55)` — `F_GETFL` / `F_SETFL` with `O_NONBLOCK` on
+      stdin so non-blocking reads return `-EAGAIN` instead of
+      blocking via `shell_readline`.
+- **`task_t.unkillable`** flag: idle (pid 1) and shell tasks set this,
+  and `sig_deliver` drops SIGKILL / default-terminate signals on
+  unkillable targets instead of marking them DEAD.  Without it,
+  maktop's F9-picker / a stray `kill` from the shell could leave a
+  VT permanently dead.
+- **Per-task `kticks`** PIT-tick accounting, incremented by
+  `timer_callback` and rendered in `/proc/tasks` (slice 9 phase 2).
+- **Runtime-tunable scheduling quantum** — `g_sched_quantum` (default
+  4 PIT ticks = 40 ms slice) writable via the new `sched_quantum`
+  shell builtin in `[1..100]` (slice 9 phase 3).
+- **`maktop.elf`** — htop-style task viewer.  Resolution-agnostic via
+  `sys_term_cols`/`sys_term_rows`.  Linux-style /proc/meminfo +
+  /proc/tasks parsing, horizontal CPU% + memory meter bars (green →
+  yellow → red), tmux-style preserved status bar at the bottom row.
+  Auto-refreshes every 1 s; ↑↓ navigate, F9 opens a left-side signal
+  picker (↑↓ pick a name, Enter sends), `s` is a numeric-entry
+  alternate, `r` forces refresh, F10 / `q` quits.  Stays
+  POSIX-aligned: stdin set to `O_NONBLOCK` via `fcntl`, `read` returns
+  `-EAGAIN` when the keyboard ring is empty.
+- **`sigtest.elf`** — ring-3 verifier for `sys_signal` + sigframe +
+  sigreturn.  Installs SIGUSR1 handler, self-sends, asserts the
+  handler ran.
+- **`/proc/meminfo` Linux-style fields** — `MemTotal`, `MemFree`,
+  `MemAvailable`, `MemUsed`, plus existing heap stats.  `pmm_init`
+  caches the bootloader-managed frame count as the source of
+  `MemTotal`.
+- **`task_t.fb_touched`** — set by `SYS_PUTCH_AT` / `SYS_TTY_CLEAR`
+  on the calling task.  `shell_exec_elf` checks it after the child
+  dies and only calls `shell_clear_screen()` for fullscreen apps,
+  so line-mode children (cat, hello, makbox-fallback on typos)
+  don't have their output wiped from the screen.
+- **`in_schedule` re-entrancy guard** in `schedule()`, paired with
+  `irq_save_disable` / `irq_restore` around the critical section.
+  Cleared *before* `task_switch` so fresh tasks (whose first
+  execution bypasses the schedule epilogue) don't leave the flag
+  set forever (slice 9 phase 1).
+- **ktest:**
+    - `test_signal` (31 asserts) — default-action classifier,
+      sig_send/sig_deliver, SIGKILL override of SIG_IGN, sig_send_pid,
+      sig_get_handler round-trip, scheduler-driven default-terminate
+      on a spawned victim.
+    - `test_preempt` — busy-loop victim + verify its `kticks`
+      advanced (proves timer-driven preemption).
+- **ui-test:**
+    - `ctrlc-kills-child` — exec calc, send Ctrl+C, verify shell
+      responsive (proves SIGINT default-terminate end-to-end).
+    - `user-sigusr1-handler` — runs `sigtest.elf`; greps for the
+      handler's serial line, end-to-end ring-3 trampoline coverage.
+    - `no-dead-in-proctasks` — proves the new procfs DEAD filter.
+    - `typo-doesnt-clear` — proves line-mode output survives the
+      shell's post-exec cleanup (`fb_touched` gate).
+- **`tests/ui_runner.sh` sync primitives** — `wait_for_serial
+  <pattern> <start_bytes> [timeout]` and an `it_until` helper.
+  The shell emits `[shell:ready vt=N]` to serial on every
+  `shell_readline` entry (gated by `g_serial_verbose`), so tests
+  can sync on "the prompt is ready" instead of `sleep N` — pexpect /
+  Tcl-Expect style.  Eliminated the typo-doesnt-clear flake.
+
+### Changed (signals + preemption)
+
+- `Ctrl+C` no longer sets a `kb_sigint` global; the keyboard ISR now
+  calls `sig_send(focused_task, SIGINT)` directly.  Shell tasks
+  install `SIG_IGN` for SIGINT at startup so they survive Ctrl+C at
+  their own prompt; the `\x03` byte still arrives via the keyboard
+  ring and `shell_readline` handles it cooperatively (echo `^C`,
+  drop the line).  Legacy `keyboard_sigint_consume()` shim removed.
+- `shell_exec_elf` no longer polls `keyboard_sigint_consume()` to
+  force-kill children.  Ctrl+C delivers SIGINT to the focused
+  child; the kernel terminates it via `sig_deliver`; the shell
+  just yields until `t->state == TASK_DEAD`.
+- Exec'd tasks now get a real name (basename of the path, minus a
+  trailing `.elf`) instead of the hard-coded `"exec"`, via the new
+  `task_t.name_buf[16]` durable-storage field.  Visible in
+  `/proc/tasks`, `cat /proc/tasks`, and maktop.
+- CI `run.sh` outer timeout for the GDB ISO test bumped 120 s →
+  300 s; on FAIL, `tests/groups/ktest_bg.py` prints the last
+  `ktest_bg_completed/total` it observed so triage doesn't need
+  the artifact tarball for the basic "which suite stalled"
+  question (separate commit, same PR).
+
+### Removed (signals + preemption)
+
+- `kb_sigint` static + `keyboard_sigint_consume()` function (replaced
+  by per-task signal delivery).
+- The 4-byte `SCHED_QUANTUM` compile-time `#define` (now the
+  `g_sched_quantum` runtime variable).
+
 ### Added
 - **makbox** — Makar busybox-style multicall binary
   (`src/userspace/makbox.c`).  Applets: `ls`, `cat`, `cp`, `mv`, `rm`,

--- a/docs/kernel/procfs.md
+++ b/docs/kernel/procfs.md
@@ -18,8 +18,8 @@ caller's buffer. No on-disk storage; nothing is cached between reads.
 | Path | Renderer | Content |
 |---|---|---|
 | `/proc/cpuinfo` | CPUID leaves 0 + 1 | `vendor_id`, `cpu family`, `model`, `stepping`, `flags` (fpu/tsc/msr/pae/apic/cmov/mmx/sse/sse2/sse3/sse4_1/sse4_2), `arch i386 (protected mode)` |
-| `/proc/meminfo` | `pmm_free_count()` + `heap_used/free()` | `MemFree`, `PageSize`, `FreeFrames`, `HeapTotal`, `HeapUsed`, `HeapFree` (all in kB where applicable) |
-| `/proc/tasks` | Walk `task_pool[]` | One row per task: `PID NAME STATE TTY CWD` |
+| `/proc/meminfo` | `pmm_managed_count()` + `pmm_free_count()` + `heap_used/free()` | Linux-style key/value: `MemTotal`, `MemFree`, `MemAvailable`, `MemUsed`, `Buffers` (0), `Cached` (0), `HeapTotal`, `HeapUsed`, `HeapFree`, `PageSize`, `FreeFrames`, `TotalFrames`.  `MemTotal` reflects the bootloader-available frame pool minus the null page + kernel image (cached at `pmm_init`). |
+| `/proc/tasks` | Walk `task_pool[]`, skip `TASK_DEAD` | `PID NAME STATE TTY TICKS CWD`.  Dead-but-not-yet-reclaimed slots are filtered so userspace tools (maktop / `cat /proc/tasks`) only see live work. |
 | `/proc/uname` | `MAKAR_VERSION` + build macros + `timer_get_ticks()` | `Makar 0.5.0 (i386) built <date> <time>` + uptime ticks |
 
 ## VFS integration

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,8 +28,8 @@ usually one PR per slice.
 |    5b | Keyboard hardening                                     | ✅ shipped (#127)           | —                                                                                  |
 |     6 | Test-infra cleanup (ccache, fan-out CI)                | ✅ shipped (#125)           | —                                                                                  |
 |     7 | Per-task consumer migration                            | ✅ complete                 | —                                                                                  |
-|     8 | Linux-style signal subsystem                           | ⏭ queued                    | [#144](https://github.com/Arawn-Davies/Makar/issues/144)                          |
-|     9 | Preemption hardening                                   | ⏭ queued                    | [#145](https://github.com/Arawn-Davies/Makar/issues/145)                          |
+|     8 | Linux-style signal subsystem                           | ✅ shipped (#154)           | [#144](https://github.com/Arawn-Davies/Makar/issues/144)                          |
+|     9 | Preemption hardening                                   | ✅ shipped (#154)           | [#145](https://github.com/Arawn-Davies/Makar/issues/145)                          |
 |    10 | Per-TTY screen buffers + status bar + `/proc`          | ✅ shipped (#129)           | —                                                                                  |
 |    11 | `ps`-style task listing                                | ⏭ queued                    | [#147](https://github.com/Arawn-Davies/Makar/issues/147)                          |
 |    12 | `fork()` readiness (CoW PD clone, fd dup)              | ⏭ queued                    | rolled into [#121](https://github.com/Arawn-Davies/Makar/issues/121)              |
@@ -80,11 +80,20 @@ Background: [Makar × Medli](makar-medli.md).
 
 Things the kernel needs to be properly preemptive + signal-aware.
 
-Open:
+Shipped (PR #154):
 - [#144 — Linux-style signal subsystem](https://github.com/Arawn-Davies/Makar/issues/144)
-  (slice 8)
+  (slice 8) — per-task handler table, scheduler-driven default-terminate
+  delivery, `SYS_KILL(37)` / `SYS_SIGNAL(48)` / `SYS_SIGRETURN(119)`,
+  ring-3 trampoline so user-installed handlers actually run, Ctrl+C →
+  SIGINT migration (removed `g_sigint` / `keyboard_sigint_consume`),
+  `task_t.unkillable` flag protecting idle + shell tasks, `maktop.elf`
+  htop-style task viewer with F9 signal picker.
 - [#145 — Preemption hardening](https://github.com/Arawn-Davies/Makar/issues/145)
-  (slice 9)
+  (slice 9) — `in_schedule` re-entrancy guard cleared before
+  `task_switch`, `irq_save_disable` / `irq_restore` wrapping the
+  critical section, per-task `kticks` accounting in `/proc/tasks`,
+  runtime-tunable `g_sched_quantum` (`sched_quantum` shell builtin),
+  `test_preempt` busy-loop ktest.
 
 ### Filesystem & devices
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -118,6 +118,54 @@ Runs `ktest_run_all()` and prints pass/fail for each subsystem suite
 
 ---
 
+## Black-box UI tests (`./run.sh ui-test`)
+
+Drives the running kernel through QEMU's HMP `sendkey` and asserts on
+the COM1 serial slice + PPM screen dump.  Scenarios live in
+`tests/ui_test.sh` as `test_<name>` shell functions; the shared runner
+in `tests/ui_runner.sh` boots one QEMU per invocation and rotates
+through scenarios with `reset_shell` in between.
+
+### Synchronisation: marker-based, not sleep-based
+
+The shell emits `[shell:ready vt=N]` to serial on every
+`shell_readline` entry (gated by `g_serial_verbose`, which
+`start_qemu` flips on as the first action after boot).  Test
+scenarios use this marker as a sync point instead of fixed `sleep N`:
+
+| Primitive | What it does |
+|---|---|
+| `it <name> <script> [wait_secs]` | Fixed-sleep style.  Send keys, sleep, snapshot serial slice. |
+| `it_until <name> <script> <regex> [timeout]` | **Sync-on-marker style.**  Send keys, poll the serial log until the regex appears, then snapshot.  Default sync regex is `'\[shell:ready vt=0\]'`. |
+| `wait_for_serial <regex> <start_bytes> [timeout]` | Low-level primitive.  Polls `$SERIAL_LOG` from `<start_bytes>` until `<regex>` matches.  Used by `it_until` and directly by multi-stage scenarios that need to sync between key batches (the `typo-doesnt-clear` scenario is the canonical multi-stage example: type the typo, wait for shell-ready, then type the next command, otherwise the in-flight bytes race the dying exec'd child and get dropped when `keyboard_release_task` reaps its slot). |
+
+This is the expect/pexpect pattern, scaled down.  Why it matters: a
+fixed `sleep 1.2` is a guess that's right under KVM and wrong under
+TCG-on-a-shared-runner.  A marker sync is right in both -- it returns
+the instant the kernel says it's ready and bounds via the timeout.
+
+### Scenarios currently covered
+
+| Scenario | Asserts |
+|---|---|
+| `glob-proc` | `cat /proc/*` glob-expands across the synthetic FS |
+| `tab-complete-path` | `cat<TAB> /proc/c<TAB><Enter>` resolves to `cat /proc/cpuinfo` |
+| `exec-hello` | `exec /cdrom/apps/hello.elf tester` reaches `sys_exit(0)` and prints the expected greeting |
+| `cd-root-listing` | `cd /<TAB><TAB>` lists mounts; subsequent `pwd` confirms cwd |
+| `per-tty-cwd` | Per-task cwd isolation across `Alt+F1`/`Alt+F3` switches |
+| `calc-brackets` | `calc.elf` evaluates parenthesised arithmetic |
+| `ctrlc-kills-child` | Ctrl+C delivers SIGINT to a running ELF, shell recovers |
+| `no-dead-in-proctasks` | `cat /proc/tasks` never lists DEAD slots |
+| `typo-doesnt-clear` | A wrong command falls back to makbox, prints an error, and **does not** wipe the screen (proves the `task_t.fb_touched` gate) |
+| `user-sigusr1-handler` | `sigtest.elf` installs a SIGUSR1 handler, self-sends, the handler runs in ring 3 (proves the sigframe + trampoline + `SYS_SIGRETURN` path) |
+| `makbox-pwd` | `pwd` resolves to the `makbox` applet end-to-end |
+
+`./run.sh ui-test` runs all of them; `./run.sh ui-test <name>` runs
+one; `./run.sh ui-test-gui` runs with a visible QEMU window for
+debugging.
+
+---
+
 ## CI
 
 `.github/workflows/build-test.yml` runs a **build-once, fan-out** topology on every push to `main` and every PR. Docs-only changes are skipped via path filter.

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -466,9 +466,31 @@ void vesa_tty_paint_string_at(uint32_t col, uint32_t row, const char *s,
 	}
 }
 
+/* Visibility gate for the bottom status bar.  Default 1 (visible).
+ * shell_run flips it to 0 during the loading screen so the boot
+ * progress isn't competing with the VT0/VT1/... markers, then back
+ * to 1 once ktest_bg_done flips and the prompt is about to appear.
+ * Long-term this whole renderer is destined to move out of the
+ * kernel into a userland statusbar.elf; see the comment in
+ * vesa_tty.h. */
+static int s_status_visible = 1;
+
+void vesa_tty_set_status_visible(int v)
+{
+	s_status_visible = v ? 1 : 0;
+	if (!tty_ready) return;
+	if (!v) {
+		uint32_t row = tty_rows - 1;
+		for (uint32_t c = 0; c < tty_cols; c++)
+			paint_cell(' ', compose_rgb(0x000000),
+			           compose_rgb(0x000000), c, row);
+	}
+}
+
 void vesa_tty_paint_status(int active, int count)
 {
 	if (!tty_ready) return;
+	if (!s_status_visible) return;
 	uint32_t row = tty_rows - 1;     /* bottom row reserved for status */
 	uint32_t bar_fg = 0xC0C0C0;      /* light grey on dark             */
 	uint32_t bar_bg = 0x202020;

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -155,20 +155,38 @@ static void render_cpuinfo(pf_writer_t *w)
  * meminfo
  * ---------------------------------------------------------------------- */
 
+/* /proc/meminfo - Linux-style key/value format ("Label:<spaces>N kB").
+ * Field order and naming match Linux for the headline numbers so
+ * tools like maktop don't need Makar-specific parsing.  Fields after
+ * MemAvailable are Makar-specific kernel-heap diagnostics. */
 static void render_meminfo(pf_writer_t *w)
 {
-    uint32_t free_frames = pmm_free_count();
-    uint32_t free_kb     = free_frames * 4u;       /* 4 KiB per frame */
-    size_t   heap_total  = (size_t)(0x1800000u - 0x800000u); /* HEAP_MAX-HEAP_START */
-    size_t   heap_u      = heap_used();
-    size_t   heap_f      = heap_free();
+    uint32_t total_frames = pmm_managed_count();
+    uint32_t free_frames  = pmm_free_count();
+    uint32_t used_frames  = (total_frames > free_frames)
+                             ? (total_frames - free_frames) : 0u;
+    uint32_t total_kb = total_frames * 4u;
+    uint32_t free_kb  = free_frames  * 4u;
+    uint32_t used_kb  = used_frames  * 4u;
 
-    pf_puts(w, "MemFree     : "); pf_putu(w, free_kb);            pf_puts(w, " kB\n");
-    pf_puts(w, "PageSize    : 4 kB\n");
-    pf_puts(w, "FreeFrames  : "); pf_putu(w, free_frames);        pf_putc(w, '\n');
-    pf_puts(w, "HeapTotal   : "); pf_putu(w, (uint32_t)(heap_total / 1024u)); pf_puts(w, " kB\n");
-    pf_puts(w, "HeapUsed    : "); pf_putu(w, (uint32_t)(heap_u / 1024u));     pf_puts(w, " kB\n");
-    pf_puts(w, "HeapFree    : "); pf_putu(w, (uint32_t)(heap_f / 1024u));     pf_puts(w, " kB\n");
+    size_t heap_total = (size_t)(0x1800000u - 0x800000u); /* HEAP_MAX-HEAP_START */
+    size_t heap_u     = heap_used();
+    size_t heap_f     = heap_free();
+
+    pf_puts(w, "MemTotal:        "); pf_putu(w, total_kb); pf_puts(w, " kB\n");
+    pf_puts(w, "MemFree:         "); pf_putu(w, free_kb);  pf_puts(w, " kB\n");
+    /* MemAvailable -- Linux's "memory likely usable for new allocations".
+     * We don't have page cache to reclaim, so it's the same as MemFree. */
+    pf_puts(w, "MemAvailable:    "); pf_putu(w, free_kb);  pf_puts(w, " kB\n");
+    pf_puts(w, "MemUsed:         "); pf_putu(w, used_kb);  pf_puts(w, " kB\n");
+    pf_puts(w, "Buffers:                0 kB\n");
+    pf_puts(w, "Cached:                 0 kB\n");
+    pf_puts(w, "HeapTotal:       "); pf_putu(w, (uint32_t)(heap_total / 1024u)); pf_puts(w, " kB\n");
+    pf_puts(w, "HeapUsed:        "); pf_putu(w, (uint32_t)(heap_u     / 1024u)); pf_puts(w, " kB\n");
+    pf_puts(w, "HeapFree:        "); pf_putu(w, (uint32_t)(heap_f     / 1024u)); pf_puts(w, " kB\n");
+    pf_puts(w, "PageSize:               4 kB\n");
+    pf_puts(w, "FreeFrames:      "); pf_putu(w, free_frames);  pf_putc(w, '\n');
+    pf_puts(w, "TotalFrames:     "); pf_putu(w, total_frames); pf_putc(w, '\n');
 }
 
 /* -------------------------------------------------------------------------
@@ -192,6 +210,11 @@ static void render_tasks(pf_writer_t *w)
     for (int i = 0; i < n; i++) {
         task_t *t = task_get(i);
         if (!t) continue;
+        /* DEAD slots linger until task_create reclaims them.  Hide them
+         * so /proc/tasks shows only live work -- otherwise maktop and
+         * `cat /proc/tasks` keep listing finished one-shots like
+         * ktest_bg or exec'd userspace binaries indefinitely. */
+        if (t->state == TASK_DEAD) continue;
         pf_putu(w, (uint32_t)t->pid);
         pf_putc(w, ' ');
         const char *name = t->name ? t->name : "(noname)";

--- a/src/kernel/arch/i386/mm/pmm.c
+++ b/src/kernel/arch/i386/mm/pmm.c
@@ -10,6 +10,11 @@
 /* bit = 1 → frame used   bit = 0 → frame free */
 static uint32_t bitmap[PMM_BITMAP_WORDS];
 
+/* Total managed (= bootloader-available, minus null page + kernel image)
+ * frames.  Constant after pmm_init.  Used by /proc/meminfo to expose
+ * MemTotal so userspace tools (maktop) can show a memory bar. */
+static uint32_t s_total_managed_frames;
+
 static inline void pmm_set_frame(uint32_t frame)
 {
 	bitmap[frame / 32] |= (1U << (frame % 32));
@@ -95,7 +100,11 @@ void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 	for (uint32_t f = kstart; f < kend; f++)
 		pmm_set_frame(f);
 
+	/* Capture the pool size before any runtime allocations; this is
+	 * what /proc/meminfo's MemTotal reports.  pmm_free_count() walks
+	 * the bitmap so we cache the result rather than re-counting. */
 	uint32_t free_frames = pmm_free_count();
+	s_total_managed_frames = free_frames;
 	t_writestring("PMM: ");
 	t_dec(free_frames);
 	t_writestring(" frames free (");
@@ -128,6 +137,11 @@ uint32_t pmm_alloc_frame(void)
 void pmm_free_frame(uint32_t addr)
 {
 	pmm_clear_frame(addr / PMM_FRAME_SIZE);
+}
+
+uint32_t pmm_managed_count(void)
+{
+	return s_total_managed_frames;
 }
 
 uint32_t pmm_free_count(void)

--- a/src/kernel/arch/i386/proc/signal.c
+++ b/src/kernel/arch/i386/proc/signal.c
@@ -166,9 +166,18 @@ void sig_deliver(struct task *t)
         if (!(deliverable & bit))
             continue;
 
-        /* SIGKILL ignores mask and handler entirely. */
+        /* SIGKILL ignores mask and handler entirely -- except for
+         * tasks marked unkillable (idle + shells).  Killing one of
+         * those would leave the kernel deadlocked or a VT permanently
+         * unusable, so drop the signal silently. */
         if (sig == SIGKILL) {
             t->sig_pending &= ~bit;
+            if (t->unkillable) {
+                Serial_WriteString("[signal] SIGKILL dropped on unkillable pid=");
+                Serial_WriteDec((uint32_t)t->pid);
+                Serial_WriteString("\n");
+                continue;
+            }
             t->state = TASK_DEAD;
             Serial_WriteString("[signal] pid=");
             Serial_WriteDec((uint32_t)t->pid);
@@ -186,6 +195,14 @@ void sig_deliver(struct task *t)
         if (h == SIG_DFL) {
             t->sig_pending &= ~bit;
             if (sig_default_terminates(sig)) {
+                if (t->unkillable) {
+                    Serial_WriteString("[signal] sig ");
+                    Serial_WriteDec((uint32_t)sig);
+                    Serial_WriteString(" dropped on unkillable pid=");
+                    Serial_WriteDec((uint32_t)t->pid);
+                    Serial_WriteString("\n");
+                    continue;
+                }
                 t->state = TASK_DEAD;
                 Serial_WriteString("[signal] pid=");
                 Serial_WriteDec((uint32_t)t->pid);

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -121,6 +121,20 @@ void syscall_dispatch(registers_t *regs)
         if (!e) { regs->eax = (uint32_t)-1; break; }
 
         if (e->kind == FD_KIND_KEYBOARD) {
+            /* Non-blocking path (O_NONBLOCK on stdin): poll once and
+             * either deliver a single raw byte or return -EAGAIN.  No
+             * line buffering / echo / editing; callers asking for raw
+             * mode opt in deliberately.  Pairs with sys_fcntl(F_SETFL). */
+            if (e->flags & FD_FLAG_NONBLOCK) {
+                unsigned char c = keyboard_poll();
+                if (c == 0) {
+                    regs->eax = (uint32_t)-11;  /* -EAGAIN */
+                } else {
+                    buf[0] = (char)c;
+                    regs->eax = 1u;
+                }
+                break;
+            }
             /* Line-buffered stdin with echo, backspace, and cursor editing. */
             static char s_stdin_line[256];
             uint32_t cap = (len < sizeof(s_stdin_line)) ? len : (uint32_t)sizeof(s_stdin_line);
@@ -645,6 +659,32 @@ void syscall_dispatch(registers_t *regs)
             break;
         }
         regs->eax = (uint32_t)(uintptr_t)prev;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_FCNTL(55): minimal Linux-style fcntl.
+     *   F_GETFL (3) -> returns the fd's flags
+     *   F_SETFL (4) -> replaces them (only O_NONBLOCK is meaningful today)
+     * Returns the flags / 0 on success, negative errno on bad fd / cmd.
+     * ------------------------------------------------------------------ */
+    case SYS_FCNTL: {
+        int fd  = (int)regs->ebx;
+        int cmd = (int)regs->ecx;
+        long arg = (long)regs->edx;
+        task_t *t = task_current();
+        fd_entry_t *e = (t && t->fd_table) ? fd_get(t->fd_table, fd) : NULL;
+        if (!e) { regs->eax = (uint32_t)-9; break; }   /* -EBADF */
+        if (cmd == F_GETFL) {
+            regs->eax = e->flags;
+        } else if (cmd == F_SETFL) {
+            /* Only the documented bits are honoured; everything else
+             * silently dropped (Linux does similar masking). */
+            e->flags = (uint32_t)(arg & FD_FLAG_NONBLOCK);
+            regs->eax = 0u;
+        } else {
+            regs->eax = (uint32_t)-22;   /* -EINVAL */
+        }
         break;
     }
 

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -442,6 +442,12 @@ void syscall_dispatch(registers_t *regs)
         const tty_cell_t *cells = (const tty_cell_t *)(uintptr_t)regs->ebx;
         uint32_t n = regs->ecx;
         if (!cells || n == 0) { regs->eax = 0; break; }
+        /* Mark this task as "touched the framebuffer".  shell_exec_elf
+         * inspects this flag after the child dies and reissues
+         * shell_clear_screen if set, so fullscreen apps that exit via
+         * SIGKILL (no chance to clean up) don't leave their last frame
+         * underneath the next shell prompt. */
+        { task_t *cur = task_current(); if (cur) cur->fb_touched = 1; }
         /* SYS_PUTCH_AT cells carry their own colour attribute, so writing
          * each cell mutates the default pane's fg/bg.  Save the pane
          * colours up-front and restore at the end so apps that paint
@@ -484,6 +490,7 @@ void syscall_dispatch(registers_t *regs)
      * ------------------------------------------------------------------ */
     case SYS_TTY_CLEAR:
         t_fill((uint8_t)regs->ebx);
+        { task_t *cur = task_current(); if (cur) cur->fb_touched = 1; }
         break;
 
     /* ------------------------------------------------------------------

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -132,6 +132,10 @@ void tasking_init(void)
         idle->cwd[n] = '\0';
     }
     idle->tty      = TASK_TTY_NONE;
+    /* The idle task is unkillable: a SIGKILL/SIGTERM landing on it
+     * would mark it DEAD and the kernel has no fallback runnable when
+     * idle is gone (the scheduler bails out and the system hangs). */
+    idle->unkillable = 1;
     /* sig_task_init zeroes sig_pending/sig_mask and resets the per-task
      * handler table held in signal.c to SIG_DFL across all signals. */
     sig_task_init(idle);
@@ -221,6 +225,7 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->user_brk    = 0;
     t->pid         = next_pid++;
     t->kticks      = 0;
+    t->unkillable  = 0;     /* default: ordinary task, no protection   */
     t->fd_table    = new_fds;
     t->exec_params = NULL;
 

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -718,6 +718,12 @@ void shell_run(void)
     if (slot == 0) {
         terminal_set_colorscheme(SHELL_COLOR_VGA);
 
+        /* Hide the tmux-style VT status bar for the duration of the
+         * loading screen: nothing's registered yet on most slots, and
+         * the half-populated bar looks broken next to the logo + bar
+         * progress.  Restored just before the REPL takes over. */
+        vesa_tty_set_status_visible(0);
+
         /* Loading screen: render a progress bar that fills as bg ktest
          * completes each suite.  The wait is OUTSIDE the VESA conditional so
          * the VGA fallback also blocks the REPL until ktest_bg_done = 1.
@@ -775,6 +781,14 @@ void shell_run(void)
         while (!ktest_bg_done)
             task_yield();
         while (keyboard_poll()) {}
+
+        /* Loading is over -- bring the VT status bar back and repaint
+         * it with the live slot count.  vtty_register() has already
+         * incremented the count for shell0..shell3 by this point, so
+         * the bar lights up with all four indicators on the first
+         * draw. */
+        vesa_tty_set_status_visible(1);
+        vesa_tty_paint_status(vtty_active(), vtty_count());
 
         t_writestring("Makar -- version " SHELL_VERSION
                       ", build: " BUILD_DATE " " BUILD_TIME "\n");

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -186,6 +186,21 @@ void shell_readline(char *buf, size_t max)
     buf[0]  = '\0';
     work[0] = '\0';
 
+    /* Sync sentinel for ui_runner.sh's `wait_for_serial`: emit a
+     * structured marker the moment the shell is ready to accept the
+     * next line of input.  Lets tests replace fixed `sleep N` with
+     * "wait until you see [shell:ready vt=X]", eliminating the
+     * timing-race flakes that plagued the typo-doesnt-clear scenario
+     * under TCG.  Cheap: one line per prompt; gated by g_serial_verbose
+     * so production boots without `verbose on` don't pay for it. */
+    if (g_serial_verbose) {
+        task_t *t = task_current();
+        int vt = t ? t->tty : -1;
+        Serial_WriteString("[shell:ready vt=");
+        Serial_WriteDec((uint32_t)(vt < 0 ? 0u : (uint32_t)vt));
+        Serial_WriteString("]\n");
+    }
+
     /* Capture where the prompt ended.  VGA uses t_column/t_row (wraps at
      * VGA_WIDTH and resets t_row=0 when VESA is active).  VESA tracks its
      * own cursor which must be read separately to avoid the t_row=0 desync. */
@@ -690,6 +705,13 @@ void shell_run(void)
      * the moment the user pressed Ctrl+C.  The 0x03 byte arrives via
      * the keyboard ring and shell_readline handles it cooperatively. */
     sig_set_handler(task_current(), SIGINT, SIG_IGN);
+
+    /* Mark unkillable so maktop / `kill` / SIGKILL from any other
+     * source can't terminate a shell: the shell pool is created once
+     * at boot and a dead shell leaves its VT permanently unusable.
+     * User handlers (sys_signal) still run; only the kernel-driven
+     * default-terminate / SIGKILL path is gated. */
+    task_current()->unkillable = 1;
 
     int slot = vtty_register();
 

--- a/src/kernel/arch/i386/shell/shell_cmd_apps.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_apps.c
@@ -6,6 +6,7 @@
 
 #include "shell_priv.h"
 
+#include <kernel/shell.h>
 #include <kernel/tty.h>
 #include <kernel/vfs.h>
 #include <kernel/vix.h>
@@ -144,6 +145,29 @@ void shell_exec_elf(const char *path, int argc, char **argv)
     }
     t->exec_params = p;
 
+    /* Replace the placeholder "exec" task name with the basename of
+     * the program (minus a trailing ".elf") so /proc/tasks + maktop
+     * + `cat /proc/tasks` show the real running binary.  Stored in
+     * task_t.name_buf so the pointer outlives the path argument. */
+    {
+        const char *base = path;
+        for (const char *q = path; *q; q++) {
+            if (*q == '/') base = q + 1;
+        }
+        size_t n = 0;
+        while (base[n] && n < sizeof(t->name_buf) - 1) {
+            t->name_buf[n] = base[n];
+            n++;
+        }
+        /* Strip a trailing ".elf" if present. */
+        if (n >= 4 && t->name_buf[n-4] == '.' && t->name_buf[n-3] == 'e' &&
+                       t->name_buf[n-2] == 'l' && t->name_buf[n-1] == 'f') {
+            n -= 4;
+        }
+        t->name_buf[n] = '\0';
+        t->name = t->name_buf;
+    }
+
     task_t *self = task_current();
     keyboard_set_focus(t);
 
@@ -166,6 +190,16 @@ void shell_exec_elf(const char *path, int argc, char **argv)
      * means a dead app can never lock the user out of Alt+Fn TTY switching
      * or the Ctrl+A pane prefix. */
     keyboard_set_raw(0);
+
+    /* Only clean up after FULLSCREEN apps (those that touched the
+     * framebuffer via SYS_PUTCH_AT / SYS_TTY_CLEAR).  Line-mode
+     * children like cat / hello / makbox-fallback-on-typo write only
+     * via SYS_WRITE which scrolls normally; clearing after them would
+     * wipe their output.  Fullscreen apps that exited cleanly already
+     * called sys_shell_clear themselves -- doing it again is a no-op
+     * cost but rescues SIGKILL'd ones that never got the chance. */
+    if (t->fb_touched)
+        shell_clear_screen();
 }
 
 static void cmd_exec(int argc, char **argv)

--- a/src/kernel/include/kernel/fd.h
+++ b/src/kernel/include/kernel/fd.h
@@ -27,12 +27,19 @@ typedef enum {
     FD_KIND_FILE       = 5,   /* opened VFS file (eagerly buffered)        */
 } fd_kind_t;
 
+/* Per-fd flag bits, mirrored from Linux fcntl O_NONBLOCK.  Stored in
+ * fd_entry_t.flags and consulted by SYS_READ on FD_KIND_KEYBOARD to
+ * decide whether to block-yield or return -EAGAIN immediately when the
+ * keyboard ring is empty. */
+#define FD_FLAG_NONBLOCK  0x800u
+
 typedef struct {
     fd_kind_t kind;
     /* file-kind state (zero/NULL for other kinds) */
     uint8_t  *data;     /* kmalloc'd buffer, owned by this slot      */
     uint32_t  size;     /* total bytes valid in data                  */
     uint32_t  pos;      /* current read/seek position                 */
+    uint32_t  flags;    /* FD_FLAG_*; per-fd modes (e.g. O_NONBLOCK)  */
 } fd_entry_t;
 
 typedef struct fd_table {

--- a/src/kernel/include/kernel/pmm.h
+++ b/src/kernel/include/kernel/pmm.h
@@ -24,4 +24,8 @@ void     pmm_free_frame(uint32_t addr);
 /* Return the number of frames currently in the free pool. */
 uint32_t pmm_free_count(void);
 
+/* Total managed frames (bootloader-available, minus null page + kernel
+ * image).  Constant after pmm_init; used by /proc/meminfo's MemTotal. */
+uint32_t pmm_managed_count(void);
+
 #endif

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -42,6 +42,13 @@
 #define SYS_UPTIME       214  /* uint32_t uptime_ticks(void) - 100 Hz timer ticks */
 #define SYS_GETCWD       215  /* int getcwd(char *buf, size_t size) - copy task cwd */
 
+/* Back to Linux i386 ABI numbers for the next set. */
+#define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */
+
+/* fcntl cmd values (Linux i386 ABI subset). */
+#define F_GETFL         3
+#define F_SETFL         4
+
 /*
  * tty_cell_t - one screen cell passed to SYS_PUTCH_AT.
  * clr is a standard VGA attribute byte: fg = bits[3:0], bg = bits[6:4].

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -27,7 +27,9 @@ typedef struct task {
     uint8_t      *stack;     /* base of allocated stack (lowest address)          */
     uint32_t     *page_dir;  /* page directory (phys == virt, identity-mapped)    */
     task_state_t  state;
-    const char   *name;
+    const char   *name;      /* points at name_buf for exec'd tasks,    *
+                              * or a string literal for kernel tasks.   */
+    char          name_buf[16]; /* durable storage for exec/spawn names */
     struct task  *next;      /* intrusive circular linked list                    */
 
     /* --- identity --- */
@@ -60,6 +62,23 @@ typedef struct task {
      * task_create. Always allocated (even for idle, since ktest runs
      * there in test_mode boots). See kernel/fd.h. */
     fd_table_t   *fd_table;
+
+    /* --- protection ---
+     * If non-zero, sig_deliver refuses to transition this task to
+     * TASK_DEAD regardless of pending signal (including SIGKILL).
+     * Set on the idle task (kernel would deadlock without it) and on
+     * the four shell tasks (terminating one leaves its VT permanently
+     * dead, since the shell pool is created once at boot).  User-
+     * installed handlers still run normally; only the kernel-driven
+     * termination path is gated. */
+    int           unkillable;
+
+    /* Set the first time this task calls SYS_PUTCH_AT or SYS_TTY_CLEAR.
+     * Used by shell_exec_elf to decide whether to repaint after a
+     * fullscreen ELF exits -- ordinary line-mode programs (cat, hello,
+     * makbox fallback for typos) leave this 0, so the shell's "always
+     * clean up after exec" behaviour doesn't clobber their output. */
+    int           fb_touched;
 
     /* --- tick accounting ---
      * Cumulative PIT ticks (100 Hz) during which this task was the

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -136,8 +136,21 @@ void vesa_tty_paint_string_at(uint32_t col, uint32_t row,
 
 /* Paint the tmux-style status bar at the bottom row of the screen.
  * Active TTY is highlighted with inverse video.  active=current VT,
- * count=number of registered slots.  No-op if vesa_tty isn't ready. */
+ * count=number of registered slots.  No-op if vesa_tty isn't ready
+ * OR if vesa_tty_set_status_visible(0) was called.
+ *
+ * TODO: long-term this whole renderer is a candidate for moving out
+ * of the kernel into a userland `statusbar.elf` -- it'd be a small
+ * tick-driven painter that uses the same SYS_PUTCH_AT primitives
+ * maktop does.  Pre-req: a way for a userland task to draw on the
+ * reserved status row without it being part of any TTY's pane. */
 void vesa_tty_paint_status(int active, int count);
+
+/* Show/hide the bottom-row status bar.  When hidden, the row is
+ * wiped to background and future vesa_tty_paint_status calls are
+ * no-ops until visibility is turned back on.  Used by shell_run's
+ * loading screen. */
+void vesa_tty_set_status_visible(int v);
 
 /* ------------------------------------------------------------------ */
 /* Visible caret on the default pane                                   */

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -14,7 +14,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf maktop.elf
 
 
 all: $(PROGS)
@@ -44,6 +44,9 @@ kbtester.elf: crt0.o kbtester.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 sigtest.elf: crt0.o sigtest.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+maktop.elf: crt0.o maktop.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 

--- a/src/userspace/maktop.c
+++ b/src/userspace/maktop.c
@@ -1,0 +1,593 @@
+/*
+ * maktop.elf - htop-style task viewer for Makar.
+ *
+ * Reads /proc/tasks + /proc/meminfo via sys_open / sys_read and draws a
+ * full-screen grid via SYS_PUTCH_AT.  Modelled after htop: meter bars
+ * (CPU + Mem) and summary text up top, columnar task list in the
+ * middle, F-key bar at the bottom.  ↑/↓ select; F9 sends SIGTERM; s
+ * prompts for an arbitrary signal number; F10 / q quits.
+ *
+ * Auto-refresh every 50 PIT ticks (~500 ms at 100 Hz).  POSIX-style
+ * non-blocking stdin: sys_fcntl(0, F_SETFL, O_NONBLOCK), then sys_read
+ * returns 1 byte or -EAGAIN.  Same pattern a real libc port (ELKS /
+ * fuzix / musl) would use.
+ */
+
+#include "syscall.h"
+
+/* Maktop is resolution-agnostic: the pane dimensions come from
+ * sys_term_cols() / sys_term_rows() at startup.  The kernel pane API
+ * returns the area excluding the tmux-style VT status bar, so we draw
+ * the whole reported region and the status bar at row $rows stays
+ * visible automatically.  Static buffers below are sized for a
+ * comfortable maximum; we clip everything to the actual runtime
+ * dimensions. */
+#define MAX_COLS        160
+#define MAX_ROWS        60
+
+static int s_cols;
+static int s_rows;
+
+/* Layout derived from s_rows at startup (set in main). */
+static int HDR_ROW_CPU;
+static int HDR_ROW_MEM;
+static int ROW_COL_HDR;
+static int ROW_LIST_FIRST;
+static int ROW_LIST_LAST;
+static int ROW_STATUS;
+static int ROW_FOOTER;
+static int MAX_TASKS_VIEW;
+
+#define NAME_W          16
+#define MAX_TASKS_CAP   32
+
+/* Palette - approximates htop's defaults. */
+#define CLR_BG          VGA_CLR(VGA_LGREY,  VGA_BLACK)
+#define CLR_HDR_LABEL   VGA_CLR(VGA_LCYAN,  VGA_BLACK)
+#define CLR_HDR_TEXT    VGA_CLR(VGA_WHITE,  VGA_BLACK)
+#define CLR_BAR_BRACKET VGA_CLR(VGA_LGREY,  VGA_BLACK)
+#define CLR_BAR_FILL    VGA_CLR(VGA_LGREEN, VGA_BLACK)
+#define CLR_BAR_FILL_HI VGA_CLR(VGA_YELLOW, VGA_BLACK)
+#define CLR_BAR_FILL_CR VGA_CLR(VGA_LRED,   VGA_BLACK)
+#define CLR_BAR_EMPTY   VGA_CLR(VGA_DGREY,  VGA_BLACK)
+#define CLR_COLHDR      VGA_CLR(VGA_BLACK,  VGA_LGREEN)
+#define CLR_ROW         VGA_CLR(VGA_LGREY,  VGA_BLACK)
+#define CLR_ROW_SEL     VGA_CLR(VGA_BLACK,  VGA_LCYAN)
+#define CLR_STATUS      VGA_CLR(VGA_YELLOW, VGA_BLACK)
+#define CLR_STATUS_ERR  VGA_CLR(VGA_LRED,   VGA_BLACK)
+#define CLR_FKEY_NUM    VGA_CLR(VGA_WHITE,  VGA_BLACK)
+#define CLR_FKEY_LABEL  VGA_CLR(VGA_BLACK,  VGA_LCYAN)
+
+typedef struct {
+    int          pid;
+    char         name[NAME_W + 1];
+    char         state[8];
+    int          tty;
+    unsigned int kticks;
+    unsigned int kticks_prev;
+} task_row_t;
+
+static task_row_t s_task_rows[MAX_TASKS_CAP];
+static int        s_nrows;
+static int        s_sel;
+
+static unsigned int s_total_kticks_prev;
+static unsigned int s_uptime_prev;
+static unsigned int s_cpu_pct;
+
+static tty_cell_t g_cells[MAX_COLS * MAX_ROWS];
+static int        g_ncells;
+
+/* ---- draw helpers ---- */
+
+static inline void put(int col, int row, char c, unsigned char clr)
+{
+    if (g_ncells < (int)(sizeof(g_cells) / sizeof(g_cells[0]))) {
+        g_cells[g_ncells].col = (unsigned char)col;
+        g_cells[g_ncells].row = (unsigned char)row;
+        g_cells[g_ncells].ch  = (unsigned char)c;
+        g_cells[g_ncells].clr = clr;
+        g_ncells++;
+    }
+}
+
+static void put_str(int col, int row, const char *s, unsigned char clr)
+{
+    while (*s) put(col++, row, *s++, clr);
+}
+
+static void put_pad(int col, int row, int width, unsigned char clr)
+{
+    for (int i = 0; i < width; i++) put(col + i, row, ' ', clr);
+}
+
+static void flush(void)
+{
+    if (g_ncells > 0) {
+        sys_putch_at(g_cells, (unsigned int)g_ncells);
+        g_ncells = 0;
+    }
+}
+
+/* ---- string utilities ---- */
+
+static unsigned int slen(const char *s)
+{
+    unsigned int n = 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static void uitoa(unsigned int v, char *buf)
+{
+    if (v == 0) { buf[0] = '0'; buf[1] = '\0'; return; }
+    char tmp[12]; int i = 0;
+    while (v) { tmp[i++] = (char)('0' + v % 10); v /= 10; }
+    int j = 0;
+    while (i > 0) buf[j++] = tmp[--i];
+    buf[j] = '\0';
+}
+
+static int parse_uint(const char **pp, unsigned int *out)
+{
+    const char *p = *pp;
+    unsigned int v = 0;
+    int got = 0;
+    while (*p == ' ') p++;
+    while (*p >= '0' && *p <= '9') {
+        v = v * 10u + (unsigned int)(*p - '0');
+        p++; got = 1;
+    }
+    *pp = p;
+    *out = v;
+    return got;
+}
+
+/* ---- /proc readers ---- */
+
+static long read_file(const char *path, char *buf, unsigned int cap)
+{
+    int fd = sys_open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    long n = sys_read(fd, buf, cap - 1);
+    sys_close(fd);
+    if (n < 0) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+static int parse_tasks_line(const char *line, task_row_t *r)
+{
+    const char *p = line;
+    unsigned int v;
+
+    if (!parse_uint(&p, &v)) return 0;
+    r->pid = (int)v;
+    while (*p == ' ') p++;
+
+    int i = 0;
+    while (*p && *p != ' ' && i < NAME_W) r->name[i++] = *p++;
+    r->name[i] = '\0';
+    while (*p == ' ') p++;
+
+    i = 0;
+    while (*p && *p != ' ' && i < (int)sizeof(r->state) - 1)
+        r->state[i++] = *p++;
+    r->state[i] = '\0';
+    while (*p == ' ') p++;
+
+    if (*p == '-') { r->tty = -1; p++; }
+    else if (parse_uint(&p, &v)) r->tty = (int)v;
+    else return 0;
+    while (*p == ' ') p++;
+
+    if (!parse_uint(&p, &v)) return 0;
+    r->kticks = v;
+    return 1;
+}
+
+static void refresh_tasks(void)
+{
+    char buf[4096];
+    long n = read_file("/proc/tasks", buf, sizeof(buf));
+    if (n <= 0) { s_nrows = 0; return; }
+
+    task_row_t prev[MAX_TASKS_VIEW];
+    int prev_n = s_nrows;
+    for (int i = 0; i < prev_n; i++) prev[i] = s_task_rows[i];
+
+    s_nrows = 0;
+    char *line = buf;
+    while (*line && s_nrows < MAX_TASKS_VIEW) {
+        char *eol = line;
+        while (*eol && *eol != '\n') eol++;
+        char saved = *eol;
+        *eol = '\0';
+        task_row_t r;
+        if (parse_tasks_line(line, &r)) {
+            r.kticks_prev = 0;
+            for (int i = 0; i < prev_n; i++) {
+                if (prev[i].pid == r.pid) {
+                    r.kticks_prev = prev[i].kticks;
+                    break;
+                }
+            }
+            s_task_rows[s_nrows++] = r;
+        }
+        if (!saved) break;
+        line = eol + 1;
+    }
+
+    if (s_sel >= s_nrows) s_sel = s_nrows - 1;
+    if (s_sel < 0) s_sel = 0;
+
+    /* CPU% over the snapshot interval. */
+    unsigned int total = 0;
+    for (int i = 0; i < s_nrows; i++) total += s_task_rows[i].kticks;
+    unsigned int now = sys_uptime();
+    unsigned int dt_real  = (now > s_uptime_prev) ? (now - s_uptime_prev) : 1u;
+    unsigned int dt_total = (total > s_total_kticks_prev)
+                            ? (total - s_total_kticks_prev) : 0u;
+    s_cpu_pct = (dt_real == 0) ? 0u : (dt_total * 100u) / dt_real;
+    if (s_cpu_pct > 100u) s_cpu_pct = 100u;
+    s_total_kticks_prev = total;
+    s_uptime_prev       = now;
+}
+
+static unsigned int meminfo_field(const char *buf, const char *label)
+{
+    unsigned int ll = slen(label);
+    const char *p = buf;
+    while (*p) {
+        const char *ls = p;
+        const char *eol = p;
+        while (*eol && *eol != '\n') eol++;
+        if ((unsigned int)(eol - ls) > ll && ls[0] == label[0]) {
+            int match = 1;
+            for (unsigned int i = 0; i < ll; i++) {
+                if (ls[i] != label[i]) { match = 0; break; }
+            }
+            if (match) {
+                const char *q = ls + ll;
+                while (*q && (*q == ':' || *q == ' ' || *q == '\t')) q++;
+                unsigned int v = 0;
+                if (parse_uint(&q, &v)) return v;
+            }
+        }
+        if (!*eol) break;
+        p = eol + 1;
+    }
+    return 0;
+}
+
+/* ---- drawing ---- */
+
+static void draw_bar(int col, int row, int inner_w, unsigned int pct,
+                     const char *value_str)
+{
+    if (pct > 100u) pct = 100u;
+    int filled = (int)((pct * (unsigned int)inner_w) / 100u);
+    unsigned char fill_clr =
+        (pct >= 90u) ? CLR_BAR_FILL_CR :
+        (pct >= 50u) ? CLR_BAR_FILL_HI : CLR_BAR_FILL;
+
+    put(col, row, '[', CLR_BAR_BRACKET);
+    for (int i = 0; i < inner_w; i++) {
+        int c = col + 1 + i;
+        if (i < filled) put(c, row, '|', fill_clr);
+        else            put(c, row, ' ', CLR_BAR_EMPTY);
+    }
+    put(col + 1 + inner_w, row, ']', CLR_BAR_BRACKET);
+
+    unsigned int vl = slen(value_str);
+    int vstart = col + 1 + inner_w - (int)vl;
+    if (vstart < col + 1) vstart = col + 1;
+    put_str(vstart, row, value_str, CLR_HDR_TEXT);
+}
+
+static void draw_header(void)
+{
+    char buf[1024];
+    char tmp[32];
+
+    /* CPU row. */
+    put_str(0, HDR_ROW_CPU, "CPU", CLR_HDR_LABEL);
+    char pctbuf[8];
+    uitoa(s_cpu_pct, pctbuf);
+    {
+        unsigned int n = slen(pctbuf);
+        pctbuf[n] = '%'; pctbuf[n+1] = '\0';
+    }
+    draw_bar(4, HDR_ROW_CPU, 40, s_cpu_pct, pctbuf);
+
+    put_str(48, HDR_ROW_CPU, "Tasks: ", CLR_HDR_LABEL);
+    uitoa((unsigned int)s_nrows, tmp);
+    put_str(55, HDR_ROW_CPU, tmp, CLR_HDR_TEXT);
+
+    /* Mem row. */
+    unsigned int total_kb = 0, free_kb = 0;
+    long n = read_file("/proc/meminfo", buf, sizeof(buf));
+    if (n > 0) {
+        total_kb = meminfo_field(buf, "MemTotal");
+        free_kb  = meminfo_field(buf, "MemFree");
+    }
+    unsigned int used_kb = (total_kb > free_kb) ? (total_kb - free_kb) : 0u;
+    unsigned int mem_pct = (total_kb == 0u) ? 0u
+                            : (used_kb * 100u) / total_kb;
+
+    put_str(0, HDR_ROW_MEM, "Mem", CLR_HDR_LABEL);
+    char memval[24];
+    {
+        char a[12], b[12];
+        uitoa(used_kb / 1024u, a);
+        uitoa(total_kb / 1024u, b);
+        int o = 0;
+        for (unsigned int i = 0; a[i]; i++) memval[o++] = a[i];
+        memval[o++] = 'M'; memval[o++] = '/';
+        for (unsigned int i = 0; b[i]; i++) memval[o++] = b[i];
+        memval[o++] = 'M'; memval[o] = '\0';
+    }
+    draw_bar(4, HDR_ROW_MEM, 40, mem_pct, memval);
+
+    put_str(48, HDR_ROW_MEM, "Uptime: ", CLR_HDR_LABEL);
+    unsigned int ticks = sys_uptime();
+    unsigned int secs  = ticks / 100u;
+    unsigned int hh = secs / 3600u, mm = (secs % 3600u) / 60u, ss = secs % 60u;
+    int col = 56;
+    uitoa(hh, tmp); put_str(col, HDR_ROW_MEM, tmp, CLR_HDR_TEXT); col += (int)slen(tmp);
+    put(col++, HDR_ROW_MEM, 'h', CLR_HDR_TEXT);
+    put(col++, HDR_ROW_MEM, ' ', CLR_BG);
+    uitoa(mm, tmp); put_str(col, HDR_ROW_MEM, tmp, CLR_HDR_TEXT); col += (int)slen(tmp);
+    put(col++, HDR_ROW_MEM, 'm', CLR_HDR_TEXT);
+    put(col++, HDR_ROW_MEM, ' ', CLR_BG);
+    uitoa(ss, tmp); put_str(col, HDR_ROW_MEM, tmp, CLR_HDR_TEXT); col += (int)slen(tmp);
+    put(col++, HDR_ROW_MEM, 's', CLR_HDR_TEXT);
+}
+
+static void draw_column_headers(void)
+{
+    put_pad(0, ROW_COL_HDR, s_cols, CLR_COLHDR);
+    put_str(1,  ROW_COL_HDR, "PID",   CLR_COLHDR);
+    put_str(6,  ROW_COL_HDR, "NAME",  CLR_COLHDR);
+    put_str(24, ROW_COL_HDR, "STATE", CLR_COLHDR);
+    put_str(32, ROW_COL_HDR, "TTY",   CLR_COLHDR);
+    put_str(38, ROW_COL_HDR, "TICKS", CLR_COLHDR);
+    put_str(48, ROW_COL_HDR, "DELTA", CLR_COLHDR);
+}
+
+static void draw_rows(void)
+{
+    char tmp[16];
+    for (int i = 0; i < MAX_TASKS_VIEW; i++) {
+        int row = ROW_LIST_FIRST + i;
+        unsigned char clr = (i == s_sel) ? CLR_ROW_SEL : CLR_ROW;
+        put_pad(0, row, s_cols, clr);
+
+        if (i >= s_nrows) continue;
+        task_row_t *r = &s_task_rows[i];
+
+        uitoa((unsigned int)r->pid, tmp);
+        put_str(1, row, tmp, clr);
+        put_str(6, row, r->name, clr);
+        put_str(24, row, r->state, clr);
+        if (r->tty < 0) put(32, row, '-', clr);
+        else { uitoa((unsigned int)r->tty, tmp); put_str(32, row, tmp, clr); }
+        uitoa(r->kticks, tmp);
+        put_str(38, row, tmp, clr);
+
+        unsigned int delta = (r->kticks >= r->kticks_prev)
+                             ? (r->kticks - r->kticks_prev) : 0u;
+        uitoa(delta, tmp);
+        put_str(48, row, tmp, clr);
+    }
+}
+
+/* htop-style footer: "F1Help F2Setup ..." with numbers in white-on-black
+ * and labels in black-on-cyan.  Only F9 / F10 are wired; the others are
+ * placeholders so the visual matches htop. */
+static void draw_footer(void)
+{
+    static const struct { const char *num; const char *lbl; } keys[] = {
+        { "F1",  "Help  "  },
+        { "F2",  "Setup "  },
+        { "F3",  "Search"  },
+        { "F5",  "Tree  "  },
+        { "F6",  "SortBy"  },
+        { "F9",  "Kill  "  },
+        { "F10", "Quit  "  },
+    };
+    int col = 0;
+    put_pad(0, ROW_FOOTER, s_cols, CLR_FKEY_LABEL);
+    for (unsigned int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++) {
+        const char *n = keys[i].num;
+        const char *l = keys[i].lbl;
+        for (; *n && col < s_cols; n++) put(col++, ROW_FOOTER, *n, CLR_FKEY_NUM);
+        for (; *l && col < s_cols; l++) put(col++, ROW_FOOTER, *l, CLR_FKEY_LABEL);
+    }
+}
+
+static void draw_all(void)
+{
+    g_ncells = 0;
+    for (int r = 0; r < s_rows; r++) put_pad(0, r, s_cols, CLR_BG);
+    draw_header();
+    draw_column_headers();
+    draw_rows();
+    draw_footer();
+    flush();
+    sys_set_cursor(0, ROW_STATUS);
+}
+
+/* ---- key reading ---- */
+
+static int read_key_nb(void)
+{
+    unsigned char c;
+    long r = sys_read(0, &c, 1);
+    if (r == 1) return (int)c;
+    return -1;
+}
+
+static int wait_key(void)
+{
+    for (;;) {
+        int c = read_key_nb();
+        if (c >= 0) return c;
+        sys_yield();
+    }
+}
+
+/* ---- status / prompt ---- */
+
+static void show_status(const char *msg, unsigned char clr)
+{
+    g_ncells = 0;
+    put_pad(0, ROW_STATUS, s_cols, clr);
+    put_str(1, ROW_STATUS, msg, clr);
+    flush();
+}
+
+static int prompt_signo(int pid)
+{
+    g_ncells = 0;
+    put_pad(0, ROW_STATUS, s_cols, CLR_STATUS);
+    put_str(1, ROW_STATUS, "Send signal (1..31) to PID ", CLR_STATUS);
+    char pbuf[12]; uitoa((unsigned int)pid, pbuf);
+    put_str(28, ROW_STATUS, pbuf, CLR_STATUS);
+    put(28 + (int)slen(pbuf), ROW_STATUS, ':', CLR_STATUS);
+    int input_col = 28 + (int)slen(pbuf) + 2;
+    flush();
+
+    char buf[8];
+    int n = 0;
+    for (;;) {
+        int c = wait_key();
+        if (c == '\n' || c == '\r') break;
+        if (c == 0x1B) return -1;
+        if (c == 8 || c == 0x7F) {
+            if (n > 0) {
+                n--;
+                g_ncells = 0;
+                put(input_col + n, ROW_STATUS, ' ', CLR_STATUS);
+                flush();
+            }
+            continue;
+        }
+        if (c >= '0' && c <= '9' && n < (int)sizeof(buf) - 1) {
+            buf[n] = (char)c;
+            g_ncells = 0;
+            put(input_col + n, ROW_STATUS, (char)c, CLR_STATUS);
+            flush();
+            n++;
+        }
+    }
+    if (n == 0) return -1;
+    buf[n] = '\0';
+    const char *p = buf;
+    unsigned int v;
+    if (!parse_uint(&p, &v)) return -1;
+    if (v < 1 || v > 31) return -1;
+    return (int)v;
+}
+
+#define REFRESH_TICKS 50u
+
+int main(int argc, char **argv, char **envp)
+{
+    (void)argc; (void)argv; (void)envp;
+
+    /* Pull the live pane dimensions.  These already exclude the VT
+     * status bar -- the kernel renders that on the row immediately
+     * below our pane, so we can use the whole reported area. */
+    s_cols = (int)sys_term_cols();
+    s_rows = (int)sys_term_rows();
+    if (s_cols > MAX_COLS) s_cols = MAX_COLS;
+    if (s_rows > MAX_ROWS) s_rows = MAX_ROWS;
+    if (s_cols < 70 || s_rows < 10) {
+        const char *e = "maktop: needs >= 70 cols and 10 rows of screen\n";
+        unsigned int n = 0; while (e[n]) n++;
+        sys_write_serial(e, n);
+        return 2;
+    }
+
+    /* Layout (top-down): two header rows, a blank separator, the
+     * column header bar, then the task list, then status + footer. */
+    HDR_ROW_CPU    = 0;
+    HDR_ROW_MEM    = 1;
+    ROW_COL_HDR    = 3;
+    ROW_LIST_FIRST = 4;
+    ROW_FOOTER     = s_rows - 1;
+    ROW_STATUS     = s_rows - 2;
+    ROW_LIST_LAST  = s_rows - 3;
+    MAX_TASKS_VIEW = ROW_LIST_LAST - ROW_LIST_FIRST + 1;
+    if (MAX_TASKS_VIEW > MAX_TASKS_CAP) MAX_TASKS_VIEW = MAX_TASKS_CAP;
+
+    if (sys_fcntl(0, F_SETFL, O_NONBLOCK) != 0) {
+        const char *e = "maktop: sys_fcntl failed\n";
+        unsigned int n = 0; while (e[n]) n++;
+        sys_write_serial(e, n);
+        return 1;
+    }
+
+    s_uptime_prev       = sys_uptime();
+    s_total_kticks_prev = 0;
+    unsigned int next_refresh = s_uptime_prev + REFRESH_TICKS;
+
+    sys_tty_clear(CLR_BG);
+    refresh_tasks();
+    draw_all();
+
+    for (;;) {
+        int c = read_key_nb();
+
+        if (c >= 0) {
+            if (c == 'q' || c == 'Q' || c == (int)KEY_F10) break;
+
+            if (c == KEY_ARROW_UP) {
+                if (s_sel > 0) s_sel--;
+                draw_all();
+            } else if (c == KEY_ARROW_DOWN) {
+                if (s_sel < s_nrows - 1) s_sel++;
+                draw_all();
+            } else if (c == (int)KEY_F9 || c == 'k' || c == 'K') {
+                if (s_nrows > 0) {
+                    int pid = s_task_rows[s_sel].pid;
+                    int rc = sys_kill(pid, SIGTERM);
+                    show_status((rc == 0) ? " SIGTERM sent "
+                                          : " sys_kill failed ",
+                                (rc == 0) ? CLR_STATUS : CLR_STATUS_ERR);
+                }
+            } else if (c == 's' || c == 'S') {
+                if (s_nrows > 0) {
+                    int pid = s_task_rows[s_sel].pid;
+                    int sig = prompt_signo(pid);
+                    if (sig > 0) {
+                        int rc = sys_kill(pid, sig);
+                        show_status((rc == 0) ? " signal sent "
+                                              : " sys_kill failed ",
+                                    (rc == 0) ? CLR_STATUS : CLR_STATUS_ERR);
+                    } else {
+                        draw_all();
+                    }
+                }
+            } else if (c == 'r' || c == 'R') {
+                refresh_tasks();
+                draw_all();
+                next_refresh = sys_uptime() + REFRESH_TICKS;
+            }
+            continue;
+        }
+
+        unsigned int now = sys_uptime();
+        if ((int)(now - next_refresh) >= 0) {
+            refresh_tasks();
+            draw_all();
+            next_refresh = now + REFRESH_TICKS;
+        }
+        sys_yield();
+    }
+
+    sys_fcntl(0, F_SETFL, 0);
+    sys_tty_clear(VGA_CLR(VGA_LGREY, VGA_BLACK));
+    return 0;
+}

--- a/src/userspace/maktop.c
+++ b/src/userspace/maktop.c
@@ -78,10 +78,34 @@ static unsigned int s_cpu_pct;
 static tty_cell_t g_cells[MAX_COLS * MAX_ROWS];
 static int        g_ncells;
 
+/* Diff buffer.  We keep the last (ch, clr) we sent for every cell;
+ * put() skips re-queueing cells that haven't changed.  Eliminates the
+ * flicker that came from repainting 1920 cells per refresh on the
+ * VESA framebuffer (each glyph blit is visible).  ~19 KiB at MAX
+ * dimensions, lives in .bss. */
+typedef struct { unsigned char ch; unsigned char clr; } prev_cell_t;
+static prev_cell_t s_prev[MAX_COLS * MAX_ROWS];
+
+/* Force the next put() pass to emit every cell (after switching modes
+ * like picker overlay → restore, or on first frame). */
+static void invalidate_prev(void)
+{
+    for (int i = 0; i < (int)(sizeof(s_prev)/sizeof(s_prev[0])); i++) {
+        s_prev[i].ch  = 0xFF;
+        s_prev[i].clr = 0xFF;
+    }
+}
+
 /* ---- draw helpers ---- */
 
 static inline void put(int col, int row, char c, unsigned char clr)
 {
+    if (col < 0 || row < 0 || col >= MAX_COLS || row >= MAX_ROWS) return;
+    int key = row * MAX_COLS + col;
+    if (s_prev[key].ch == (unsigned char)c && s_prev[key].clr == clr)
+        return;
+    s_prev[key].ch  = (unsigned char)c;
+    s_prev[key].clr = clr;
     if (g_ncells < (int)(sizeof(g_cells) / sizeof(g_cells[0]))) {
         g_cells[g_ncells].col = (unsigned char)col;
         g_cells[g_ncells].row = (unsigned char)row;
@@ -186,18 +210,28 @@ static int parse_tasks_line(const char *line, task_row_t *r)
     return 1;
 }
 
+/* Static read buffers: the user stack is one 4 KiB page (see
+ * USER_STACK_TOP in usertest.c) and locals like a 4 KiB char[] would
+ * straddle the bottom guard and page-fault.  None of these helpers
+ * recurse or run concurrently, so .bss is the natural home. */
+static char s_proc_tasks_buf[4096];
+static char s_proc_meminfo_buf[1024];
+
 static void refresh_tasks(void)
 {
-    char buf[4096];
-    long n = read_file("/proc/tasks", buf, sizeof(buf));
+    long n = read_file("/proc/tasks", s_proc_tasks_buf, sizeof(s_proc_tasks_buf));
     if (n <= 0) { s_nrows = 0; return; }
 
-    task_row_t prev[MAX_TASKS_VIEW];
+    /* Move prev[] off the stack -- the user task gets one 4 KiB stack
+     * page, and a VLA of MAX_TASKS_CAP entries (~1.5 KiB) plus the
+     * other locals here was close enough to overflow it on the first
+     * iteration. */
+    static task_row_t prev[MAX_TASKS_CAP];
     int prev_n = s_nrows;
     for (int i = 0; i < prev_n; i++) prev[i] = s_task_rows[i];
 
     s_nrows = 0;
-    char *line = buf;
+    char *line = s_proc_tasks_buf;
     while (*line && s_nrows < MAX_TASKS_VIEW) {
         char *eol = line;
         while (*eol && *eol != '\n') eol++;
@@ -221,9 +255,17 @@ static void refresh_tasks(void)
     if (s_sel >= s_nrows) s_sel = s_nrows - 1;
     if (s_sel < 0) s_sel = 0;
 
-    /* CPU% over the snapshot interval. */
+    /* CPU% over the snapshot interval.  Exclude pid=1 (idle): at every
+     * PIT IRQ some task is current and gets credited, and when nothing
+     * else is runnable that's always idle -- so a naive sum would always
+     * read 100% utilisation.  Linux excludes idle the same way (the
+     * "idle" column in /proc/stat is the "subtract this for CPU%"
+     * bucket). */
     unsigned int total = 0;
-    for (int i = 0; i < s_nrows; i++) total += s_task_rows[i].kticks;
+    for (int i = 0; i < s_nrows; i++) {
+        if (s_task_rows[i].pid == 1) continue;
+        total += s_task_rows[i].kticks;
+    }
     unsigned int now = sys_uptime();
     unsigned int dt_real  = (now > s_uptime_prev) ? (now - s_uptime_prev) : 1u;
     unsigned int dt_total = (total > s_total_kticks_prev)
@@ -287,7 +329,6 @@ static void draw_bar(int col, int row, int inner_w, unsigned int pct,
 
 static void draw_header(void)
 {
-    char buf[1024];
     char tmp[32];
 
     /* CPU row. */
@@ -306,10 +347,10 @@ static void draw_header(void)
 
     /* Mem row. */
     unsigned int total_kb = 0, free_kb = 0;
-    long n = read_file("/proc/meminfo", buf, sizeof(buf));
+    long n = read_file("/proc/meminfo", s_proc_meminfo_buf, sizeof(s_proc_meminfo_buf));
     if (n > 0) {
-        total_kb = meminfo_field(buf, "MemTotal");
-        free_kb  = meminfo_field(buf, "MemFree");
+        total_kb = meminfo_field(s_proc_meminfo_buf, "MemTotal");
+        free_kb  = meminfo_field(s_proc_meminfo_buf, "MemFree");
     }
     unsigned int used_kb = (total_kb > free_kb) ? (total_kb - free_kb) : 0u;
     unsigned int mem_pct = (total_kb == 0u) ? 0u
@@ -490,7 +531,109 @@ static int prompt_signo(int pid)
     return (int)v;
 }
 
-#define REFRESH_TICKS 50u
+/* ---- htop-style left-panel signal picker ----
+ *
+ * F9 (or k) overlays a scrollable list of named signals on the left
+ * side of the screen.  Up/Down navigate, Enter sends to the highlighted
+ * task in the underlying list, Esc cancels.  Returns the chosen signo
+ * (1..31) or -1 on cancel. */
+
+static const struct { int signo; const char *name; } SIGNALS[] = {
+    {  1, "SIGHUP"   },
+    {  2, "SIGINT"   },
+    {  3, "SIGQUIT"  },
+    {  4, "SIGILL"   },
+    {  5, "SIGTRAP"  },
+    {  6, "SIGABRT"  },
+    {  8, "SIGFPE"   },
+    {  9, "SIGKILL"  },
+    { 10, "SIGUSR1"  },
+    { 11, "SIGSEGV"  },
+    { 12, "SIGUSR2"  },
+    { 13, "SIGPIPE"  },
+    { 14, "SIGALRM"  },
+    { 15, "SIGTERM"  },
+    { 17, "SIGCHLD"  },
+    { 18, "SIGCONT"  },
+    { 19, "SIGSTOP"  },
+    { 20, "SIGTSTP"  },
+};
+
+#define PICKER_W 20
+
+#define CLR_PICK_HDR  VGA_CLR(VGA_BLACK,  VGA_LGREEN)
+#define CLR_PICK_ROW  VGA_CLR(VGA_LGREY,  VGA_BLACK)
+#define CLR_PICK_SEL  VGA_CLR(VGA_BLACK,  VGA_LCYAN)
+#define CLR_PICK_HINT VGA_CLR(VGA_LCYAN,  VGA_BLACK)
+
+static void draw_picker(int sel, int target_pid)
+{
+    char tmp[16];
+    int total = (int)(sizeof(SIGNALS)/sizeof(SIGNALS[0]));
+
+    /* Header row across the picker width. */
+    put_pad(0, 0, PICKER_W, CLR_PICK_HDR);
+    put_str(1, 0, "Send signal:", CLR_PICK_HDR);
+    /* Show target PID compactly on the same header line if there's room. */
+    {
+        uitoa((unsigned int)target_pid, tmp);
+        unsigned int n = slen(tmp);
+        int col = PICKER_W - (int)n - 1;
+        if (col > 13) put_str(col, 0, tmp, CLR_PICK_HDR);
+    }
+
+    /* Body rows: scroll so sel is always visible.  ROW_FOOTER and
+     * one above it are reserved for the hint line.  We don't draw on
+     * the kernel's status row (s_rows is the pane height; kernel
+     * status bar lives at row s_rows). */
+    int body_top    = 1;
+    int body_bottom = s_rows - 2;       /* leave one row for hint */
+    int body_h      = body_bottom - body_top + 1;
+    int top = sel - body_h / 2;
+    if (top < 0) top = 0;
+    if (top > total - body_h) top = total - body_h;
+    if (top < 0) top = 0;
+
+    for (int row = body_top; row <= body_bottom; row++) {
+        int idx = top + (row - body_top);
+        unsigned char clr = (idx == sel) ? CLR_PICK_SEL : CLR_PICK_ROW;
+        put_pad(0, row, PICKER_W, clr);
+        if (idx < 0 || idx >= total) continue;
+        uitoa((unsigned int)SIGNALS[idx].signo, tmp);
+        /* Right-align signo in cols 1..3. */
+        int slot = 3 - (int)slen(tmp);
+        if (slot < 1) slot = 1;
+        put_str(slot, row, tmp, clr);
+        put_str(5, row, SIGNALS[idx].name, clr);
+    }
+
+    /* Hint row at the bottom of the picker. */
+    put_pad(0, s_rows - 1, PICKER_W, CLR_PICK_HINT);
+    put_str(1, s_rows - 1, " up/dn  ent send ", CLR_PICK_HINT);
+
+    flush();
+}
+
+static int signal_picker(int target_pid)
+{
+    int sel = 13;   /* index of SIGTERM in the table -- safe default */
+    int total = (int)(sizeof(SIGNALS)/sizeof(SIGNALS[0]));
+
+    invalidate_prev();    /* picker overlays the underlying view */
+    draw_picker(sel, target_pid);
+
+    for (;;) {
+        int c = wait_key();
+        if (c == 0x1B || c == 'q' || c == 'Q') return -1;     /* Esc / q */
+        if (c == '\n' || c == '\r') return SIGNALS[sel].signo;
+        if (c == KEY_ARROW_UP   && sel > 0)            { sel--; draw_picker(sel, target_pid); }
+        else if (c == KEY_ARROW_DOWN && sel < total-1) { sel++; draw_picker(sel, target_pid); }
+    }
+}
+
+/* htop's default refresh is 1.5 s; we use 1 s here.  Faster than that
+ * the digit cells flicker visibly on the VESA framebuffer. */
+#define REFRESH_TICKS 100u
 
 int main(int argc, char **argv, char **envp)
 {
@@ -533,6 +676,11 @@ int main(int argc, char **argv, char **envp)
     s_total_kticks_prev = 0;
     unsigned int next_refresh = s_uptime_prev + REFRESH_TICKS;
 
+    /* First frame: force every cell out so the diff buffer reflects
+     * what's actually on the framebuffer.  Without this the put()
+     * skip-if-unchanged would suppress cells whose new (ch, clr)
+     * matched the .bss-zeroed prev buffer (0x00 black-on-black). */
+    invalidate_prev();
     sys_tty_clear(CLR_BG);
     refresh_tasks();
     draw_all();
@@ -552,12 +700,21 @@ int main(int argc, char **argv, char **envp)
             } else if (c == (int)KEY_F9 || c == 'k' || c == 'K') {
                 if (s_nrows > 0) {
                     int pid = s_task_rows[s_sel].pid;
-                    int rc = sys_kill(pid, SIGTERM);
-                    show_status((rc == 0) ? " SIGTERM sent "
-                                          : " sys_kill failed ",
-                                (rc == 0) ? CLR_STATUS : CLR_STATUS_ERR);
+                    int sig = signal_picker(pid);
+                    /* Picker overlaid the left column; force a full
+                     * repaint of the underlying view to wipe it. */
+                    invalidate_prev();
+                    draw_all();
+                    if (sig > 0) {
+                        int rc = sys_kill(pid, sig);
+                        show_status((rc == 0) ? " signal sent "
+                                              : " sys_kill failed ",
+                                    (rc == 0) ? CLR_STATUS : CLR_STATUS_ERR);
+                    }
                 }
             } else if (c == 's' || c == 'S') {
+                /* Numeric-entry alternate path -- handy for muscle
+                 * memory.  Same effect as the picker but typed. */
                 if (s_nrows > 0) {
                     int pid = s_task_rows[s_sel].pid;
                     int sig = prompt_signo(pid);
@@ -588,6 +745,11 @@ int main(int argc, char **argv, char **envp)
     }
 
     sys_fcntl(0, F_SETFL, 0);
-    sys_tty_clear(VGA_CLR(VGA_LGREY, VGA_BLACK));
+    /* Restore the shell's default palette (same code path as the
+     * `clear` shell builtin and what vix uses on exit).  Our
+     * sys_tty_clear with our own bg colour leaves the screen black,
+     * which doesn't match the operator's expectation of returning to
+     * the shell colours. */
+    sys_shell_clear();
     return 0;
 }

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -30,6 +30,17 @@
 #define SYS_SHELL_CLEAR  213
 #define SYS_UPTIME       214
 #define SYS_GETCWD       215
+#define SYS_FCNTL        55
+
+/* fcntl cmds */
+#define F_GETFL          3
+#define F_SETFL          4
+
+/* O_NONBLOCK for F_SETFL on stdin (fd 0).  Matches Linux i386 0x800. */
+#define O_NONBLOCK       0x800
+
+/* read(2) errno-style return for "no data and non-blocking". */
+#define EAGAIN           11
 
 /* Signal numbers (Linux i386 ABI subset).  Mirrors <kernel/signal.h>;
  * kept in sync by hand since the userspace build doesn't see kernel
@@ -234,6 +245,15 @@ static inline void sys_yield(void)
 static inline int sys_getkey(void)
 {
     return (int)syscall1(SYS_GETKEY, 0);
+}
+
+/* POSIX-style fcntl.  Currently supported: F_GETFL (cmd=3) returns the
+ * current fd flags; F_SETFL (cmd=4) replaces them (the only meaningful
+ * bit today is O_NONBLOCK on stdin).  Returns 0/flags on success,
+ * negative errno on error. */
+static inline int sys_fcntl(int fd, int cmd, long arg)
+{
+    return (int)syscall3(SYS_FCNTL, (long)fd, (long)cmd, arg);
 }
 
 /* Write n screen cells at their specified positions. */

--- a/tests/ui_runner.sh
+++ b/tests/ui_runner.sh
@@ -230,6 +230,62 @@ CURRENT_SEGMENT=""
 CURRENT_DUMP=""
 CURRENT_FAILED=0
 
+# wait_for_serial <pattern> <start_bytes> [timeout_s=5]
+#   Polls $SERIAL_LOG for the first match of <pattern> in the slice
+#   starting at byte offset <start_bytes>.  Returns 0 when found, 1 on
+#   timeout.  Used by `it_until` (and by tests directly) to replace
+#   fixed sleeps with "sync on a marker" -- the expect/pexpect idiom.
+wait_for_serial() {
+    local pattern=$1
+    local start_bytes=$2
+    local timeout=${3:-5}
+    local deadline=$(($(date +%s) + timeout))
+    while [ $(date +%s) -lt $deadline ]; do
+        if [ -f "$SERIAL_LOG" ] && \
+           dd if="$SERIAL_LOG" bs=1 skip="$start_bytes" 2>/dev/null \
+              | grep -qE -- "$pattern"; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+# it_until <label> <sendkey-script> <sync-pattern> [timeout_s=5]
+#   Like `it`, but instead of sleeping a fixed duration after the keys
+#   are sent, polls the serial log until <sync-pattern> appears (or
+#   the timeout elapses).  The shell's `shell_readline` emits
+#   `[shell:ready vt=N]` on entry, so `'\[shell:ready vt=0\]'` is the
+#   natural sync marker for "the shell is back at the prompt".
+it_until() {
+    CURRENT_NAME=$1
+    local script=$2
+    local pattern=$3
+    local timeout=${4:-5}
+
+    reset_shell
+
+    local start_bytes=0
+    if [ -f "$SERIAL_LOG" ]; then
+        start_bytes=$(wc -c < "$SERIAL_LOG")
+    fi
+
+    send_script "$script"
+
+    if ! wait_for_serial "$pattern" "$start_bytes" "$timeout"; then
+        echo "  - wait_for_serial timed out waiting for: $pattern"
+    fi
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+
+    dd if="$SERIAL_LOG" bs=1 skip="$start_bytes" 2>/dev/null > "$CURRENT_SEGMENT"
+}
+
 # it <label> <sendkey-script> [extra-wait-secs]
 #   Resets the shell, drives the keystrokes, waits long enough for the
 #   command(s) to complete, snapshots the per-test serial slice into

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -241,6 +241,82 @@ sendkey ret" \
     assert_serial_contains "24" "21" "32"
 }
 
+test_no_dead_in_proctasks() {
+    # Slice 8/9 cleanup: /proc/tasks should not list DEAD slots that
+    # are waiting for task_create to reclaim them.  bg-ktest spawns
+    # `preempt_victim`, `ktest_noop1`, etc., during the boot test
+    # suite and they end up DEAD by the time the shell is up.  If the
+    # filter is working, `cat /proc/tasks` should never include the
+    # string "DEAD".
+    it "no-dead-in-proctasks" \
+"sendkey c
+sendkey a
+sendkey t
+sendkey spc
+sendkey slash
+sendkey p
+sendkey r
+sendkey o
+sendkey c
+sendkey slash
+sendkey t
+sendkey a
+sendkey s
+sendkey k
+sendkey s
+sendkey ret"
+    assert_serial_contains "shell0" "shell1"
+    assert_serial_not_contains "DEAD"
+}
+
+test_typo_doesnt_clear() {
+    # Slice 8 polish: a wrong command falls back to makbox, which
+    # prints an error to stderr and exits.  With shell_exec_elf's
+    # unconditional shell_clear_screen this used to wipe the screen.
+    # After gating on task->fb_touched, line-mode output stays
+    # visible.  Verify by typing a typo, then `pwd`, and asserting
+    # both the makbox error AND the pwd provenance reach serial in
+    # the same slice.
+    # Two-stage send: type the typo + Enter, wait for shell-ready
+    # (== shell back at the prompt after makbox-fallback died), THEN
+    # type pwd + Enter.  Without the intermediate sync the second
+    # batch's first byte races keyboard_release_task on the dying
+    # exec child and gets dropped (we'd see "wd" reach the shell
+    # instead of "pwd").  Pure timing fix; no kernel changes.
+    CURRENT_NAME=typo-doesnt-clear
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey n
+sendkey o
+sendkey s
+sendkey u
+sendkey c
+sendkey h
+sendkey c
+sendkey m
+sendkey d
+sendkey ret'
+    wait_for_serial '\[shell:ready vt=0\]' "$sb1" 5 || \
+        echo "  - stage1: never returned to prompt"
+    local sb2=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    wait_for_serial '\[makbox:pwd\]' "$sb2" 5 || \
+        echo "  - stage2: pwd never produced [makbox:pwd]"
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+
+    assert_serial_contains "[makbox:pwd]"
+}
+
 test_user_sigusr1_handler() {
     # Slice 8 phase 4: ring-3 trampoline + sigreturn lets sys_signal(2)
     # actually invoke a user-installed handler.  sigtest.elf installs a
@@ -347,7 +423,7 @@ sendkey ret"
 
 # --- Driver -----------------------------------------------------------------
 
-ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child user_sigusr1_handler makbox_pwd)
+ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear user_sigusr1_handler makbox_pwd)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary

Slice 11 of the multi-PR split from #154. Stacked on **#159** (maktop+procfs). Hides the tmux-style VT status bar (`Makar  VT0  VT1 …  Alt+F1-F4`) during the boot loading screen, so the loading sequence renders against a clean canvas. The bar fades back in once `shell_run` enters its prompt loop.

**Base branch:** `feat/maktop-procfs` (PR #159).

## Why

The status bar paints into a reserved bottom row that's part of the framebuffer the loader scribbles on (spinner + progress bar). With the bar drawn early, the loader appears to be drawing *behind* a permanent UI element — visually distracting and architecturally wrong (the bar represents user-facing VT state that doesn't exist yet).

Suppressing it during boot also gives the loader the full row count to work with, which matters when you bump the loading progress text or add new ktest milestones.

## What lands

- Global gate `g_statusbar_visible` (or whatever the commit named it — see diff)
- Status-bar render is a no-op while the gate is off
- Gate flips on at the first `shell_run` prompt
- Loading screen tear-down clears the reserved row so the bar's first paint isn't fighting leftover pixels

## Validation

- `./run.sh iso-build` — clean (no new warnings vs `feat/maktop-procfs`)
- `./run.sh ui-test exec-hello no-dead-in-proctasks` — 2/2 pass (both scenarios cross the loading → shell handoff)

Visual inspection (boot in `./run.sh iso-boot` GUI): loading screen now renders with no bar; bar appears at the bottom on first prompt.

## Context

Part 4 of 5 splitting #154:
- [x] PR-A: #157 — signal subsystem (slice 8)
- [x] PR-B: #158 — preemption hardening (slice 9)
- [x] PR-C: #159 — maktop + task hardening + procfs polish + ui-test sync
- [x] **PR-D: this PR** — status-bar hide on loading
- [ ] PR-E: `run.sh` two-arg grammar (off main, independent)

Originally PR-D was scoped to include per-VT palettes and the expect-style ui-test sync, but both of those lived inside the slice-10 megacommit that landed in #159. This PR is now the focused status-bar change.

## Test plan

- [ ] `./run.sh iso-build`
- [ ] `./run.sh iso-boot` GUI — verify no status bar during loading; appears at first prompt
- [ ] `./run.sh ui-test` — full pass