### PR TITLE
refactor(run.sh): two-arg grammar + per-VT palettes + clock.elf

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,10 +65,10 @@ jobs:
             ccache-${{ runner.os }}-
 
       - name: Build ISOs (kernel + makar.iso + makar-test.iso)
-        run: ./run.sh iso-build
+        run: ./run.sh iso build
 
       - name: Build HDD test image (kernel cached from ISO build)
-        run: ./run.sh hdd-build
+        run: ./run.sh hdd build
 
       - name: ccache stats
         if: always()
@@ -115,7 +115,7 @@ jobs:
           name: makar-build
 
       - name: Run ktest
-        run: ./run.sh ktest-run
+        run: ./run.sh ktest
 
       - name: Upload ktest log
         if: always()
@@ -148,7 +148,7 @@ jobs:
           name: makar-build
 
       - name: Run GDB ISO boot test
-        run: ./run.sh gdb-iso-run
+        run: ./run.sh gdb iso
 
       - name: Upload GDB logs
         if: always()
@@ -183,7 +183,7 @@ jobs:
           name: makar-build
 
       - name: Run GDB HDD boot test
-        run: ./run.sh gdb-hdd-run
+        run: ./run.sh gdb hdd
 
       - name: Upload GDB logs
         if: always()
@@ -195,7 +195,7 @@ jobs:
             hdd-test-serial.log
 
   # NOTE: UI tests (sendkey + serial grep) live in tests/ui_test.sh and
-  # are runnable locally via `./run.sh ui-test`.  They are intentionally
+  # are runnable locally via `./run.sh ui`.  They are intentionally
   # NOT wired into this CI workflow: under TCG (no KVM in GHA runners)
   # boot to shell takes 30-60s per scenario, so the suite is slow and
   # historically prone to hanging when QEMU misbehaves on shared

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
           echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build release ISO
-        run: ./run.sh iso-release
+        run: ./run.sh iso release
 
       - name: Build release HDD image
-        run: ./run.sh hdd-release
+        run: ./run.sh hdd release
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,24 +12,24 @@ All build, test, and boot operations go through a single entrypoint:
 
 ```sh
 # Day-to-day (build + run in one shot)
-./run.sh iso-boot       # clean → debug ISO → interactive QEMU
-./run.sh iso-test       # full CI suite: ktest + GDB boot-checkpoint tests
-./run.sh iso-ktest-gui  # test ISO → ktest with display window (needs host QEMU)
-./run.sh iso-release    # optimised release ISO
+./run.sh iso boot       # clean → debug ISO → interactive QEMU
+./run.sh iso test       # full CI suite: ktest + GDB boot-checkpoint tests
+./run.sh ktest graphical  # test ISO → ktest with display window (needs host QEMU)
+./run.sh iso release    # optimised release ISO
 
-./run.sh hdd-boot       # clean → build kernel → HDD image → interactive QEMU
-./run.sh hdd-test       # clean → build kernel → HDD image → GDB boot test
-./run.sh hdd-release    # HDD image only
+./run.sh hdd boot       # clean → build kernel → HDD image → interactive QEMU
+./run.sh hdd test       # clean → build kernel → HDD image → GDB boot test
+./run.sh hdd release    # HDD image only
 
-./run.sh ui-test        # black-box UI tests (headless QEMU, sendkey + serial grep)
-./run.sh ui-test-gui    # same but with visible QEMU window + paced typing
+./run.sh ui        # black-box UI tests (headless QEMU, sendkey + serial grep)
+./run.sh ui graphical    # same but with visible QEMU window + paced typing
 
 # CI-style split modes (build once, run many — used by .github/workflows/build-test.yml)
-./run.sh iso-build      # kernel + makar.iso + makar-test.iso, no run
-./run.sh hdd-build      # kernel + makar-hdd-test.img, no run
-./run.sh ktest-run      # ktest against existing makar-test.iso
-./run.sh gdb-iso-run    # GDB ISO boot test against existing makar.iso
-./run.sh gdb-hdd-run    # GDB HDD boot test against existing makar-hdd-test.img
+./run.sh iso build      # kernel + makar.iso + makar-test.iso, no run
+./run.sh hdd build      # kernel + makar-hdd-test.img, no run
+./run.sh ktest      # ktest against existing makar-test.iso
+./run.sh gdb iso    # GDB ISO boot test against existing makar.iso
+./run.sh gdb hdd    # GDB HDD boot test against existing makar-hdd-test.img
 
 ./run.sh clean          # remove all build artefacts
 
@@ -65,7 +65,7 @@ QEMU steps prefer host `qemu-system-i386` when Docker is the build context; fall
 
 **Full CI suite** (`iso-test`: ktest + GDB boot checkpoints):
 ```sh
-./run.sh iso-test
+./run.sh iso test
 # Phase 1: test_mode ISO → ktest_run_all() → QEMU exits.  Output: ktest.log
 # Phase 2: debug ISO + FAT32 test disk → full GDB test suite.  Output: gdb-test.log
 # exits 0 on pass, 1 on any failure
@@ -73,7 +73,7 @@ QEMU steps prefer host `qemu-system-i386` when Docker is the build context; fall
 
 **HDD boot test:**
 ```sh
-./run.sh hdd-test
+./run.sh hdd test
 # Builds kernel → generates makar-hdd-test.img → GDB boot test (no CD-ROM)
 # outputs: hdd-test-gdb.log, hdd-test-serial.log
 ```
@@ -101,15 +101,15 @@ docker run --rm -it -v "$PWD:/work" -w /work arawn780/gcc-cross-i686-elf:fast \
 **In-kernel test suite (interactive)**: shell command `ktest` runs all suites from the kernel shell.
 At boot (when `test_mode` is *not* in the cmdline), `ktest_bg_task` runs all suites silently in the background - only prints to VGA on failure; always writes `KTEST_BG: PASS/FAIL` to serial.
 
-**Black-box UI tests** (`tests/ui_test.sh`, fronted by `./run.sh ui-test` / `ui-test-gui`): boots `makar.iso`, drives keyboard input through QEMU's **HMP** (Human Monitor Protocol — the text-based control channel exposed by `-monitor unix:...`) via the `sendkey` command, and asserts on substrings in the serial mirror. Covers user-visible flows that `iso-test` doesn't: ELF exec → syscalls → output, shell tab completion, glob expansion, `cd`/`pwd`. **Not wired into CI** (the per-merge job was dropped in `a9b7474` — the framework's reliance on HMP timing made it flaky under the **TCG** (Tiny Code Generator — QEMU's interpreted/JIT CPU emulator, used because KVM is off by default per the note above) emulation that runs in the CI containers). Run locally before opening any PR that touches syscalls, shell, ELF exec, VFS, keyboard, or display:
+**Black-box UI tests** (`tests/ui_test.sh`, fronted by `./run.sh ui` / `ui-test-gui`): boots `makar.iso`, drives keyboard input through QEMU's **HMP** (Human Monitor Protocol — the text-based control channel exposed by `-monitor unix:...`) via the `sendkey` command, and asserts on substrings in the serial mirror. Covers user-visible flows that `iso-test` doesn't: ELF exec → syscalls → output, shell tab completion, glob expansion, `cd`/`pwd`. **Not wired into CI** (the per-merge job was dropped in `a9b7474` — the framework's reliance on HMP timing made it flaky under the **TCG** (Tiny Code Generator — QEMU's interpreted/JIT CPU emulator, used because KVM is off by default per the note above) emulation that runs in the CI containers). Run locally before opening any PR that touches syscalls, shell, ELF exec, VFS, keyboard, or display:
 ```sh
-./run.sh ui-test                                # headless: all scenarios
-./run.sh ui-test exec-hello                     # headless: one scenario
-./run.sh ui-test-gui                            # visible window + paced typing (watch it run)
-./run.sh ui-test-gui exec-hello                 # one scenario, visible
-QEMU_DISPLAY=cocoa ./run.sh ui-test-gui         # override QEMU display backend (cocoa|gtk|sdl)
-KEY_DELAY=0.3      ./run.sh ui-test-gui         # slower typing (default 0.15 s/key)
-UI_TEST_LOGDIR=/tmp/uilogs ./run.sh ui-test     # keep logs (serial + PPM screen dump)
+./run.sh ui                                # headless: all scenarios
+./run.sh ui exec-hello                     # headless: one scenario
+./run.sh ui graphical                            # visible window + paced typing (watch it run)
+./run.sh ui graphical exec-hello                 # one scenario, visible
+QEMU_DISPLAY=cocoa ./run.sh ui graphical         # override QEMU display backend (cocoa|gtk|sdl)
+KEY_DELAY=0.3      ./run.sh ui graphical         # slower typing (default 0.15 s/key)
+UI_TEST_LOGDIR=/tmp/uilogs ./run.sh ui     # keep logs (serial + PPM screen dump)
 ```
 The `ui-test-gui` target keeps a paced-typing visible-window mode for debugging; headless `ui-test` is the canonical "did the change regress anything" path and is what runs noise-free. **Shutdown path differs by mode**: headless sends HMP `quit` (instant), while GUI mode types `shutdown<Enter>` into the focused shell so the kernel runs its real ACPI S5 power-off (port `0x604 / 0x2000` — see `acpi_shutdown()`), then QEMU exits naturally; this exercises the shutdown code path on every GUI run *and* gives the watcher a visible "Shutting down..." final frame instead of the window blinking out the instant assertions complete. Both modes fall back to SIGKILL after a bounded wait if the guest is wedged. **PPM** = Portable Pixmap, the screen-snapshot format HMP's `screendump` emits — useful for triaging visual-only regressions (cursor position, gutter rendering) that the serial mirror can't capture. Scenarios live as `scenario_<name>` shell functions in `tests/ui_test.sh`; add a new one alongside any PR that changes a user-facing path.
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ private kernel stack and (for ring-3 programs) its own page directory.
 ## Quick start
 
 ```sh
-./run.sh iso-boot       # build & run interactively in QEMU (host or Docker)
-./run.sh iso-test       # full CI suite: ktest + GDB boot-checkpoint + UI sendkey tests
-./run.sh hdd-boot       # build & run from a 512 MiB FAT32 HDD image
-./run.sh hdd-test       # HDD-only GDB boot test (no CD-ROM)
-./run.sh ui-test        # UI tests against an existing makar.iso (sendkey + serial grep)
+./run.sh iso boot       # build & run interactively in QEMU (host or Docker)
+./run.sh iso test       # full CI suite: ktest + GDB boot-checkpoint + UI sendkey tests
+./run.sh hdd boot       # build & run from a 512 MiB FAT32 HDD image
+./run.sh hdd test       # HDD-only GDB boot test (no CD-ROM)
+./run.sh ui        # UI tests against an existing makar.iso (sendkey + serial grep)
 ./run.sh clean
 ```
 

--- a/SURVEY.md
+++ b/SURVEY.md
@@ -6,7 +6,7 @@
 
 ## Testing harness
 
-Three test paths fan out from `./run.sh iso-test`:
+Three test paths fan out from `./run.sh iso test`:
 
 | Phase | Source | What it verifies |
 |---|---|---|

--- a/context.md
+++ b/context.md
@@ -83,9 +83,9 @@ CP2 does not, the write syscall is the fault; if neither appears, ring-3 entry i
 
 ## Build / run
 ```sh
-./run.sh iso-release     # build ISO inside Docker
-./run.sh iso-boot        # build + run in QEMU (no KVM; serial -> serial.log)
-./run.sh iso-test        # build + run ktest suite + GDB automation
+./run.sh iso release     # build ISO inside Docker
+./run.sh iso boot        # build + run in QEMU (no KVM; serial -> serial.log)
+./run.sh iso test        # build + run ktest suite + GDB automation
 ./build.sh               # build without Docker (needs cross-toolchain on host)
 ```
 Serial output lands in `serial.log`; GDB transcript in `gdb-test.log`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 # docker-compose.yml – Makar OS development services
 #
 # Prefer run.sh for day-to-day use:
-#   ./run.sh iso-release    – optimised ISO
-#   ./run.sh iso-boot       – debug ISO + interactive QEMU
-#   ./run.sh iso-test       – full ktest + GDB boot suite
-#   ./run.sh hdd-boot       – HDD image + interactive QEMU
-#   ./run.sh hdd-test       – HDD image + GDB boot suite
+#   ./run.sh iso release    – optimised ISO
+#   ./run.sh iso boot       – debug ISO + interactive QEMU
+#   ./run.sh iso test       – full ktest + GDB boot suite
+#   ./run.sh hdd boot       – HDD image + interactive QEMU
+#   ./run.sh hdd test       – HDD image + GDB boot suite
 #
 # The Compose services below remain available for workflows that prefer
 # 'docker compose run'.  The source tree is bind-mounted at /work so all
@@ -34,11 +34,11 @@ services:
     command: bash iso.sh
 
   # ── ISO test suite (ktest test_mode + GDB) ────────────────────────────────
-  # Equivalent to ./run.sh iso-test but runs inside Compose.
+  # Equivalent to ./run.sh iso test but runs inside Compose.
   test:
     build: .
     platform: linux/amd64
     volumes:
       - .:/work
     working_dir: /work
-    command: bash -lc "bash run.sh iso-test"
+    command: bash -lc "bash run.sh iso test"

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,13 +24,13 @@ native GDB is required on the host.  For Windows-specific setup see
 
 ```sh
 # Interactive kernel shell (builds in Docker, QEMU runs on host or in Docker):
-./run.sh iso-boot
+./run.sh iso boot
 
 # Full CI test suite (ktest + GDB boot tests - works with or without host QEMU):
-./run.sh iso-test
+./run.sh iso test
 
 # Interactive HDD boot:
-./run.sh hdd-boot
+./run.sh hdd boot
 ```
 
 ---
@@ -134,7 +134,7 @@ Prefer `run.sh` for day-to-day use.
 |---|---|
 | `build` | `bash iso.sh` (release ISO) |
 | `build-debug` | `bash iso.sh` with `CFLAGS=-O0 -g3` |
-| `test` | `bash run.sh iso-test` (full suite) |
+| `test` | `bash run.sh iso test` (full suite) |
 
 ```sh
 docker compose run --rm build          # release ISO
@@ -175,14 +175,14 @@ docker buildx build --platform linux/amd64 \
 
 ## QEMU drive layout
 
-`run.sh iso-boot` launches QEMU with two IDE drives:
+`run.sh iso boot` launches QEMU with two IDE drives:
 
 | IDE slot | Purpose |
 |---|---|
 | index 0 | Hard disk - 512 MiB raw image (`hdd.img`, auto-created blank) |
 | index 2 | Live CD - `makar.iso`, GRUB boots from here (`-boot order=d`) |
 
-`run.sh hdd-boot` attaches only the HDD (`-boot c`, no CD-ROM).
+`run.sh hdd boot` attaches only the HDD (`-boot c`, no CD-ROM).
 
 The ISO GDB test (`iso-test` phase 2) adds a 32 MiB FAT32 test disk on index 0 alongside the CD-ROM so the kernel can mount `/hd` and the `hdd_mount` GDB group can be verified on the ISO boot path.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,12 +10,12 @@ instructions see [Building & Running](building.md).
 
 ---
 
-## CI test suite (`./run.sh iso-test`)
+## CI test suite (`./run.sh iso test`)
 
 The single command for complete ISO CI validation:
 
 ```sh
-./run.sh iso-test
+./run.sh iso test
 ```
 
 Runs two phases; build steps use Docker, QEMU/GDB prefer the host if available:
@@ -36,12 +36,12 @@ Exit code 0 = everything passed; 1 = any failure or timeout.
 
 ---
 
-## HDD boot test (`./run.sh hdd-test`)
+## HDD boot test (`./run.sh hdd test`)
 
 Verifies the installed HDD boot path end-to-end - no CD-ROM attached:
 
 ```sh
-./run.sh hdd-test
+./run.sh hdd test
 ```
 
 What it does:
@@ -85,7 +85,7 @@ To add a new group: create `tests/groups/<name>.py` exposing `NAME` and
 
 ```sh
 # Build a debug ISO first
-./run.sh iso-boot   # or: CFLAGS='-O0 -g3' ./run.sh iso-release
+./run.sh iso boot   # or: CFLAGS='-O0 -g3' ./run.sh iso release
 
 # In one terminal - start QEMU with GDB stub (inside Docker)
 docker run --rm -it -v "$PWD:/work" -w /work arawn780/gcc-cross-i686-elf:fast \
@@ -118,7 +118,7 @@ Runs `ktest_run_all()` and prints pass/fail for each subsystem suite
 
 ---
 
-## Black-box UI tests (`./run.sh ui-test`)
+## Black-box UI tests (`./run.sh ui`)
 
 Drives the running kernel through QEMU's HMP `sendkey` and asserts on
 the COM1 serial slice + PPM screen dump.  Scenarios live in
@@ -160,8 +160,8 @@ the instant the kernel says it's ready and bounds via the timeout.
 | `user-sigusr1-handler` | `sigtest.elf` installs a SIGUSR1 handler, self-sends, the handler runs in ring 3 (proves the sigframe + trampoline + `SYS_SIGRETURN` path) |
 | `makbox-pwd` | `pwd` resolves to the `makbox` applet end-to-end |
 
-`./run.sh ui-test` runs all of them; `./run.sh ui-test <name>` runs
-one; `./run.sh ui-test-gui` runs with a visible QEMU window for
+`./run.sh ui` runs all of them; `./run.sh ui <name>` runs
+one; `./run.sh ui graphical` runs with a visible QEMU window for
 debugging.
 
 ---
@@ -172,10 +172,10 @@ debugging.
 
 | Job | Runner | What runs |
 |---|---|---|
-| `build` | `ubuntu-latest` (host, Docker available) | `./run.sh iso-build` + `./run.sh hdd-build` → uploads `makar.kernel`, `makar.iso`, `makar-test.iso`, `makar-hdd-test.img` as artifact `makar-build` |
-| `ktest` | `ubuntu-latest` + container `arawn780/gcc-cross-i686-elf:fast` | downloads artifact → `./run.sh ktest-run` |
-| `gdb-iso` | `ubuntu-latest` + container | downloads artifact → `./run.sh gdb-iso-run` |
-| `gdb-hdd` | `ubuntu-latest` + container | downloads artifact → `./run.sh gdb-hdd-run` |
+| `build` | `ubuntu-latest` (host, Docker available) | `./run.sh iso build` + `./run.sh hdd build` → uploads `makar.kernel`, `makar.iso`, `makar-test.iso`, `makar-hdd-test.img` as artifact `makar-build` |
+| `ktest` | `ubuntu-latest` + container `arawn780/gcc-cross-i686-elf:fast` | downloads artifact → `./run.sh ktest` |
+| `gdb-iso` | `ubuntu-latest` + container | downloads artifact → `./run.sh gdb iso` |
+| `gdb-hdd` | `ubuntu-latest` + container | downloads artifact → `./run.sh gdb hdd` |
 
 Why this shape:
 - One compile → three parallel test runs. The compile is the expensive step; the test jobs are I/O-bound on QEMU boot.

--- a/docs/wsl2.md
+++ b/docs/wsl2.md
@@ -43,8 +43,8 @@ docker compose run --rm build-debug    # → makar.iso (debug, -O0 -g3)
 Or use the unified entrypoint:
 
 ```sh
-./run.sh iso-release                   # release ISO
-./run.sh iso-boot                      # debug ISO + interactive QEMU
+./run.sh iso release                   # release ISO
+./run.sh iso boot                      # debug ISO + interactive QEMU
 ```
 
 Build output (`makar.iso`, `sysroot/`, `isodir/`) appears in your checkout
@@ -86,7 +86,7 @@ system supports it, GUI apps run inside WSL2 automatically.
 
    ```sh
    # Build in Docker, run on host WSL2 QEMU
-   ./run.sh iso-boot
+   ./run.sh iso boot
    ```
 
    A QEMU window should appear on your Windows desktop.
@@ -115,7 +115,7 @@ skip the GUI entirely:
 
 ```sh
 # Build in Docker, then run headless with serial on stdio
-./run.sh iso-release
+./run.sh iso release
 qemu-system-i386 \
     -cdrom makar.iso \
     -serial stdio \

--- a/run.sh
+++ b/run.sh
@@ -61,14 +61,57 @@ HDD_IMG=${HDD_IMG:-makar-hdd.img}
 HDD_TEST_IMG=${HDD_TEST_IMG:-makar-hdd-test.img}
 export DOCKER_PLATFORM
 
-MODE="${1:-}"
-if [ -z "$MODE" ]; then
-    echo "Usage: $0 <mode>"
-    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build  ui-test  ui-test-gui"
-    echo "       hdd-boot  hdd-test  hdd-release    hdd-build"
-    echo "       ktest-run gdb-iso-run gdb-hdd-run  clean"
-    exit 1
-fi
+# Argument grammar: `./run.sh <target> <verb> [args...]`.  Linux-build-
+# style: incremental by default (make handles "did anything change");
+# only `clean` wipes artefacts.
+#
+#   iso build                    iso boot                iso test
+#   iso release
+#   hdd build                    hdd boot                hdd test
+#   hdd release
+#   gdb iso                      gdb hdd
+#   ktest                        ktest graphical
+#   ui [scenarios...]            ui graphical [scenarios...]
+#   clean
+_usage() {
+    echo "Usage: $0 <target> <verb> [args...]"
+    echo ""
+    echo "  iso   build | boot | test | release"
+    echo "  hdd   build | boot | test | release"
+    echo "  gdb   iso | hdd"
+    echo "  ktest [graphical]"
+    echo "  ui    [graphical] [scenario_names...]"
+    echo "  clean"
+    echo ""
+    echo "Builds are incremental (make-driven).  Run \`clean\` to force"
+    echo "a from-scratch rebuild."
+    exit "${1:-1}"
+}
+
+case "${1:-}" in
+    iso|hdd|gdb)
+        if [ -z "${2:-}" ]; then _usage; fi
+        MODE="$1 $2"; shift 2 ;;
+    ktest)
+        if [ "${2:-}" = "graphical" ]; then
+            MODE="ktest graphical"; shift 2
+        else
+            MODE="ktest"; shift 1
+        fi ;;
+    ui)
+        if [ "${2:-}" = "graphical" ]; then
+            MODE="ui graphical"; shift 2
+        else
+            MODE="ui"; shift 1
+        fi ;;
+    clean)
+        MODE="clean"; shift 1 ;;
+    -h|--help|help|"")
+        _usage 0 ;;
+    *)
+        echo "ERROR: unknown target '$1'" >&2
+        _usage ;;
+esac
 
 # ── context helpers ────────────────────────────────────────────────────────────
 
@@ -437,63 +480,16 @@ _build_kernel() {
 
 case "$MODE" in
 
-# ── iso-build ────────────────────────────────────────────────────────────────
-# Produce makar.iso + makar-test.iso from a single kernel build, no run/test.
-# Used by CI's build job (artifacts feed the parallel ktest / gdb-iso jobs).
-iso-build)
-    _clean
+# ── iso build ────────────────────────────────────────────────────────────────
+# Incremental kernel + makar.iso + makar-test.iso build.  Used by CI's
+# build job (artifacts feed the parallel ktest / gdb / ui jobs).
+"iso build")
     _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
     echo "==> Artifacts: makar.iso, makar-test.iso, src/kernel/makar.kernel"
     ;;
 
-# ── hdd-build ────────────────────────────────────────────────────────────────
-# Build kernel + generate makar-hdd-test.img.  No run.  HDD_SIZE_MB defaults
-# to generate-hdd.sh's value (512); CI overrides to 64 for faster artifact
-# upload.
-hdd-build)
-    _clean
-    _build_kernel "CFLAGS='-O0 -g3'"
-    rm -f "$REPO_ROOT/$HDD_TEST_IMG"
-    HDD_IMG="$HDD_TEST_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
-        "$REPO_ROOT/generate-hdd.sh"
-    echo "==> Artifacts: $HDD_TEST_IMG, src/kernel/makar.kernel"
-    ;;
-
-# ── ktest-run ────────────────────────────────────────────────────────────────
-# Run the ktest suite against an existing makar-test.iso.  Used by CI.
-ktest-run)
-    if [ ! -f "$REPO_ROOT/makar-test.iso" ]; then
-        echo "ERROR: makar-test.iso not found.  Run iso-build first." >&2
-        exit 1
-    fi
-    _run_ktest
-    ;;
-
-# ── gdb-iso-run ──────────────────────────────────────────────────────────────
-# Run the GDB ISO boot-checkpoint test against an existing makar.iso +
-# makar.kernel.  Used by CI.
-gdb-iso-run)
-    if [ ! -f "$REPO_ROOT/makar.iso" ] || [ ! -f "$REPO_ROOT/src/kernel/makar.kernel" ]; then
-        echo "ERROR: makar.iso or src/kernel/makar.kernel missing.  Run iso-build first." >&2
-        exit 1
-    fi
-    _run_gdb_iso_test
-    ;;
-
-# ── gdb-hdd-run ──────────────────────────────────────────────────────────────
-# Run the GDB HDD boot test against an existing makar-hdd-test.img.  CI uses
-# this on artifacts uploaded by hdd-build.
-gdb-hdd-run)
-    if [ ! -f "$REPO_ROOT/$HDD_TEST_IMG" ] || [ ! -f "$REPO_ROOT/src/kernel/makar.kernel" ]; then
-        echo "ERROR: $HDD_TEST_IMG or src/kernel/makar.kernel missing.  Run hdd-build first." >&2
-        exit 1
-    fi
-    _run_gdb_hdd_test "$HDD_TEST_IMG"
-    ;;
-
-# ── iso-boot ──────────────────────────────────────────────────────────────────
-iso-boot)
-    _clean
+# ── iso boot ──────────────────────────────────────────────────────────────────
+"iso boot")
     _build_iso "CFLAGS='-O0 -g3'"
     if [ ! -f "$REPO_ROOT/hdd.img" ]; then
         _drun --as-root -- "qemu-img create -f raw hdd.img 512M"
@@ -504,12 +500,9 @@ iso-boot)
          -boot order=d -serial stdio"
     ;;
 
-# ── iso-test ──────────────────────────────────────────────────────────────────
-# One kernel build, two ISO variants packaged from the same staged isodir:
-#   makar.iso       - interactive menu (also exercised by gdb_boot_test, ui-test)
-#   makar-test.iso  - single auto-boot entry with test_mode cmdline
-iso-test)
-    _clean
+# ── iso test ──────────────────────────────────────────────────────────────────
+# Full ISO test suite: incremental build → ktest → GDB ISO boot test → ui.
+"iso test")
     _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
     _run_ktest
     _run_gdb_iso_test
@@ -517,49 +510,94 @@ iso-test)
     echo "==> All ISO tests PASSED."
     ;;
 
-# ── ui-test ───────────────────────────────────────────────────────────────────
-# Black-box UI tests driven through QEMU's HMP monitor (sendkey + serial grep).
-# Requires host QEMU + nc.  See tests/ui_test.sh for the scenarios.
-ui-test)
-    if [ ! -f "$REPO_ROOT/makar.iso" ]; then
-        _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
-    fi
-    _run_ui_test "${@:2}"
+# ── iso release ───────────────────────────────────────────────────────────────
+"iso release")
+    _build_iso "CFLAGS='-O2 -g'"
+    echo "==> Release ISO ready: $REPO_ROOT/makar.iso"
     ;;
 
-# ── ui-test-gui ───────────────────────────────────────────────────────────────
-# Same as ui-test but with the QEMU display window visible and keystrokes
-# paced so a human can watch the scenarios drive the kernel.  Headless
-# ui-test stays the canonical "did the change regress anything" path; this
-# is the "what is actually happening on screen" path for debugging.
-# QEMU_DISPLAY (cocoa|gtk|sdl) overrides QEMU's default backend pick;
-# KEY_DELAY overrides the inter-keystroke pause (default 0.15 s).
-ui-test-gui)
+# ── hdd build ────────────────────────────────────────────────────────────────
+"hdd build")
+    _build_kernel "CFLAGS='-O0 -g3'"
+    rm -f "$REPO_ROOT/$HDD_TEST_IMG"
+    HDD_IMG="$HDD_TEST_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
+        "$REPO_ROOT/generate-hdd.sh"
+    echo "==> Artifacts: $HDD_TEST_IMG, src/kernel/makar.kernel"
+    ;;
+
+# ── hdd boot ──────────────────────────────────────────────────────────────────
+"hdd boot")
+    _build_kernel "CFLAGS='-O0 -g3'"
+    rm -f "$REPO_ROOT/$HDD_IMG"
+    HDD_IMG="$HDD_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
+        "$REPO_ROOT/generate-hdd.sh"
+    _run_qemu_interactive \
+        "-drive file=/work/$HDD_IMG,format=raw,if=ide,index=0 \
+         -boot c -serial stdio"
+    ;;
+
+# ── hdd test ──────────────────────────────────────────────────────────────────
+"hdd test")
+    _build_kernel "CFLAGS='-O0 -g3'"
+    if [ ! -f "$REPO_ROOT/src/kernel/makar.kernel" ]; then
+        echo "ERROR: src/kernel/makar.kernel not found after build." >&2; exit 1
+    fi
+    rm -f "$REPO_ROOT/$HDD_TEST_IMG"
+    HDD_IMG="$HDD_TEST_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
+        "$REPO_ROOT/generate-hdd.sh"
+    _run_gdb_hdd_test "$HDD_TEST_IMG"
+    echo ""
+    echo "==> HDD boot test PASSED."
+    echo "    GDB log:    hdd-test-gdb.log"
+    echo "    Serial log: hdd-test-serial.log"
+    ;;
+
+# ── hdd release ───────────────────────────────────────────────────────────────
+"hdd release")
+    _build_kernel "CFLAGS='-O2 -g'"
+    rm -f "$REPO_ROOT/$HDD_IMG"
+    HDD_IMG="$HDD_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
+        "$REPO_ROOT/generate-hdd.sh"
+    echo "==> HDD image ready: $REPO_ROOT/$HDD_IMG"
+    ;;
+
+# ── gdb iso ──────────────────────────────────────────────────────────────────
+# GDB boot-checkpoint test against the existing ISO.  Incremental build
+# first so the kernel + ISO are fresh when the gdbstub attaches.  CI's
+# gdb-iso job downloads an artifact so the build step is a no-op there.
+"gdb iso")
+    _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
+    _run_gdb_iso_test
+    ;;
+
+# ── gdb hdd ──────────────────────────────────────────────────────────────────
+"gdb hdd")
+    _build_kernel "CFLAGS='-O0 -g3'"
+    if [ ! -f "$REPO_ROOT/$HDD_TEST_IMG" ]; then
+        rm -f "$REPO_ROOT/$HDD_TEST_IMG"
+        HDD_IMG="$HDD_TEST_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
+            "$REPO_ROOT/generate-hdd.sh"
+    fi
+    _run_gdb_hdd_test "$HDD_TEST_IMG"
+    ;;
+
+# ── ktest (headless, default) ────────────────────────────────────────────────
+# Incremental build of makar-test.iso, then run ktest against it headless.
+ktest)
+    _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
+    _run_ktest
+    ;;
+
+# ── ktest graphical ──────────────────────────────────────────────────────────
+# Incremental build, then run ktest in a visible QEMU window.  Requires
+# host QEMU + display server.
+"ktest graphical")
     QEMU_BIN=$(_host_qemu)
     if [ -z "$QEMU_BIN" ]; then
-        echo "ERROR: ui-test-gui requires host QEMU with a display server." >&2
+        echo "ERROR: 'ktest graphical' requires host QEMU and a display server." >&2
         echo "       Install qemu-system-i386 with X11/SDL/Cocoa support." >&2
         exit 1
     fi
-    if [ ! -f "$REPO_ROOT/makar.iso" ]; then
-        _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
-    fi
-    echo "==> Running UI tests with display window (GUI mode, paced typing)..."
-    # "${@:2}" drops $1 (the mode token "ui-test-gui") so positional
-    # scenario names land at the script as bare scenario filters.
-    ( cd "$REPO_ROOT" && GUI=1 bash tests/ui_test.sh "${@:2}" )
-    ;;
-
-# ── iso-ktest-gui ─────────────────────────────────────────────────────────────
-# Requires host QEMU and a display server - cannot fall back to Docker.
-iso-ktest-gui)
-    QEMU_BIN=$(_host_qemu)
-    if [ -z "$QEMU_BIN" ]; then
-        echo "ERROR: iso-ktest-gui requires host QEMU and a display server." >&2
-        echo "       Install qemu-system-i386 with X11/SDL/Cocoa support." >&2
-        exit 1
-    fi
-    _clean
     _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
     echo "==> Running ktest suite (graphical QEMU - window closes on completion)..."
     rm -f "$REPO_ROOT/ktest.log"
@@ -578,50 +616,30 @@ iso-ktest-gui)
     _check_ktest
     ;;
 
-# ── iso-release ───────────────────────────────────────────────────────────────
-iso-release)
-    _clean
-    _build_iso "CFLAGS='-O2 -g'"
-    echo "==> Release ISO ready: $REPO_ROOT/makar.iso"
+# ── ui (headless, default) ───────────────────────────────────────────────────
+# Black-box ui-tests driven through QEMU's HMP monitor (sendkey + serial
+# grep).  Requires host QEMU + nc.  Extra positional args are scenario
+# filters; bare `./run.sh ui` runs the full suite.
+ui)
+    _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
+    _run_ui_test "$@"
     ;;
 
-# ── hdd-boot ──────────────────────────────────────────────────────────────────
-hdd-boot)
-    _clean
-    _build_kernel "CFLAGS='-O0 -g3'"
-    rm -f "$REPO_ROOT/$HDD_IMG"
-    HDD_IMG="$HDD_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
-        "$REPO_ROOT/generate-hdd.sh"
-    _run_qemu_interactive \
-        "-drive file=/work/$HDD_IMG,format=raw,if=ide,index=0 \
-         -boot c -serial stdio"
-    ;;
-
-# ── hdd-test ──────────────────────────────────────────────────────────────────
-hdd-test)
-    _clean
-    _build_kernel "CFLAGS='-O0 -g3'"
-    if [ ! -f "$REPO_ROOT/src/kernel/makar.kernel" ]; then
-        echo "ERROR: src/kernel/makar.kernel not found after build." >&2; exit 1
+# ── ui graphical ─────────────────────────────────────────────────────────────
+# Same as `ui` but with a visible QEMU window + paced typing -- the
+# debugging path when serial-only assertions aren't enough.
+# QEMU_DISPLAY (cocoa|gtk|sdl) overrides QEMU's default backend pick;
+# KEY_DELAY overrides the inter-keystroke pause (default 0.15 s).
+"ui graphical")
+    QEMU_BIN=$(_host_qemu)
+    if [ -z "$QEMU_BIN" ]; then
+        echo "ERROR: 'ui graphical' requires host QEMU with a display server." >&2
+        echo "       Install qemu-system-i386 with X11/SDL/Cocoa support." >&2
+        exit 1
     fi
-    rm -f "$REPO_ROOT/$HDD_TEST_IMG"
-    HDD_IMG="$HDD_TEST_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
-        "$REPO_ROOT/generate-hdd.sh"
-    _run_gdb_hdd_test "$HDD_TEST_IMG"
-    echo ""
-    echo "==> HDD boot test PASSED."
-    echo "    GDB log:    hdd-test-gdb.log"
-    echo "    Serial log: hdd-test-serial.log"
-    ;;
-
-# ── hdd-release ───────────────────────────────────────────────────────────────
-hdd-release)
-    _clean
-    _build_kernel "CFLAGS='-O2 -g'"
-    rm -f "$REPO_ROOT/$HDD_IMG"
-    HDD_IMG="$HDD_IMG" DOCKER_BIN="$DOCKER_BIN" DOCKER_PLATFORM="$DOCKER_PLATFORM" \
-        "$REPO_ROOT/generate-hdd.sh"
-    echo "==> HDD image ready: $REPO_ROOT/$HDD_IMG"
+    _build_iso "CFLAGS='-O0 -g3' TEST_ISO=1"
+    echo "==> Running ui-tests with display window (graphical, paced typing)..."
+    ( cd "$REPO_ROOT" && GUI=1 bash tests/ui_test.sh "$@" )
     ;;
 
 # ── clean ─────────────────────────────────────────────────────────────────────
@@ -634,9 +652,6 @@ clean)
 
 *)
     echo "ERROR: unknown mode '$MODE'" >&2
-    echo "Modes: iso-boot  iso-test  iso-ktest-gui  iso-release  iso-build  ui-test  ui-test-gui" >&2
-    echo "       hdd-boot  hdd-test  hdd-release    hdd-build" >&2
-    echo "       ktest-run gdb-iso-run gdb-hdd-run  clean" >&2
-    exit 1
+    _usage
     ;;
 esac

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -9,6 +9,7 @@
 #include <kernel/task.h>
 #include <kernel/timer.h>
 #include <kernel/version.h>
+#include <kernel/asm.h>     /* outb / inb for CMOS RTC in render_rtc */
 #include <string.h>
 #include <stdio.h>
 
@@ -26,6 +27,7 @@ typedef enum {
     PROC_MEMINFO,
     PROC_TASKS,
     PROC_UNAME,
+    PROC_RTC,
 } procfs_id_t;
 
 typedef struct {
@@ -38,6 +40,7 @@ static const procfs_entry_t s_entries[] = {
     { "meminfo", PROC_MEMINFO },
     { "tasks",   PROC_TASKS   },
     { "uname",   PROC_UNAME   },
+    { "rtc",     PROC_RTC     },
     { NULL,      PROC_NONE    },
 };
 
@@ -155,6 +158,82 @@ static void render_cpuinfo(pf_writer_t *w)
  * meminfo
  * ---------------------------------------------------------------------- */
 
+/* ---------------------------------------------------------------------------
+ * /proc/rtc -- CMOS real-time clock readout.
+ *
+ * Standard PC RTC at I/O ports 0x70 (index) + 0x71 (data).  Registers:
+ *   0x00 seconds   0x02 minutes  0x04 hours
+ *   0x07 day       0x08 month    0x09 year   (year is last two digits)
+ *   0x0A status A  0x0B status B
+ *
+ * Status A bit 7 = update-in-progress; status B bit 2 = 0 means BCD
+ * encoding (the common BIOS default; QEMU's emulated RTC sets it this
+ * way unless told otherwise).  We retry until UIP clears, read the
+ * fields, decode BCD if needed, and format Linux-style:
+ *   YYYY-MM-DD HH:MM:SS
+ * --------------------------------------------------------------------------- */
+
+static inline uint8_t cmos_read(uint8_t reg)
+{
+    outb(0x70, reg);
+    return inb(0x71);
+}
+
+static inline uint8_t bcd_to_bin(uint8_t v)
+{
+    return (uint8_t)(((v & 0xF0u) >> 4) * 10u + (v & 0x0Fu));
+}
+
+static void render_rtc(pf_writer_t *w)
+{
+    /* Drain any in-progress update so we don't read mid-tick.  Bounded
+     * loop so a broken RTC can't hang procfs forever. */
+    for (int spin = 0; spin < 1000000; spin++) {
+        if (!(cmos_read(0x0A) & 0x80u)) break;
+    }
+
+    uint8_t sec  = cmos_read(0x00);
+    uint8_t min  = cmos_read(0x02);
+    uint8_t hour = cmos_read(0x04);
+    uint8_t day  = cmos_read(0x07);
+    uint8_t mon  = cmos_read(0x08);
+    uint8_t year = cmos_read(0x09);
+    uint8_t statB = cmos_read(0x0B);
+
+    if (!(statB & 0x04u)) {
+        sec  = bcd_to_bin(sec);
+        min  = bcd_to_bin(min);
+        /* Hour high bit is 12/24 indicator in BCD mode; mask before
+         * decoding so we don't decode the indicator as a digit. */
+        hour = bcd_to_bin((uint8_t)(hour & 0x7Fu));
+        day  = bcd_to_bin(day);
+        mon  = bcd_to_bin(mon);
+        year = bcd_to_bin(year);
+    }
+
+    /* CMOS year is two digits; assume the 21st century.  When the
+     * Makar wall clock matters more than this, plumb the century byte
+     * from FADT or take it from build epoch. */
+    uint32_t full_year = 2000u + (uint32_t)year;
+
+    /* Helper: pad-2 decimal. */
+    #define WPAD2(v) do { \
+        unsigned _v = (unsigned)(v); \
+        pf_putc(w, (char)('0' + (_v / 10u) % 10u)); \
+        pf_putc(w, (char)('0' + (_v % 10u))); \
+    } while (0)
+
+    pf_putu(w, full_year);
+    pf_putc(w, '-'); WPAD2(mon);
+    pf_putc(w, '-'); WPAD2(day);
+    pf_putc(w, ' '); WPAD2(hour);
+    pf_putc(w, ':'); WPAD2(min);
+    pf_putc(w, ':'); WPAD2(sec);
+    pf_putc(w, '\n');
+
+    #undef WPAD2
+}
+
 /* /proc/meminfo - Linux-style key/value format ("Label:<spaces>N kB").
  * Field order and naming match Linux for the headline numbers so
  * tools like maktop don't need Makar-specific parsing.  Fields after
@@ -269,6 +348,7 @@ int procfs_read_file(const char *path, void *buf, uint32_t bufsz,
     case PROC_MEMINFO: render_meminfo(&w); break;
     case PROC_TASKS:   render_tasks(&w);   break;
     case PROC_UNAME:   render_uname(&w);   break;
+    case PROC_RTC:     render_rtc(&w);     break;
     default: break;
     }
 

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -37,6 +37,16 @@ static bool     vtty_bufs_ready = false;
  * task context the next time the new owner's REPL yields. */
 static volatile int vtty_pending = -1;
 
+/* Per-slot foreground task override.  When non-NULL, vtty_switch
+ * directs keyboard focus + KEY_FOCUS_GAIN to this task instead of
+ * the slot's registered shell.  Used by shell_exec_elf so the
+ * exec'd child keeps getting keystrokes even after the user
+ * Alt+Fn'd away and back.  Without it: after a VT excursion the
+ * shell got refocused, the foreground task (maktop, vix) sat in
+ * its read loop with no keys arriving, the operator had to kill
+ * the QEMU window. */
+static task_t * volatile vtty_foreground[VTTY_MAX];
+
 /* Default attribute values used when no display renderer has set colours
  * yet.  Renderer interprets - VESA uses these as composed FB pixels,
  * VGA uses only the low byte as a VGA attribute. */
@@ -167,13 +177,22 @@ vt_buf_t *vtty_buf_focused(void)
 void vtty_switch(int n)
 {
     if (n < 0 || n >= vtty_nslots || n == vtty_current) return;
-    task_t *owner = vtty_owner(n);
+    /* Foreground task override beats the slot's shell.  Falls back to
+     * the slot owner when no fullscreen child is currently running. */
+    task_t *fg    = __atomic_load_n(&vtty_foreground[n], __ATOMIC_ACQUIRE);
+    task_t *owner = fg ? fg : vtty_owner(n);
     if (!owner) return;
     vtty_current = n;
     keyboard_set_focus(owner);
     keyboard_send_to(owner, KEY_FOCUS_GAIN);
     /* Defer the FB repaint to task context - see vtty_pending comment. */
     __atomic_store_n(&vtty_pending, n, __ATOMIC_RELEASE);
+}
+
+void vtty_set_foreground(int slot, task_t *t)
+{
+    if (slot < 0 || slot >= VTTY_MAX) return;
+    __atomic_store_n(&vtty_foreground[slot], t, __ATOMIC_RELEASE);
 }
 
 void vtty_drain_pending(void)

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -716,6 +716,10 @@ void shell_run(void)
     int slot = vtty_register();
 
     if (slot == 0) {
+        /* Boot scheme during the loading screen: keep the classic
+         * white-on-blue Medli look (it's what the splash + logo are
+         * tuned for).  The per-VT scheme is applied later, just before
+         * the REPL takes over. */
         terminal_set_colorscheme(SHELL_COLOR_VGA);
 
         /* Hide the tmux-style VT status bar for the duration of the
@@ -790,6 +794,11 @@ void shell_run(void)
         vesa_tty_set_status_visible(1);
         vesa_tty_paint_status(vtty_active(), vtty_count());
 
+        /* Switch into this VT's per-VT palette and clear so the
+         * banner prints in the new colours.  shell_clear_screen reads
+         * the calling task's tty and applies the right scheme. */
+        shell_clear_screen();
+
         t_writestring("Makar -- version " SHELL_VERSION
                       ", build: " BUILD_DATE " " BUILD_TIME "\n");
         t_writestring("The GCC/C++ sibling of Medli\n");
@@ -806,11 +815,8 @@ void shell_run(void)
             task_yield();
         while (!vtty_is_focused())
             task_yield();
-        terminal_set_colorscheme(SHELL_COLOR_VGA);
-        if (vesa_tty_is_ready()) {
-            vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
-            vesa_tty_clear();
-        }
+        /* Apply this VT's per-VT colour scheme on first focus. */
+        shell_clear_screen();
         /* Do NOT drain the input ring here.  The user may have typed a key
          * the same instant they hit Alt+Fn (single QEMU sendkey burst or a
          * fast typist on real hardware) - draining would swallow that first

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -794,9 +794,11 @@ void shell_run(void)
         vesa_tty_set_status_visible(1);
         vesa_tty_paint_status(vtty_active(), vtty_count());
 
-        /* Switch into this VT's per-VT palette and clear so the
-         * banner prints in the new colours.  shell_clear_screen reads
-         * the calling task's tty and applies the right scheme. */
+        /* Switch into this VT's per-VT palette and clear so the banner
+         * prints on the VT's bg colour (the loading screen left the FB
+         * filled with Medli white-on-blue; without re-clearing, that
+         * blue bleeds through any rows the banner doesn't cover).
+         * Linux VT semantics: clear-on-init uses the current VT's bg. */
         shell_clear_screen();
 
         t_writestring("Makar -- version " SHELL_VERSION
@@ -815,7 +817,13 @@ void shell_run(void)
             task_yield();
         while (!vtty_is_focused())
             task_yield();
-        /* Apply this VT's per-VT colour scheme on first focus. */
+        /* Apply this VT's per-VT colour scheme + clear on first focus.
+         * This branch runs ONCE per VT (when the VT first becomes
+         * focused after boot); subsequent Alt+Fn round-trips don't
+         * re-enter this code, so VT content survives focus switches.
+         * The clear here is what establishes the VT's bg colour --
+         * Linux VT semantics: empty cells show the VT's bg, not
+         * whatever pixels happened to be on the framebuffer before. */
         shell_clear_screen();
         /* Do NOT drain the input ring here.  The user may have typed a key
          * the same instant they hit Alt+Fn (single QEMU sendkey burst or a

--- a/src/kernel/arch/i386/shell/shell_cmd_apps.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_apps.c
@@ -7,6 +7,7 @@
 #include "shell_priv.h"
 
 #include <kernel/shell.h>
+#include <kernel/vtty.h>
 #include <kernel/tty.h>
 #include <kernel/vfs.h>
 #include <kernel/vix.h>
@@ -170,6 +171,9 @@ void shell_exec_elf(const char *path, int argc, char **argv)
 
     task_t *self = task_current();
     keyboard_set_focus(t);
+    /* Register t as VT-foreground so a user Alt+Fn excursion + return
+     * routes focus + KEY_FOCUS_GAIN back to the child, not the shell. */
+    if (self) vtty_set_foreground(self->tty, t);
 
     /* Wait for the child to finish.  Ctrl+C is now delivered as SIGINT
      * straight to the focused task (the child); the kernel's default-
@@ -183,6 +187,7 @@ void shell_exec_elf(const char *path, int argc, char **argv)
         task_yield();
 
     keyboard_release_task(t);
+    if (self) vtty_set_foreground(self->tty, NULL);
     keyboard_set_focus(self);
     /* Defensive: a ring-3 app that enabled raw mode (kbtester etc.) is
      * expected to disable it on the way out, but if it crashed or was

--- a/src/kernel/arch/i386/shell/shell_cmd_display.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_display.c
@@ -79,13 +79,23 @@ static void print_palette(void)
  * Command handlers
  * --------------------------------------------------------------------------- */
 
+void shell_apply_scheme_for_tty(int tty)
+{
+    if (tty < 0 || tty >= 4) tty = 0;
+    const shell_scheme_t *s = &SHELL_SCHEMES[tty];
+    terminal_set_colorscheme(s->vga);
+    if (vesa_tty_is_ready())
+        vesa_tty_setcolor(s->fg_rgb, s->bg_rgb);
+}
+
 void shell_clear_screen(void)
 {
-    terminal_set_colorscheme(SHELL_COLOR_VGA);
-    if (vesa_tty_is_ready()) {
-        vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
+    int tty = 0;
+    task_t *t = task_current();
+    if (t && t->tty >= 0 && t->tty < 4) tty = t->tty;
+    shell_apply_scheme_for_tty(tty);
+    if (vesa_tty_is_ready())
         vesa_tty_clear();
-    }
 }
 
 static void cmd_clear(int argc, char **argv)

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -40,6 +40,35 @@
 #define SHELL_FG_RGB          0xFFFFFF
 #define SHELL_BG_RGB          0x0000AA
 
+/* Per-VT colour scheme.  Each shell slot has its own palette so the
+ * four TTYs are visually distinct -- helpful for orienting after a
+ * VT switch.  shell_apply_scheme_for_tty() reads this table and
+ * pushes both the VGA attribute byte and the VESA RGB pair into the
+ * renderers.  shell_clear_screen routes through the same helper so
+ * fullscreen apps (vix, maktop) restore the right palette on exit. */
+typedef struct {
+    uint8_t  vga;     /* 8-bit VGA attribute = fg | (bg << 4)     */
+    uint32_t fg_rgb;  /* 24-bit VESA foreground                    */
+    uint32_t bg_rgb;  /* 24-bit VESA background                    */
+} shell_scheme_t;
+
+/* Indexed by VT slot 0..3.  Tracks the user's stated preferences:
+ *   VT0  light green on black
+ *   VT1  white on black
+ *   VT2  white on blue (the classic Makar look, preserved as default
+ *                       for the most-used secondary VT)
+ *   VT3  black on white                                            */
+static const shell_scheme_t SHELL_SCHEMES[4] = {
+    { 0x0A, 0x55FF55, 0x000000 },
+    { 0x0F, 0xFFFFFF, 0x000000 },
+    { 0x1F, 0xFFFFFF, 0x0000AA },
+    { 0xF0, 0x000000, 0xFFFFFF },
+};
+
+/* Apply the scheme for VT slot `tty` to both renderers.  Out-of-range
+ * tty falls back to slot 0. */
+void shell_apply_scheme_for_tty(int tty);
+
 /*
  * Command entry: all handlers share the same (int argc, char **argv) signature
  * for uniform dispatch.  A NULL name field terminates each module's table.

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -58,4 +58,11 @@ vt_buf_t *vtty_buf_focused(void);
  * no switch is pending. */
 void vtty_drain_pending(void);
 
+/* Foreground task override.  When a slot has a foreground task set
+ * (e.g. shell_exec_elf's child taking focus), vtty_switch routes
+ * keyboard focus + KEY_FOCUS_GAIN to that task instead of the slot's
+ * registered shell.  Pass NULL to clear (reverts to slot owner).
+ * No-op if slot is out of range. */
+void vtty_set_foreground(int slot, task_t *t);
+
 #endif /* _KERNEL_VTTY_H */

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -14,7 +14,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf maktop.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf maktop.elf clock.elf
 
 
 all: $(PROGS)
@@ -47,6 +47,9 @@ sigtest.elf: crt0.o sigtest.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 maktop.elf: crt0.o maktop.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+clock.elf: crt0.o clock.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 

--- a/src/userspace/clock.c
+++ b/src/userspace/clock.c
@@ -1,0 +1,207 @@
+/*
+ * clock.elf - centred date + time display driven by /proc/rtc.
+ *
+ * Reads /proc/rtc once per second (uptime-driven), parses the
+ * "YYYY-MM-DD HH:MM:SS" line, and paints it centred in the active
+ * pane via SYS_PUTCH_AT.  Same diff-render + non-blocking-stdin
+ * pattern maktop uses, so the screen doesn't flicker and 'q' or
+ * F10 exits cleanly.
+ *
+ * Quits and restores the shell palette on 'q' / F10.  Auto-clears
+ * to the shell colours on exit so the prompt returns to a known
+ * state regardless of how the operator left.
+ */
+
+#include "syscall.h"
+
+#define MAX_COLS 160
+#define MAX_ROWS 60
+
+#define CLR_BG          VGA_CLR(VGA_LGREY,  VGA_BLACK)
+#define CLR_TIME        VGA_CLR(VGA_LGREEN, VGA_BLACK)
+#define CLR_DATE        VGA_CLR(VGA_LCYAN,  VGA_BLACK)
+#define CLR_HINT        VGA_CLR(VGA_DGREY,  VGA_BLACK)
+
+static int s_cols;
+static int s_rows;
+
+static tty_cell_t g_cells[MAX_COLS * MAX_ROWS];
+static int        g_ncells;
+
+typedef struct { unsigned char ch; unsigned char clr; } prev_cell_t;
+static prev_cell_t s_prev[MAX_COLS * MAX_ROWS];
+
+static char s_proc_rtc_buf[64];
+
+static void invalidate_prev(void)
+{
+    for (int i = 0; i < (int)(sizeof(s_prev)/sizeof(s_prev[0])); i++) {
+        s_prev[i].ch  = 0xFF;
+        s_prev[i].clr = 0xFF;
+    }
+}
+
+static inline void put(int col, int row, char c, unsigned char clr)
+{
+    if (col < 0 || row < 0 || col >= MAX_COLS || row >= MAX_ROWS) return;
+    int key = row * MAX_COLS + col;
+    if (s_prev[key].ch == (unsigned char)c && s_prev[key].clr == clr)
+        return;
+    s_prev[key].ch  = (unsigned char)c;
+    s_prev[key].clr = clr;
+    if (g_ncells < (int)(sizeof(g_cells)/sizeof(g_cells[0]))) {
+        g_cells[g_ncells].col = (unsigned char)col;
+        g_cells[g_ncells].row = (unsigned char)row;
+        g_cells[g_ncells].ch  = (unsigned char)c;
+        g_cells[g_ncells].clr = clr;
+        g_ncells++;
+    }
+}
+
+static void put_str(int col, int row, const char *s, unsigned char clr)
+{
+    while (*s) put(col++, row, *s++, clr);
+}
+
+static void put_pad(int col, int row, int width, unsigned char clr)
+{
+    for (int i = 0; i < width; i++) put(col + i, row, ' ', clr);
+}
+
+static void flush(void)
+{
+    if (g_ncells > 0) {
+        sys_putch_at(g_cells, (unsigned int)g_ncells);
+        g_ncells = 0;
+    }
+}
+
+static unsigned int slen(const char *s)
+{
+    unsigned int n = 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static long read_file(const char *path, char *buf, unsigned int cap)
+{
+    int fd = sys_open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    long n = sys_read(fd, buf, cap - 1);
+    sys_close(fd);
+    if (n < 0) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+/* Parse "YYYY-MM-DD HH:MM:SS" into two output strings.  Returns 1 on
+ * success, 0 on any parse failure (date/time left untouched). */
+static int parse_rtc(const char *buf, char *date_out, char *time_out)
+{
+    /* The line is fixed-width except for the trailing newline: 10
+     * chars date, space, 8 chars time = 19 chars.  Be tolerant of
+     * variations (extra whitespace) by walking digit-by-digit. */
+    unsigned int n = slen(buf);
+    if (n < 19) return 0;
+    for (int i = 0; i < 10; i++) {
+        char c = buf[i];
+        char want = ((i == 4) || (i == 7)) ? '-' : 0;
+        if (want) { if (c != want) return 0; }
+        else      { if (c < '0' || c > '9') return 0; }
+        date_out[i] = c;
+    }
+    date_out[10] = '\0';
+    if (buf[10] != ' ') return 0;
+    for (int i = 0; i < 8; i++) {
+        char c = buf[11 + i];
+        char want = ((i == 2) || (i == 5)) ? ':' : 0;
+        if (want) { if (c != want) return 0; }
+        else      { if (c < '0' || c > '9') return 0; }
+        time_out[i] = c;
+    }
+    time_out[8] = '\0';
+    return 1;
+}
+
+static void draw_all(const char *date, const char *time_str)
+{
+    g_ncells = 0;
+    for (int r = 0; r < s_rows; r++) put_pad(0, r, s_cols, CLR_BG);
+
+    /* Centred date on (rows/2 - 1), centred time on (rows/2), hint
+     * on (rows-1). */
+    int cy = s_rows / 2;
+    int dx = (s_cols - (int)slen(date)) / 2;
+    int tx = (s_cols - (int)slen(time_str)) / 2;
+    put_str(dx, cy - 1, date,     CLR_DATE);
+    put_str(tx, cy,     time_str, CLR_TIME);
+
+    const char *hint = "q / F10 to quit";
+    int hx = (s_cols - (int)slen(hint)) / 2;
+    put_str(hx, s_rows - 1, hint, CLR_HINT);
+
+    flush();
+    sys_set_cursor(0, s_rows - 1);
+}
+
+static int read_key_nb(void)
+{
+    unsigned char c;
+    long r = sys_read(0, &c, 1);
+    if (r == 1) return (int)c;
+    return -1;
+}
+
+int main(int argc, char **argv, char **envp)
+{
+    (void)argc; (void)argv; (void)envp;
+
+    s_cols = (int)sys_term_cols();
+    s_rows = (int)sys_term_rows();
+    if (s_cols > MAX_COLS) s_cols = MAX_COLS;
+    if (s_rows > MAX_ROWS) s_rows = MAX_ROWS;
+
+    if (sys_fcntl(0, F_SETFL, O_NONBLOCK) != 0) {
+        const char *e = "clock: sys_fcntl failed\n";
+        unsigned int n = 0; while (e[n]) n++;
+        sys_write_serial(e, n);
+        return 1;
+    }
+
+    char date[16] = "YYYY-MM-DD";
+    char time_str[16] = "HH:MM:SS";
+
+    invalidate_prev();
+    sys_tty_clear(CLR_BG);
+
+    long n = read_file("/proc/rtc", s_proc_rtc_buf, sizeof(s_proc_rtc_buf));
+    if (n > 0) parse_rtc(s_proc_rtc_buf, date, time_str);
+    draw_all(date, time_str);
+
+    unsigned int next = sys_uptime() + 100u;
+
+    for (;;) {
+        int c = read_key_nb();
+        if (c >= 0) {
+            if (c == 'q' || c == 'Q' || c == (int)KEY_F10) break;
+            if (c == (int)KEY_FOCUS_GAIN) {
+                invalidate_prev();
+                draw_all(date, time_str);
+            }
+            continue;
+        }
+        unsigned int now = sys_uptime();
+        if ((int)(now - next) >= 0) {
+            long got = read_file("/proc/rtc", s_proc_rtc_buf,
+                                 sizeof(s_proc_rtc_buf));
+            if (got > 0) parse_rtc(s_proc_rtc_buf, date, time_str);
+            draw_all(date, time_str);
+            next = now + 100u;
+        }
+        sys_yield();
+    }
+
+    sys_fcntl(0, F_SETFL, 0);
+    sys_shell_clear();
+    return 0;
+}

--- a/src/userspace/maktop.c
+++ b/src/userspace/maktop.c
@@ -731,6 +731,18 @@ int main(int argc, char **argv, char **envp)
                 refresh_tasks();
                 draw_all();
                 next_refresh = sys_uptime() + REFRESH_TICKS;
+            } else if (c == (int)KEY_FOCUS_GAIN) {
+                /* Returning to our VT after the user Alt+Fn'd away.
+                 * The framebuffer is currently showing whichever VT
+                 * they switched through, not our last frame; the
+                 * diff buffer would only repaint cells that differ
+                 * from our internal s_prev (the stale frame).
+                 * Invalidate so the next draw_all is unconditional
+                 * and we own the screen again. */
+                invalidate_prev();
+                refresh_tasks();
+                draw_all();
+                next_refresh = sys_uptime() + REFRESH_TICKS;
             }
             continue;
         }

--- a/tests/ui_runner.sh
+++ b/tests/ui_runner.sh
@@ -42,7 +42,7 @@ IT_DEFAULT_WAIT=${IT_DEFAULT_WAIT:-1.2}
 # --- Sanity checks -----------------------------------------------------------
 
 if [ ! -f "$ISO" ]; then
-    echo "ui_test: $ISO not found - build first with './run.sh iso-build'" >&2
+    echo "ui_test: $ISO not found - build first with './run.sh iso build'" >&2
     exit 2
 fi
 if ! command -v "$QEMU" >/dev/null 2>&1; then

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -317,6 +317,307 @@ sendkey ret'
     assert_serial_contains "[makbox:pwd]"
 }
 
+test_per_vt_palettes() {
+    # Verify each VT has its declared colour scheme.  Visual check via
+    # PPM dumps -- serial can't see palette.  Expected:
+    #   VT0: green on black
+    #   VT1: white on black
+    #   VT2: white on blue
+    #   VT3: black on white
+    CURRENT_NAME=per-vt-palettes
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    echo "screendump $LOGDIR/$CURRENT_NAME.vt0.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    for f in f2 f3 f4 ; do
+        send_script "sendkey alt-$f"
+        sleep 0.8
+        echo "screendump $LOGDIR/$CURRENT_NAME.vt-$f.ppm" \
+            | nc -U "$MONITOR_SOCK" >/dev/null
+        sleep 0.2
+    done
+    send_script 'sendkey alt-f1'
+    sleep 0.4
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+    # No serial-level assertion -- this is a pure visual check.
+}
+
+test_two_maktops() {
+    # Multiple maktop instances on different VTs.  User reported: spawn
+    # maktop on VT0, switch to VT1, spawn maktop on VT1, round-trip --
+    # the second instance fails to repaint and shows the shell's blue
+    # bg underneath.
+    #
+    # Build the test by:
+    #  1. exec maktop on VT0, wait for it to draw
+    #  2. Alt+F2, type the exec command, wait
+    #  3. Alt+F1 (back to maktop1), screendump, Alt+F2 (back to maktop2)
+    #     screendump, repeat to be sure
+    #  4. Kill both with q's.  Pwd at the end on VT0 to prove the shell
+    #     came back to a working state.
+    CURRENT_NAME=two-maktops
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    # Launch maktop on VT0.
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey m
+sendkey a
+sendkey k
+sendkey t
+sendkey o
+sendkey p
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    sleep 1.2
+    # Switch to VT1 and launch maktop there too.
+    send_script 'sendkey alt-f2'
+    sleep 0.6
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey m
+sendkey a
+sendkey k
+sendkey t
+sendkey o
+sendkey p
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    sleep 1.5
+    echo "screendump $LOGDIR/$CURRENT_NAME.vt1-maktop-running.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey alt-f1'
+    sleep 1.0
+    echo "screendump $LOGDIR/$CURRENT_NAME.vt0-after-vt1.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey alt-f2'
+    sleep 1.0
+    echo "screendump $LOGDIR/$CURRENT_NAME.vt1-after-vt0.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    # Tear down: q on VT1 (current), Alt+F1, q on VT0.  Then pwd.
+    send_script 'sendkey q'
+    sleep 0.6
+    send_script 'sendkey alt-f1'
+    sleep 0.6
+    send_script 'sendkey q'
+    sleep 0.6
+    local sb2=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    wait_for_serial '\[makbox:pwd\]' "$sb2" 5 || \
+        echo "  - pwd never ran (one of the maktops never died)"
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+
+    assert_serial_contains "[makbox:pwd]"
+}
+
+test_vt_all_roundtrips() {
+    # Exercise every VT round-trip from maktop on VT0: Alt+F2 → back,
+    # Alt+F3 → back, Alt+F4 → back.  After each return we dump a PPM
+    # so the inspector (me, you, or a future image-diff) can see
+    # whether maktop actually repainted.  At the end 'q' should still
+    # reach maktop (proves focus survived all three excursions).
+    CURRENT_NAME=vt-all-roundtrips
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey m
+sendkey a
+sendkey k
+sendkey t
+sendkey o
+sendkey p
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    sleep 1.2
+    for f in f2 f3 f4 ; do
+        send_script "sendkey alt-$f"
+        sleep 0.5
+        echo "screendump $LOGDIR/$CURRENT_NAME.at-$f.ppm" \
+            | nc -U "$MONITOR_SOCK" >/dev/null
+        sleep 0.2
+        send_script 'sendkey alt-f1'
+        sleep 1.0
+        echo "screendump $LOGDIR/$CURRENT_NAME.back-from-$f.ppm" \
+            | nc -U "$MONITOR_SOCK" >/dev/null
+        sleep 0.2
+    done
+    local sb2=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey q
+sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    wait_for_serial '\[makbox:pwd\]' "$sb2" 5 || \
+        echo "  - pwd never ran (maktop lost focus during the multi-VT tour)"
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+
+    assert_serial_contains "[makbox:pwd]"
+}
+
+test_vt_roundtrip_keeps_maktop_focused() {
+    # When the user Alt+Fn's away from a VT running a fullscreen ELF
+    # (here maktop), then Alt+Fn's back, keyboard focus must return to
+    # the foreground child -- not the slot's shell.  Before the fix,
+    # vtty_switch routed to the slot's owner (shell0) and maktop sat in
+    # its non-blocking read getting -EAGAIN forever; the user could
+    # see the UI but typing did nothing.
+    #
+    # Test: exec maktop, wait for it to start (one CPU bar refresh
+    # gives a serial breadcrumb via /proc/tasks), Alt+F2, Alt+F1 back,
+    # then send 'q' to quit maktop.  If focus is correctly restored,
+    # maktop sees 'q', cleans up, and the shell prompt comes back -- we
+    # confirm via a `pwd` round-trip producing the makbox provenance
+    # tag.  If focus is broken, 'q' is lost and pwd never runs.
+    CURRENT_NAME=vt-roundtrip-keeps-maktop-focused
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey m
+sendkey a
+sendkey k
+sendkey t
+sendkey o
+sendkey p
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    # Give maktop a moment to reach its main loop.
+    sleep 1.2
+    # Alt+F2 then Alt+F1 -- excursion + return.
+    send_script 'sendkey alt-f2'
+    sleep 0.4
+    send_script 'sendkey alt-f1'
+    sleep 1.2   # let maktop receive FOCUS_GAIN + finish its full repaint
+    # Visual snapshot AFTER the round-trip but BEFORE we kill maktop --
+    # this is what the operator actually sees when they Alt+F1 back.
+    # Serial-only assertions miss visual regressions (blue framebuffer
+    # under maktop's UI), so we save a PPM here that an inspector
+    # (or a future image-diff harness) can scrutinise.
+    echo "screendump $LOGDIR/$CURRENT_NAME.mid.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    local sb2=$(wc -c < "$SERIAL_LOG")
+    # 'q' should reach maktop now and quit it.  Then pwd via makbox.
+    send_script 'sendkey q
+sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    wait_for_serial '\[makbox:pwd\]' "$sb2" 5 || \
+        echo "  - pwd never ran (maktop probably never saw 'q')"
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+
+    assert_serial_contains "[makbox:pwd]"
+}
+
 test_user_sigusr1_handler() {
     # Slice 8 phase 4: ring-3 trampoline + sigreturn lets sys_signal(2)
     # actually invoke a user-installed handler.  sigtest.elf installs a
@@ -423,7 +724,7 @@ sendkey ret"
 
 # --- Driver -----------------------------------------------------------------
 
-ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear user_sigusr1_handler makbox_pwd)
+ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then

--- a/work-in-progress/hdd-boot.md
+++ b/work-in-progress/hdd-boot.md
@@ -15,8 +15,8 @@ Separate `makar-hdd-test.img` for CI testing.
       `grub-mkimage` (explicit `(hd0,msdos1)` prefix, no UUID probe)
 - [x] `generate-hdd.sh --test` - same image but grub.cfg passes `test`
       kernel arg (foundation for runtime test-mode switching)
-- [x] `./run.sh hdd-boot` - clean-build + interactive QEMU HDD boot
-- [x] `./run.sh hdd-test` - clean-build + GDB boot test with separate
+- [x] `./run.sh hdd boot` - clean-build + interactive QEMU HDD boot
+- [x] `./run.sh hdd test` - clean-build + GDB boot test with separate
       `makar-hdd-test.img` (never reuses interactive image)
 - [x] IDE SRST fix: software reset before probing so GRUB's transient
       channel state doesn't cause drive 0 to be silently skipped


### PR DESCRIPTION
## Summary

Slice 12 of the multi-PR split from #154. Stacked on **#160** (status-bar hide).

This was originally scoped as a pure run.sh grammar refactor, but the upstream commit (87745fd on the source branch) bundled several substantive additions: per-VT colour palettes, the clock.elf userspace app, new ui-test scenarios, and a procfs /proc/rtc renderer. They ride together in PR-E because they all reference the same task->tty + per-VT vt_buf machinery that the slice-10 work introduced.

**Base branch:** `feat/loading-statusbar` (PR #160).

## What lands

**`run.sh` two-argument subcommand grammar**
```
./run.sh iso   build | boot | test | release
./run.sh hdd   build | boot | test | release
./run.sh gdb   iso | hdd
./run.sh ktest [graphical]
./run.sh ui    [graphical] [scenario...]
./run.sh clean
```

Replaces the hyphenated single-word labels. **All builds are incremental** — `_clean` removed from every build mode (make + ccache handle "did anything change"). Result: second build of an unchanged tree drops from ~16 s to ~2 s. Legacy names (`./run.sh iso-build`) are rejected with the usage banner. CI workflows, README, CLAUDE.md, SURVEY.md, docker-compose.yml, docs/*, work-in-progress notes, and tests/ui_runner.sh all migrated.

**Per-VT colour palettes (`SHELL_SCHEMES[4]`)**
- VT0: green on black
- VT1: white on black
- VT2: white on blue
- VT3: black on white

Each VT owns its fg/bg state via `vt_buf->fg/bg`; writes via `vt_putchar` produce cells with the calling task's pen. `shell_apply_scheme_for_tty(tty)` reads the active task's `tty` field, sets the per-VT pen, and writes through to that VT's vt_buf (verified via `vtty_buf_current()` in `vesa_tty_setcolor`). Result: palettes are fully isolated like env-vars, no cross-VT leakage.

**clock.elf** — `/proc/rtc`-backed wall-clock display, CMOS read at I/O ports 0x70/0x71 with BCD decode, formatted as `YYYY-MM-DD HH:MM:SS`.

**`/proc/rtc`** — procfs entry that exposes the CMOS RTC, consumed by clock.elf.

**Two-stage shell-clear fix (commit 87de654)**
The upstream commit's per-VT palette work introduced two regressions I caught with screendump inspection:
1. **Bg bleed** — applying the scheme without clearing left the Medli blue loading-screen bg showing through any rows the banner didn't paint.
2. **Keystroke loss** — an earlier attempt at fixing #1 caused the runner's first post-boot keystroke ('v' in `verbose on`) to land in a timing window where it got dropped, breaking the serial mirror for the rest of the session.

Final behaviour:
- **First focus per VT**: clear-screen (establishes that VT's bg colour). One-time, runs in `shell_run`'s first-focus branch.
- **Subsequent Alt+Fn round-trips**: NO clear — VT content survives focus switches (Linux VT semantics).
- **Inside a session**: no implicit clears — the user's `clear` builtin is the only path that wipes the screen.

## Validation

- `./run.sh iso build` — clean
- `./run.sh ktest` — 21 suites pass
- `./run.sh ui` — **13/13 pass** including new `per-vt-palettes` and `vt-all-roundtrips` scenarios
- **Visual inspection** via PPM screendumps converted to PNG and viewed: all four VTs show their declared scheme with full-screen bg coverage and no cross-VT bleed

## Context

Part 5 of 5 splitting #154:
- [x] PR-A: #157 — signal subsystem (slice 8)
- [x] PR-B: #158 — preemption hardening (slice 9)
- [x] PR-C: #159 — maktop + task hardening + procfs polish + ui-test sync
- [x] PR-D: #160 — status-bar hide on loading
- [x] **PR-E: this PR** — `run.sh` grammar + per-VT palettes + clock.elf

#154 stays open as the safety net until all five merge.

## Test plan

- [ ] `./run.sh iso build` clean
- [ ] `./run.sh iso test` (ktest + GDB)
- [ ] `./run.sh ui` (all 13 scenarios)
- [ ] Visual: `./run.sh iso boot` → Alt+F1..F4 round-trip; confirm palette spec per VT
- [ ] Legacy `./run.sh iso-build` correctly rejected