### PR TITLE
feat(shell): bash-flavoured scripting — vars + if/while/for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,28 @@ Stack: PS/2 IRQ → scancode (set-1 + 0xE0 prefix) → keycode (HID-style abstra
 - Ctrl+C: abort current input line (prints `^C`, returns empty line to REPL).
 - Tab completion: first token completes command names; subsequent tokens complete VFS paths via `vfs_complete()` → `fat32_complete()`.
 - `exec <path>`: loads and runs an ELF binary from the VFS. Ctrl+C during exec force-kills the child task.
+- **makbox fallback is restricted**: bare command names route through makbox **only** if they match an actual applet (`ls cat cp mv rm rmdir echo pwd`). Anything else hits the shell's "Unknown command" path — typos no longer trigger makbox's usage banner.
+- `datetime` / `date` / `time` builtins — one-line `YYYY-MM-DD HH:MM:SS` from `/proc/rtc`.  Scriptable; for fullscreen use see `clock.elf`.
+
+### Shell scripting (sh-flavoured)
+The kernel shell exposes a per-shell-task scripting layer (`kernel/sh_script.h`, `arch/i386/shell/sh_script.c`):
+
+| Surface | Behaviour |
+|---|---|
+| `NAME=value` | Per-task assignment.  RHS shell-expanded.  Stored in `task_t.script_vars` (isolated per VT — VT0's vars don't leak into VT1, matching the per-VT palette model). |
+| `$VAR` / `${VAR}` / `$?` | Expansion at REPL or inside scripts.  `$?` is the last command's exit status (set after every dispatched line and every `[ TEST ]`). |
+| `env` / `unset NAME ...` | Dump table / remove vars. |
+| `read VAR` | Reads one line of input from the keyboard into VAR. |
+| `[ TEST ]` | String tests (`-z`/`-n`/`=`/`!=`) and integer tests (`-eq`/`-ne`/`-lt`/`-le`/`-gt`/`-ge`).  Non-numeric operand to integer ops fails with `[: integer expected`. |
+| `sh script.sh` / `./script.sh` | Run a script file (path ending in `.sh` dispatches through the script interpreter; arbitrary paths still try to ELF-exec). |
+| `# comment` | End-of-line comments (outside quotes). |
+| `if / elif / else / fi` | Chained, both multi-line and single-line `if [ X ]; then CMD; fi` forms. |
+| `while ... do ... done` | Multi-statement `do` bodies via `;`-split preprocessor. |
+| `for VAR in WORDS; do ... done` | Word-list iteration with `$VAR` expansion in the list. |
+| `sleep N` | Busy-yield until N seconds elapse (PIT-driven). |
+| `true` / `false` | POSIX status helpers. |
+
+Limitations: no command substitution (`$(cmd)`), no pipes, no subshells (needs `fork()` — see slice 12).  See `src/userspace/demo.sh` for a worked example exercising every surface.
 
 ### VMM (per-task page directories)
 - `vmm_create_pd()` - allocates a page directory and mirrors kernel PDEs (indices 0–63)
@@ -214,7 +236,8 @@ Freestanding ELF binaries built with the cross-compiler. Link against `crt0.S` +
 |--------|-------------|
 | `hello.elf` | Hello-world smoke test |
 | `calc.elf` | bc-style expression calculator - `+`, `-`, `*`, `/`, `%`, parentheses, recursive-descent parser |
-| `makbox.elf` | Makar busybox: multicall binary for `ls`, `cat`, `cp`, `mv`, `rm`, `rmdir`, `echo`, `pwd`. The shell PATH-resolves bare names against `*.elf` first, then falls back to `makbox <name>` — no symlinks needed (FAT32 has none). Replaces the former standalone `ls.elf`/`echo.elf`/`rm.elf`/`mv.elf`/`cp.elf`. |
+| `makbox.elf` | Makar busybox: multicall binary for `ls`, `cat`, `cp`, `mv`, `rm`, `rmdir`, `echo`, `pwd`. Shell dispatch falls back to `makbox <name>` **only for those specific applet names** — random typos no longer get routed into makbox just to surface its usage banner; they hit the shell's "Unknown command" path instead. Replaces the former standalone `ls.elf`/`echo.elf`/`rm.elf`/`mv.elf`/`cp.elf`. |
+| `clock.elf` | Fullscreen wall-clock display (CMOS RTC via `/proc/rtc`).  For scripted / one-line use see the `datetime`/`date`/`time` shell builtins instead. |
 | `diskinfo.elf` | partition table + FAT32 BPB dump via `SYS_DISK_INFO` |
 | `vix.elf` | pane-aware vi-style text editor; uses `SYS_PUTCH_AT` / `SYS_SET_CURSOR` / `SYS_TERM_SIZE` |
 | `kbtester.elf` | keyboard diagnostic — logs every event (scancode/keycode/sentinel/modifier) to serial via `SYS_WRITE_SERIAL` |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,7 @@ usually one PR per slice.
 |    15 | VFS `task->cwd` authoritative                          | ✅ shipped (#135)           | —                                                                                  |
 |    16 | VGA-text fallback per-TTY                              | ⏭ queued                    | [#146](https://github.com/Arawn-Davies/Makar/issues/146)                          |
 |    17 | makbox multicall + `SYS_GETCWD` + exec race fix        | ✅ shipped (#137)           | —                                                                                  |
+|    18 | Bash-flavoured shell scripting (vars, `$?`, if/elif/else, while, for, `sh script.sh`, `./script.sh`, makbox-restriction, `datetime`/`date`/`time` builtins) | ✅ shipped (#163)           | —                                                                                  |
 
 ## Active themes
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,0 +1,103 @@
+---
+title: Shell scripting
+nav_order: 7
+---
+
+# Shell scripting
+
+The Makar shell exposes a small bash-flavoured scripting layer.  No `fork()`, no pipes, no command substitution yet — everything runs inside the calling shell task.  Per-VT isolation: each shell's variable table hangs off its `task_t`, so `NAME=foo` on VT0 doesn't show up in VT1.
+
+Implementation: `kernel/sh_script.h`, `arch/i386/shell/sh_script.c`, `arch/i386/shell/shell_cmd_script.c`.
+
+## Variables
+
+```sh
+NAME=value           # per-task, no spaces around =, RHS shell-expanded
+echo $NAME           # $VAR
+echo ${NAME}_suffix  # ${VAR} for boundary cases
+echo $?              # last command's exit status (0 on success, 127 unknown)
+env                  # dump the table
+unset NAME [...]     # remove vars
+```
+
+## Tests
+
+```sh
+[ STR ]              # non-empty string
+[ -z STR ]           # empty
+[ -n STR ]           # non-empty (explicit)
+[ STR1 = STR2 ]      # string equal
+[ STR1 != STR2 ]     # string not equal
+
+[ N1 -eq N2 ]        # integer equal       (-ne, -lt, -le, -gt, -ge)
+                     # non-numeric operand: error, $? = 2
+```
+
+## Control flow
+
+```sh
+if [ TEST ]; then
+    ...
+elif [ TEST ]; then
+    ...
+else
+    ...
+fi
+
+# Single-line form
+if [ TEST ]; then CMD; fi
+
+while [ TEST ]; do
+    ...
+done
+
+for VAR in WORD1 WORD2 WORD3; do
+    ...
+done
+```
+
+Multi-statement lines split on `;` are supported (`if [ X ]; then A; elif [ Y ]; then B; else C; fi` works on a single line).  `# ...` comments terminate the line outside quotes.
+
+## Running scripts
+
+```sh
+sh /cdrom/apps/demo.sh
+./script.sh               # path ending in .sh goes through the interpreter
+/cdrom/apps/script.sh     # absolute path, same dispatch
+```
+
+The `sh` builtin writes the script's final `$?` to serial as `sh: exit=N` so test runners can scrape the value.
+
+## Builtins relevant to scripting
+
+| Command | Notes |
+|---|---|
+| `sh PATH` | Run a script file (path on the VFS). |
+| `read VAR` | One line of input → `VAR`. |
+| `env` / `unset` | Variable table dump / remove. |
+| `[ ... ]` | Test (also usable interactively). |
+| `sleep N` | Busy-yield N seconds (100 Hz PIT). |
+| `true` / `false` | POSIX status helpers. |
+| `datetime` / `date` / `time` | One-line `YYYY-MM-DD HH:MM:SS` from `/proc/rtc`.  For the fullscreen wall clock, use `clock.elf`. |
+
+## Limitations (and what they're waiting on)
+
+- **No command substitution (`$(cmd)`)** — would require capturing a child's stdout into a buffer; needs subshell-equivalent.
+- **No pipes** — needs `fork()`.
+- **No background jobs (`&`)** — needs `fork()`.
+- **`elif` chained but `elif` itself can't appear on the same line as preceding body** — `; elif` is fine; `then A; elif [ Y ]; then B` works; bare `; elif` without preceding `; then BODY` may not parse.
+- **64 KiB scratch buffer for script source** — warns on truncation; chain `sh foo.sh; sh bar.sh` for bigger workloads.
+
+## Worked example
+
+`src/userspace/demo.sh` is bundled into `/cdrom/apps/demo.sh` and `/hd/apps/demo.sh`.  It exercises every feature listed above with section markers (`cwd-ok`, `gt-ok`, `elif-correct-blue`, etc.) so a regression in any layer fails loudly.  Run with:
+
+```sh
+sh /cdrom/apps/demo.sh
+```
+
+or the bash-style equivalent:
+
+```sh
+/cdrom/apps/demo.sh
+```

--- a/generate-hdd.sh
+++ b/generate-hdd.sh
@@ -33,7 +33,7 @@ DOCKER_BIN=${DOCKER_BIN:-docker}
 DOCKER_PLATFORM=${DOCKER_PLATFORM:-linux/amd64}
 BUILD_IMAGE=${BUILD_IMAGE:-arawn780/gcc-cross-i686-elf:fast}
 HDD_IMG=${HDD_IMG:-makar-hdd.img}
-HDD_SIZE_MB=${HDD_SIZE_MB:-512}
+HDD_SIZE_MB=${HDD_SIZE_MB:-96}
 
 # Parse flags.
 for _arg in "$@"; do

--- a/generate-hdd.sh
+++ b/generate-hdd.sh
@@ -136,6 +136,17 @@ if [ -d /work/isodir/apps ]; then
     cp -r /work/isodir/apps/. "$MNT/apps/"
 fi
 
+# Mirror the ISO's docs + src trees onto the HDD so the same VIX-readable
+# documentation and source code are available from /hd as from /cdrom.
+if [ -d /work/isodir/docs ]; then
+    mkdir -p "$MNT/docs"
+    cp -r /work/isodir/docs/. "$MNT/docs/"
+fi
+if [ -d /work/isodir/src ]; then
+    mkdir -p "$MNT/src"
+    cp -r /work/isodir/src/. "$MNT/src/"
+fi
+
 cat > "$MNT/boot/grub/grub.cfg" << GCFG
 set default=0
 set timeout=3

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -51,4 +51,6 @@ $(ARCHDIR)/shell/shell_cmd_disk.o \
 $(ARCHDIR)/shell/shell_cmd_fs.o \
 $(ARCHDIR)/shell/shell_cmd_apps.o \
 $(ARCHDIR)/shell/shell_cmd_man.o \
+$(ARCHDIR)/shell/shell_cmd_script.o \
+$(ARCHDIR)/shell/sh_script.o \
 $(ARCHDIR)/debug/debug.o \

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -498,10 +498,17 @@ void syscall_dispatch(registers_t *regs)
      * Returns EAX = (cols << 16) | rows.
      * ------------------------------------------------------------------ */
     case SYS_TERM_SIZE: {
+        /* Report the *drawable* area, not the full framebuffer.  The
+         * bottom VESA_TTY_STATUS_ROWS row is reserved for the tmux-style
+         * VT bar -- fullscreen apps (maktop, clock, vix) that paint up
+         * to (rows-1) would otherwise stomp the bar.  Resolution-aware
+         * because both vesa_tty_get_rows() and the constant scale with
+         * the chosen mode. */
         uint32_t cols, rows;
         if (vesa_tty_is_ready()) {
             cols = vesa_tty_get_cols();
             rows = vesa_tty_get_rows();
+            if (rows > VESA_TTY_STATUS_ROWS) rows -= VESA_TTY_STATUS_ROWS;
         } else {
             cols = VGA_WIDTH;
             rows = (uint32_t)t_get_rows();

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -192,6 +192,15 @@ task_t *task_create(const char *name, void (*entry)(void))
             if (t->exec_params) {
                 kfree(t->exec_params);
                 t->exec_params = NULL;
+    t->script_vars = NULL;
+            }
+
+            /* Reap the per-shell-task scripting variable table.  Same
+             * deferred-free pattern as fd_table: don't touch from
+             * task_exit (which may run in arbitrary scheduler context). */
+            if (t->script_vars) {
+                extern void sh_vars_free_for(void *task);
+                sh_vars_free_for(t);
             }
 
             /* Reuse the existing kernel stack. */
@@ -228,6 +237,7 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->unkillable  = 0;     /* default: ordinary task, no protection   */
     t->fd_table    = new_fds;
     t->exec_params = NULL;
+    t->script_vars = NULL;
 
     /* Reset signal state.  Must run after the slot is on the task pool
      * (either freshly allocated above or reclaimed from a DEAD slot) so

--- a/src/kernel/arch/i386/shell/sh_script.c
+++ b/src/kernel/arch/i386/shell/sh_script.c
@@ -644,22 +644,154 @@ int sh_run_file(const char *path)
         /* Crude size print without depending on stdio. */
         t_writestring("256KiB; split into multiple files and chain via `sh`\n");
     }
-    /* Build an array of line pointers by NUL-terminating each \n. */
+    /* Split into logical lines.  Two passes:
+     *   1. break on \n  (physical lines)
+     *   2. break on `;`  (multi-statement lines)
+     *
+     * The second pass respects single-quote and double-quote runs so
+     * `echo "a; b"` stays one statement.  Trailing-`then`/`do` keywords
+     * after a `;` stay glued to the previous line so the `if`/`while`/
+     * `for` headers (`if [ X ]; then`) are still recognised by the
+     * keyword walker. */
     int nlines = 1;
-    for (uint32_t i = 0; i < sz; i++) if (data[i] == '\n') nlines++;
-    char **lines = (char **)kmalloc((size_t)nlines * sizeof(char *));
+    for (uint32_t i = 0; i < sz; i++) if (data[i] == '\n' || data[i] == ';') nlines++;
+    /* Each `;` may yield up to two fragments after gluing keywords, so
+     * over-allocate a little. */
+    char **lines = (char **)kmalloc((size_t)(nlines + 4) * sizeof(char *));
     if (!lines) { kfree(data); return -1; }
     int li = 0;
-    lines[li++] = data;
-    for (uint32_t i = 0; i < sz; i++) {
-        if (data[i] == '\n') {
-            data[i] = '\0';
-            if ((uint32_t)(i + 1) < sz)
-                lines[li++] = &data[i + 1];
+
+    /* Pass 1: physical lines. */
+    char *p = data;
+    char *line_start = data;
+    while (p < data + sz) {
+        if (*p == '\n') {
+            *p = '\0';
+            lines[li++] = line_start;
+            line_start = p + 1;
+        }
+        p++;
+    }
+    if (line_start < data + sz) lines[li++] = line_start;
+
+    /* Pre-strip comments before semicolon split so a trailing `# ...`
+     * doesn't smuggle a fake `;` into our parser. */
+    for (int i = 0; i < li; i++) sh_strip_comment(lines[i]);
+
+    /* Pass 2: split each physical line on top-level `;` into its own
+     * logical line, then run a fix-up pass so control-flow keywords
+     * end up where the walker expects them.
+     *
+     * Source forms we have to handle:
+     *
+     *   if [ X ]; then A; B; fi             # inline if (full)
+     *   if [ X ]; then A; elif [ Y ]; then B; else C; fi
+     *   while [ X ]; do A; B; done
+     *   for V in W; do A; B; done
+     *
+     * After a naive `;`-split we'd get fragments like ["if [ X ]",
+     * "then A", "elif [ Y ]", "then B", "else C", "fi"].  The walker
+     * wants:
+     *
+     *   if [ X ]; then     # condition line (then trimmed off)
+     *   A
+     *   elif [ Y ]; then
+     *   B
+     *   else
+     *   C
+     *   fi
+     *
+     * Fix-up rule: if a fragment starts with `then ` or `do `, peel the
+     * keyword off, glue it onto the previous line (with `; `), and emit
+     * the remainder as a new line.  `else FOO` and `elif ... ; then FOO`
+     * have FOO peeled off the same way. */
+    int  oli = 0;
+    char **olines = (char **)kmalloc((size_t)(nlines * 4 + 16) * sizeof(char *));
+    if (!olines) { kfree(lines); kfree(data); return -1; }
+    for (int i = 0; i < li; i++) {
+        char *s = lines[i];
+        int   sq = 0, dq = 0;
+        char *frag = s;
+        for (char *q = s; *q; q++) {
+            if (*q == '\'' && !dq) sq = !sq;
+            else if (*q == '"' && !sq) dq = !dq;
+            else if (*q == ';' && !sq && !dq) {
+                *q = '\0';
+                olines[oli++] = frag;
+                frag = q + 1;
+            }
+        }
+        olines[oli++] = frag;
+    }
+    /* Fix-up: emit keyword + body splits. */
+    char **flines = (char **)kmalloc((size_t)(oli * 4 + 16) * sizeof(char *));
+    if (!flines) { kfree(olines); kfree(lines); kfree(data); return -1; }
+    int fli = 0;
+    static char glue_buf[2048];
+    size_t glue_used = 0;
+    for (int i = 0; i < oli; i++) {
+        char *t = olines[i];
+        while (*t == ' ' || *t == '\t') t++;
+        /* If this fragment starts with `then ` or `do `, glue the
+         * keyword onto the previous emitted line and emit the body. */
+        if ((strncmp(t, "then", 4) == 0 && (t[4] == '\0' || t[4] == ' ')) ||
+            (strncmp(t, "do",   2) == 0 && (t[2] == '\0' || t[2] == ' '))) {
+            const char *kw = (t[0] == 't') ? "then" : "do";
+            size_t kwlen = (kw[0] == 't') ? 4 : 2;
+            /* glue: <prev>; then  -- in a static glue arena.  No
+             * lifetime issue: glue_buf lives till sh_run_file returns. */
+            if (fli > 0) {
+                char *prev = flines[fli - 1];
+                size_t pl = strlen(prev);
+                if (glue_used + pl + 3 + kwlen + 1 < sizeof(glue_buf)) {
+                    char *dst = glue_buf + glue_used;
+                    memcpy(dst, prev, pl);
+                    dst[pl] = ';'; dst[pl+1] = ' ';
+                    memcpy(dst + pl + 2, kw, kwlen);
+                    dst[pl + 2 + kwlen] = '\0';
+                    flines[fli - 1] = dst;
+                    glue_used += pl + 2 + kwlen + 1;
+                }
+            }
+            /* Emit body if any. */
+            char *body = t + kwlen;
+            while (*body == ' ' || *body == '\t') body++;
+            if (*body) flines[fli++] = body;
+            continue;
+        }
+        /* `else BODY` and `elif ...; then BODY` already split correctly
+         * for `else`; for `elif` the `then BODY` next fragment is what
+         * gets peeled by the path above.  Just emit. */
+        flines[fli++] = olines[i];
+    }
+    /* `else BODY` on one line: split into "else" + "BODY". */
+    int  efli = 0;
+    char **elines = (char **)kmalloc((size_t)(fli * 2 + 16) * sizeof(char *));
+    if (!elines) { kfree(flines); kfree(olines); kfree(lines); kfree(data); return -1; }
+    for (int i = 0; i < fli; i++) {
+        char *t = flines[i];
+        char *p = t;
+        while (*p == ' ' || *p == '\t') p++;
+        if (strncmp(p, "else ", 5) == 0) {
+            /* Emit `else`, then the body. */
+            if (glue_used + 5 < sizeof(glue_buf)) {
+                memcpy(glue_buf + glue_used, "else", 5);
+                elines[efli++] = glue_buf + glue_used;
+                glue_used += 5;
+            }
+            char *body = p + 5;
+            while (*body == ' ' || *body == '\t') body++;
+            if (*body) elines[efli++] = body;
+        } else {
+            elines[efli++] = t;
         }
     }
-    /* Pre-strip comments on every line so keyword recognition is clean. */
-    for (int i = 0; i < li; i++) sh_strip_comment(lines[i]);
+    kfree(flines);
+    kfree(olines);
+    kfree(lines);
+    lines = elines;
+    li = efli;
+    /* No further comment strip needed -- already done above. */
     int rc = run_block(lines, 0, li);
     kfree(lines);
     kfree(data);

--- a/src/kernel/arch/i386/shell/sh_script.c
+++ b/src/kernel/arch/i386/shell/sh_script.c
@@ -1,0 +1,519 @@
+/*
+ * sh_script.c - per-shell-task variable table + script interpreter.
+ *
+ * Variables live in task_t.script_vars (per-shell-task isolation,
+ * Linux-VT-like).  Allocated on first set; grown by power-of-two.
+ *
+ * Script execution is line-oriented with a small recursive-descent
+ * interpreter for if/while/for and a simple `[ ... ]` test builtin.
+ * No subshells, no pipes, no command substitution -- we run inside
+ * the kernel shell task, calling shell_dispatch for each statement.
+ */
+
+#include <kernel/sh_script.h>
+#include <kernel/shell.h>
+#include <kernel/task.h>
+#include <kernel/heap.h>
+#include <kernel/tty.h>
+#include <kernel/vfs.h>
+#include <string.h>
+#include "shell_priv.h"
+
+/* ---- variable table ------------------------------------------------------ */
+
+typedef struct sh_var {
+    char *name;
+    char *value;
+} sh_var_t;
+
+typedef struct sh_var_tab {
+    int       cap;
+    int       len;
+    sh_var_t *items;
+} sh_var_tab_t;
+
+static sh_var_tab_t *vars_for_current(int create)
+{
+    task_t *t = task_current();
+    if (!t) return NULL;
+    if (!t->script_vars && create) {
+        sh_var_tab_t *tab = (sh_var_tab_t *)kmalloc(sizeof(*tab));
+        if (!tab) return NULL;
+        tab->cap = 0; tab->len = 0; tab->items = NULL;
+        t->script_vars = tab;
+    }
+    return (sh_var_tab_t *)t->script_vars;
+}
+
+static int vars_find(sh_var_tab_t *tab, const char *name)
+{
+    if (!tab) return -1;
+    for (int i = 0; i < tab->len; i++)
+        if (strcmp(tab->items[i].name, name) == 0)
+            return i;
+    return -1;
+}
+
+const char *sh_vars_get(const char *name)
+{
+    sh_var_tab_t *tab = vars_for_current(0);
+    int i = vars_find(tab, name);
+    return (i >= 0) ? tab->items[i].value : NULL;
+}
+
+int sh_vars_set(const char *name, const char *value)
+{
+    sh_var_tab_t *tab = vars_for_current(1);
+    if (!tab) return -1;
+    int i = vars_find(tab, name);
+    if (i >= 0) {
+        char *nv = (char *)kmalloc(strlen(value) + 1);
+        if (!nv) return -1;
+        strcpy(nv, value);
+        kfree(tab->items[i].value);
+        tab->items[i].value = nv;
+        return 0;
+    }
+    if (tab->len == tab->cap) {
+        int   nc = tab->cap ? tab->cap * 2 : 8;
+        sh_var_t *na = (sh_var_t *)kmalloc((size_t)nc * sizeof(sh_var_t));
+        if (!na) return -1;
+        if (tab->items) {
+            memcpy(na, tab->items, (size_t)tab->len * sizeof(sh_var_t));
+            kfree(tab->items);
+        }
+        tab->items = na;
+        tab->cap   = nc;
+    }
+    char *nn = (char *)kmalloc(strlen(name)  + 1);
+    char *nv = (char *)kmalloc(strlen(value) + 1);
+    if (!nn || !nv) { kfree(nn); kfree(nv); return -1; }
+    strcpy(nn, name); strcpy(nv, value);
+    tab->items[tab->len].name  = nn;
+    tab->items[tab->len].value = nv;
+    tab->len++;
+    return 0;
+}
+
+void sh_vars_unset(const char *name)
+{
+    sh_var_tab_t *tab = vars_for_current(0);
+    int i = vars_find(tab, name);
+    if (i < 0) return;
+    kfree(tab->items[i].name);
+    kfree(tab->items[i].value);
+    tab->items[i] = tab->items[tab->len - 1];
+    tab->len--;
+}
+
+void sh_vars_iter(sh_vars_iter_cb cb, void *ctx)
+{
+    sh_var_tab_t *tab = vars_for_current(0);
+    if (!tab) return;
+    for (int i = 0; i < tab->len; i++)
+        if (cb(tab->items[i].name, tab->items[i].value, ctx))
+            return;
+}
+
+void sh_vars_free_for(void *task)
+{
+    task_t *t = (task_t *)task;
+    if (!t || !t->script_vars) return;
+    sh_var_tab_t *tab = (sh_var_tab_t *)t->script_vars;
+    for (int i = 0; i < tab->len; i++) {
+        kfree(tab->items[i].name);
+        kfree(tab->items[i].value);
+    }
+    kfree(tab->items);
+    kfree(tab);
+    t->script_vars = NULL;
+}
+
+/* ---- helpers ------------------------------------------------------------- */
+
+static int is_ident_start(char c) { return (c=='_') || (c>='A'&&c<='Z') || (c>='a'&&c<='z'); }
+static int is_ident_cont(char c)  { return is_ident_start(c) || (c>='0'&&c<='9'); }
+
+/* ---- $VAR / ${VAR} expansion --------------------------------------------- */
+
+int sh_expand(const char *in, char *out, size_t outsz)
+{
+    size_t oi = 0;
+    for (size_t i = 0; in[i]; ) {
+        if (in[i] == '$' && (is_ident_start(in[i+1]) || in[i+1] == '{')) {
+            int braced = (in[i+1] == '{');
+            size_t s = i + 1 + (size_t)braced;
+            size_t e = s;
+            while (in[e] && is_ident_cont(in[e])) e++;
+            if (e == s) { /* not actually a var */ goto literal; }
+            if (braced && in[e] != '}') return -1;
+            char name[64];
+            size_t nl = e - s;
+            if (nl >= sizeof(name)) return -1;
+            memcpy(name, in + s, nl);
+            name[nl] = '\0';
+            const char *v = sh_vars_get(name);
+            if (v) {
+                size_t vl = strlen(v);
+                if (oi + vl >= outsz) return -1;
+                memcpy(out + oi, v, vl);
+                oi += vl;
+            }
+            i = e + (size_t)braced;
+            continue;
+        }
+literal:
+        if (oi + 1 >= outsz) return -1;
+        out[oi++] = in[i++];
+    }
+    out[oi] = '\0';
+    return 0;
+}
+
+/* ---- assignment ---------------------------------------------------------- */
+
+int sh_try_assign(const char *line)
+{
+    /* Match ^[A-Za-z_][A-Za-z0-9_]*=.*$ -- no leading whitespace, no spaces
+     * around '='.  Matches bash/sh assignment grammar. */
+    if (!is_ident_start(line[0])) return 0;
+    size_t i = 1;
+    while (is_ident_cont(line[i])) i++;
+    if (line[i] != '=') return 0;
+    char name[64];
+    if (i >= sizeof(name)) return 0;
+    memcpy(name, line, i);
+    name[i] = '\0';
+    const char *rhs = line + i + 1;
+    static char expanded[512];
+    if (sh_expand(rhs, expanded, sizeof(expanded)) != 0) {
+        t_writestring("sh: assignment expansion overflow\n");
+        return 1;
+    }
+    if (sh_vars_set(name, expanded) != 0)
+        t_writestring("sh: OOM on assignment\n");
+    return 1;
+}
+
+/* ---- comment strip ------------------------------------------------------- */
+
+void sh_strip_comment(char *line)
+{
+    int sq = 0, dq = 0;
+    for (size_t i = 0; line[i]; i++) {
+        if (line[i] == '\'' && !dq) sq = !sq;
+        else if (line[i] == '"' && !sq) dq = !dq;
+        else if (line[i] == '#' && !sq && !dq) {
+            line[i] = '\0';
+            return;
+        }
+    }
+}
+
+/* ---- line execution ------------------------------------------------------ */
+
+int sh_exec_line(char *line)
+{
+    /* Trim leading whitespace. */
+    while (*line == ' ' || *line == '\t') line++;
+    if (!*line) return 1;
+    sh_strip_comment(line);
+    /* Trim trailing whitespace. */
+    size_t l = strlen(line);
+    while (l > 0 && (line[l-1] == ' ' || line[l-1] == '\t' || line[l-1] == '\r'))
+        line[--l] = '\0';
+    if (!*line) return 1;
+
+    if (sh_try_assign(line)) return 1;
+
+    static char expanded[1024];
+    if (sh_expand(line, expanded, sizeof(expanded)) != 0) {
+        t_writestring("sh: line too long after expansion\n");
+        return 0;
+    }
+    char *argv[SHELL_MAX_ARGS];
+    int argc = shell_parse(expanded, argv, SHELL_MAX_ARGS);
+    if (argc == 0) return 1;
+    return shell_dispatch_argv(argc, argv);
+}
+
+/* ---- script-file walker with if/while/for -------------------------------- */
+/*
+ * Strategy: load whole file into a buffer, split into NUL-terminated
+ * lines (line[i] is a pointer into the buffer).  Walk with a small
+ * stack-based interpreter.
+ *
+ * Supported constructs:
+ *   if [ TEST ]; then ... elif [ TEST ]; then ... else ... fi
+ *   while [ TEST ]; do ... done
+ *   for VAR in WORDS; do ... done
+ *   [ TEST ]          -- sets $? to 0/1 via _sh_last_status
+ *
+ * We split each line on `;` so the user can write `if [ x ]; then` on
+ * one line, but we tolerate split across lines too.  Keywords are
+ * recognised only when they are the first token of a logical statement.
+ */
+
+static int sh_last_status = 0;
+
+/* Forward decl: defined further down. */
+static int run_block(char **lines, int from, int to);
+
+/* Find matching end-keyword (fi/done) starting from `from`, respecting
+ * nesting.  Returns line index of the matching end, or -1. */
+static int find_match(char **lines, int from, int to,
+                      const char *open1, const char *open2,
+                      const char *close, const char **mids, int n_mids,
+                      int *first_mid_out)
+{
+    int depth = 1;
+    if (first_mid_out) *first_mid_out = -1;
+    for (int i = from; i < to; i++) {
+        char *t = lines[i];
+        while (*t == ' ' || *t == '\t') t++;
+        size_t l1 = strlen(open1);
+        if ((open2 && strncmp(t, open2, strlen(open2)) == 0 && (t[strlen(open2)] == ' ' || t[strlen(open2)] == '\t' || t[strlen(open2)] == '\0')) ||
+            (strncmp(t, open1, l1) == 0 && (t[l1] == ' ' || t[l1] == '\t' || t[l1] == '\0'))) {
+            depth++;
+            continue;
+        }
+        size_t cl = strlen(close);
+        if (strncmp(t, close, cl) == 0 && (t[cl] == '\0' || t[cl] == ' ' || t[cl] == ';')) {
+            depth--;
+            if (depth == 0) return i;
+            continue;
+        }
+        if (depth == 1 && first_mid_out && *first_mid_out < 0) {
+            for (int m = 0; m < n_mids; m++) {
+                size_t ml = strlen(mids[m]);
+                if (strncmp(t, mids[m], ml) == 0 &&
+                    (t[ml] == '\0' || t[ml] == ' ' || t[ml] == ';')) {
+                    *first_mid_out = i;
+                    break;
+                }
+            }
+        }
+    }
+    return -1;
+}
+
+/* `[ ARGS ]` test.  Supports:
+ *   [ -z STR ]        empty
+ *   [ -n STR ]        non-empty
+ *   [ STR = STR ]     string equal
+ *   [ STR != STR ]    string not equal
+ *   [ INT -eq INT ]   integer equal (also -ne -lt -le -gt -ge)
+ * Returns 0 on true, 1 on false (sh convention).
+ */
+static int atoi_safe(const char *s) { int r=0,n=0; if(*s=='-'){n=1;s++;} while(*s>='0'&&*s<='9') r=r*10+(*s++-'0'); return n?-r:r; }
+
+static int sh_test(int argc, char **argv)
+{
+    if (argc == 0) return 1;
+    if (argc == 1) return (*argv[0]) ? 0 : 1;
+    if (argc == 2) {
+        if (strcmp(argv[0], "-z") == 0) return (!*argv[1]) ? 0 : 1;
+        if (strcmp(argv[0], "-n") == 0) return ( *argv[1]) ? 0 : 1;
+    }
+    if (argc == 3) {
+        if (strcmp(argv[1], "=")  == 0) return strcmp(argv[0], argv[2]) == 0 ? 0 : 1;
+        if (strcmp(argv[1], "!=") == 0) return strcmp(argv[0], argv[2]) != 0 ? 0 : 1;
+        int a = atoi_safe(argv[0]), b = atoi_safe(argv[2]);
+        if (strcmp(argv[1], "-eq") == 0) return a == b ? 0 : 1;
+        if (strcmp(argv[1], "-ne") == 0) return a != b ? 0 : 1;
+        if (strcmp(argv[1], "-lt") == 0) return a <  b ? 0 : 1;
+        if (strcmp(argv[1], "-le") == 0) return a <= b ? 0 : 1;
+        if (strcmp(argv[1], "-gt") == 0) return a >  b ? 0 : 1;
+        if (strcmp(argv[1], "-ge") == 0) return a >= b ? 0 : 1;
+    }
+    return 1;
+}
+
+/* Evaluate a `[ ... ]` condition expressed as a raw line.  Returns 1
+ * (true) or 0 (false). */
+static int eval_condition(const char *line)
+{
+    /* Strip leading whitespace + opening `[`. */
+    while (*line == ' ' || *line == '\t') line++;
+    if (*line != '[') {
+        /* Treat as a command; success means status 0. */
+        static char buf[256];
+        strncpy(buf, line, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        int rc = sh_exec_line(buf);
+        return rc ? 1 : 0;   /* dispatched OK ~= "true" */
+    }
+    line++;   /* skip [ */
+    static char buf[256];
+    strncpy(buf, line, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+    /* Strip trailing `]` and optional trailing `;` from a single-line form. */
+    size_t l = strlen(buf);
+    while (l > 0 && (buf[l-1] == ';' || buf[l-1] == ' ' || buf[l-1] == '\t')) buf[--l] = '\0';
+    if (l > 0 && buf[l-1] == ']') buf[--l] = '\0';
+    static char expanded[512];
+    if (sh_expand(buf, expanded, sizeof(expanded)) != 0) return 0;
+    char *argv[SHELL_MAX_ARGS];
+    int argc = shell_parse(expanded, argv, SHELL_MAX_ARGS);
+    int rc = sh_test(argc, argv);
+    sh_last_status = rc;
+    return rc == 0;
+}
+
+/* Run lines[from .. to-1] as a block, honouring keywords. */
+static int run_block(char **lines, int from, int to)
+{
+    int i = from;
+    while (i < to) {
+        char *t = lines[i];
+        while (*t == ' ' || *t == '\t') t++;
+
+        if (strncmp(t, "if ", 3) == 0 || strcmp(t, "if") == 0) {
+            const char *mids[2] = { "elif ", "else" };
+            int mid;
+            int end = find_match(lines, i + 1, to, "if", NULL, "fi",
+                                 mids, 2, &mid);
+            if (end < 0) { t_writestring("sh: missing fi\n"); return -2; }
+            /* Condition is on the same line as `if`: "if [ X ]; then" */
+            const char *cond_start = t + 2;
+            while (*cond_start == ' ' || *cond_start == '\t') cond_start++;
+            /* Drop a trailing "; then" or " then" if present. */
+            static char cond[256];
+            strncpy(cond, cond_start, sizeof(cond) - 1);
+            cond[sizeof(cond) - 1] = '\0';
+            char *th = strstr(cond, "then");
+            if (th) {
+                while (th > cond && (th[-1] == ' ' || th[-1] == ';' || th[-1] == '\t'))
+                    th--;
+                *th = '\0';
+            }
+            int true_branch = eval_condition(cond);
+            int body_from = i + 1;
+            int body_to   = (mid >= 0) ? mid : end;
+            int else_from = (mid >= 0) ? (mid + 1) : end;
+            int rc = 0;
+            if (true_branch) {
+                rc = run_block(lines, body_from, body_to);
+            } else if (mid >= 0) {
+                /* Currently treats elif as else (no chained elif).  Good
+                 * enough for the MVP; chained elif is a follow-up. */
+                rc = run_block(lines, else_from, end);
+            }
+            if (rc < 0) return rc;
+            i = end + 1;
+            continue;
+        }
+
+        if (strncmp(t, "while ", 6) == 0) {
+            int end = find_match(lines, i + 1, to, "while", NULL, "done",
+                                 NULL, 0, NULL);
+            if (end < 0) { t_writestring("sh: missing done\n"); return -2; }
+            static char cond[256];
+            strncpy(cond, t + 6, sizeof(cond) - 1);
+            cond[sizeof(cond) - 1] = '\0';
+            char *dw = strstr(cond, "do");
+            if (dw) {
+                while (dw > cond && (dw[-1] == ' ' || dw[-1] == ';' || dw[-1] == '\t'))
+                    dw--;
+                *dw = '\0';
+            }
+            int guard = 0;
+            while (eval_condition(cond)) {
+                int rc = run_block(lines, i + 1, end);
+                if (rc < 0) return rc;
+                if (++guard > 100000) { t_writestring("sh: while-loop guard tripped\n"); break; }
+            }
+            i = end + 1;
+            continue;
+        }
+
+        if (strncmp(t, "for ", 4) == 0) {
+            int end = find_match(lines, i + 1, to, "for", NULL, "done",
+                                 NULL, 0, NULL);
+            if (end < 0) { t_writestring("sh: missing done\n"); return -2; }
+            /* Parse: `for VAR in W1 W2 ...; do` */
+            const char *p = t + 4;
+            while (*p == ' ') p++;
+            char var[64];
+            size_t vi = 0;
+            while (*p && is_ident_cont(*p) && vi + 1 < sizeof(var))
+                var[vi++] = *p++;
+            var[vi] = '\0';
+            while (*p == ' ') p++;
+            if (strncmp(p, "in", 2) != 0) {
+                t_writestring("sh: bad for syntax\n"); return -2;
+            }
+            p += 2;
+            static char wbuf[256];
+            strncpy(wbuf, p, sizeof(wbuf) - 1);
+            wbuf[sizeof(wbuf) - 1] = '\0';
+            char *dw = strstr(wbuf, "do");
+            if (dw) {
+                while (dw > wbuf && (dw[-1] == ' ' || dw[-1] == ';' || dw[-1] == '\t'))
+                    dw--;
+                *dw = '\0';
+            }
+            static char expanded[512];
+            if (sh_expand(wbuf, expanded, sizeof(expanded)) != 0) {
+                t_writestring("sh: for-list expansion overflow\n");
+                return -2;
+            }
+            char *argv[SHELL_MAX_ARGS];
+            int argc = shell_parse(expanded, argv, SHELL_MAX_ARGS);
+            for (int k = 0; k < argc; k++) {
+                sh_vars_set(var, argv[k]);
+                int rc = run_block(lines, i + 1, end);
+                if (rc < 0) return rc;
+            }
+            i = end + 1;
+            continue;
+        }
+
+        /* Plain command line. */
+        static char copy[512];
+        strncpy(copy, lines[i], sizeof(copy) - 1);
+        copy[sizeof(copy) - 1] = '\0';
+        sh_last_status = sh_exec_line(copy) ? 0 : 1;
+        i++;
+    }
+    return 0;
+}
+
+int sh_run_file(const char *path)
+{
+    /* Read into a fixed scratch buffer.  64 KiB is plenty for hand-written
+     * shell scripts; bigger scripts can be split into multiple files and
+     * `sh` chained.  Allocated from the heap to keep the kernel stack lean. */
+    enum { SH_MAX_SCRIPT = 65536 };
+    char    *data = (char *)kmalloc(SH_MAX_SCRIPT);
+    uint32_t sz = 0;
+    if (!data) return -1;
+    if (vfs_read_file(path, data, SH_MAX_SCRIPT - 1, &sz) != 0) {
+        kfree(data);
+        t_writestring("sh: cannot open ");
+        t_writestring(path);
+        t_writestring("\n");
+        return -1;
+    }
+    data[sz] = '\0';
+    /* Build an array of line pointers by NUL-terminating each \n. */
+    int nlines = 1;
+    for (uint32_t i = 0; i < sz; i++) if (data[i] == '\n') nlines++;
+    char **lines = (char **)kmalloc((size_t)nlines * sizeof(char *));
+    if (!lines) { kfree(data); return -1; }
+    int li = 0;
+    lines[li++] = data;
+    for (uint32_t i = 0; i < sz; i++) {
+        if (data[i] == '\n') {
+            data[i] = '\0';
+            if ((uint32_t)(i + 1) < sz)
+                lines[li++] = &data[i + 1];
+        }
+    }
+    /* Pre-strip comments on every line so keyword recognition is clean. */
+    for (int i = 0; i < li; i++) sh_strip_comment(lines[i]);
+    int rc = run_block(lines, 0, li);
+    kfree(lines);
+    kfree(data);
+    return rc;
+}

--- a/src/kernel/arch/i386/shell/sh_script.c
+++ b/src/kernel/arch/i386/shell/sh_script.c
@@ -140,6 +140,18 @@ int sh_expand(const char *in, char *out, size_t outsz)
 {
     size_t oi = 0;
     for (size_t i = 0; in[i]; ) {
+        /* $? -- last command's exit status.  Special single-char var,
+         * not an identifier, so handle before the general ident path. */
+        if (in[i] == '$' && in[i+1] == '?') {
+            const char *v = sh_vars_get("?");
+            if (!v) v = "0";
+            size_t vl = strlen(v);
+            if (oi + vl >= outsz) return -1;
+            memcpy(out + oi, v, vl);
+            oi += vl;
+            i += 2;
+            continue;
+        }
         if (in[i] == '$' && (is_ident_start(in[i+1]) || in[i+1] == '{')) {
             int braced = (in[i+1] == '{');
             size_t s = i + 1 + (size_t)braced;
@@ -256,6 +268,22 @@ int sh_exec_line(char *line)
 
 static int sh_last_status = 0;
 
+/* Set $? from sh_last_status.  Called after every dispatched line, after
+ * every `[ TEST ]` evaluation, and on exit from a script so the parent
+ * shell observes the final status. */
+static void publish_status(int rc)
+{
+    sh_last_status = rc;
+    char buf[12];
+    int n = 0;
+    if (rc < 0) { buf[n++] = '-'; rc = -rc; }
+    char tmp[12]; int t = 0;
+    do { tmp[t++] = (char)('0' + (rc % 10)); rc /= 10; } while (rc && t < (int)sizeof(tmp));
+    while (t > 0) buf[n++] = tmp[--t];
+    buf[n] = '\0';
+    sh_vars_set("?", buf);
+}
+
 /* Forward decl: defined further down. */
 static int run_block(char **lines, int from, int to);
 
@@ -305,7 +333,16 @@ static int find_match(char **lines, int from, int to,
  *   [ INT -eq INT ]   integer equal (also -ne -lt -le -gt -ge)
  * Returns 0 on true, 1 on false (sh convention).
  */
-static int atoi_safe(const char *s) { int r=0,n=0; if(*s=='-'){n=1;s++;} while(*s>='0'&&*s<='9') r=r*10+(*s++-'0'); return n?-r:r; }
+static int is_numeric(const char *s)
+{
+    if (!s || !*s) return 0;
+    if (*s == '-' || *s == '+') s++;
+    if (!*s) return 0;
+    while (*s) { if (*s < '0' || *s > '9') return 0; s++; }
+    return 1;
+}
+
+static int atoi_safe(const char *s) { int r=0,n=0; if(*s=='-'){n=1;s++;} else if(*s=='+'){s++;} while(*s>='0'&&*s<='9') r=r*10+(*s++-'0'); return n?-r:r; }
 
 static int sh_test(int argc, char **argv)
 {
@@ -318,13 +355,25 @@ static int sh_test(int argc, char **argv)
     if (argc == 3) {
         if (strcmp(argv[1], "=")  == 0) return strcmp(argv[0], argv[2]) == 0 ? 0 : 1;
         if (strcmp(argv[1], "!=") == 0) return strcmp(argv[0], argv[2]) != 0 ? 0 : 1;
-        int a = atoi_safe(argv[0]), b = atoi_safe(argv[2]);
-        if (strcmp(argv[1], "-eq") == 0) return a == b ? 0 : 1;
-        if (strcmp(argv[1], "-ne") == 0) return a != b ? 0 : 1;
-        if (strcmp(argv[1], "-lt") == 0) return a <  b ? 0 : 1;
-        if (strcmp(argv[1], "-le") == 0) return a <= b ? 0 : 1;
-        if (strcmp(argv[1], "-gt") == 0) return a >  b ? 0 : 1;
-        if (strcmp(argv[1], "-ge") == 0) return a >= b ? 0 : 1;
+        /* Integer ops: refuse if either operand isn't numeric so a
+         * non-numeric string doesn't silently compare as 0. */
+        int is_int_op =
+               (strcmp(argv[1], "-eq") == 0) || (strcmp(argv[1], "-ne") == 0)
+            || (strcmp(argv[1], "-lt") == 0) || (strcmp(argv[1], "-le") == 0)
+            || (strcmp(argv[1], "-gt") == 0) || (strcmp(argv[1], "-ge") == 0);
+        if (is_int_op) {
+            if (!is_numeric(argv[0]) || !is_numeric(argv[2])) {
+                t_writestring("sh: [: integer expected\n");
+                return 2;   /* bash convention: usage/operand error */
+            }
+            int a = atoi_safe(argv[0]), b = atoi_safe(argv[2]);
+            if (strcmp(argv[1], "-eq") == 0) return a == b ? 0 : 1;
+            if (strcmp(argv[1], "-ne") == 0) return a != b ? 0 : 1;
+            if (strcmp(argv[1], "-lt") == 0) return a <  b ? 0 : 1;
+            if (strcmp(argv[1], "-le") == 0) return a <= b ? 0 : 1;
+            if (strcmp(argv[1], "-gt") == 0) return a >  b ? 0 : 1;
+            if (strcmp(argv[1], "-ge") == 0) return a >= b ? 0 : 1;
+        }
     }
     return 1;
 }
@@ -356,7 +405,7 @@ static int eval_condition(const char *line)
     char *argv[SHELL_MAX_ARGS];
     int argc = shell_parse(expanded, argv, SHELL_MAX_ARGS);
     int rc = sh_test(argc, argv);
-    sh_last_status = rc;
+    publish_status(rc);
     return rc == 0;
 }
 
@@ -368,36 +417,126 @@ static int run_block(char **lines, int from, int to)
         char *t = lines[i];
         while (*t == ' ' || *t == '\t') t++;
 
-        if (strncmp(t, "if ", 3) == 0 || strcmp(t, "if") == 0) {
-            const char *mids[2] = { "elif ", "else" };
-            int mid;
-            int end = find_match(lines, i + 1, to, "if", NULL, "fi",
-                                 mids, 2, &mid);
-            if (end < 0) { t_writestring("sh: missing fi\n"); return -2; }
-            /* Condition is on the same line as `if`: "if [ X ]; then" */
-            const char *cond_start = t + 2;
-            while (*cond_start == ' ' || *cond_start == '\t') cond_start++;
-            /* Drop a trailing "; then" or " then" if present. */
-            static char cond[256];
-            strncpy(cond, cond_start, sizeof(cond) - 1);
-            cond[sizeof(cond) - 1] = '\0';
-            char *th = strstr(cond, "then");
-            if (th) {
-                while (th > cond && (th[-1] == ' ' || th[-1] == ';' || th[-1] == '\t'))
-                    th--;
-                *th = '\0';
+        /* Single-line form: `if [ X ]; then CMD; fi`.  Bash-compatible.
+         * Detect by spotting `; fi` at the end of this line (after `; then`).
+         * Handles only one body command (no elif/else on the same line). */
+        if ((strncmp(t, "if ", 3) == 0 || strcmp(t, "if") == 0)) {
+            size_t tl = strlen(t);
+            int has_inline_fi = 0;
+            if (tl >= 4) {
+                /* Match ` fi` (with optional trailing whitespace already trimmed). */
+                if (t[tl-2] == 'f' && t[tl-1] == 'i' &&
+                    (tl == 2 || t[tl-3] == ' ' || t[tl-3] == ';'))
+                    has_inline_fi = 1;
             }
-            int true_branch = eval_condition(cond);
-            int body_from = i + 1;
-            int body_to   = (mid >= 0) ? mid : end;
-            int else_from = (mid >= 0) ? (mid + 1) : end;
+            if (has_inline_fi) {
+                /* Split into <cond> | <body>.  Layout:
+                 *   if <COND>; then <BODY>; fi
+                 * Steps: find " then " or ";then "; that splits cond/body.
+                 * Then strip trailing "; fi" from body. */
+                static char work[512];
+                strncpy(work, t, sizeof(work) - 1);
+                work[sizeof(work) - 1] = '\0';
+                /* skip past "if " */
+                char *cp = work + (work[2] == ' ' ? 3 : 2);
+                while (*cp == ' ') cp++;
+                char *then_kw = strstr(cp, "then");
+                if (then_kw) {
+                    /* Cond ends just before `then` (and any `;` / spaces). */
+                    char *cend = then_kw;
+                    while (cend > cp && (cend[-1] == ' ' || cend[-1] == ';' || cend[-1] == '\t'))
+                        cend--;
+                    *cend = '\0';
+                    char *body = then_kw + 4;
+                    while (*body == ' ') body++;
+                    /* Trim trailing "; fi" (or " fi") from body. */
+                    size_t bl = strlen(body);
+                    while (bl > 0 && (body[bl-1] == ' ' || body[bl-1] == '\t')) body[--bl] = '\0';
+                    if (bl >= 2 && body[bl-1] == 'i' && body[bl-2] == 'f') {
+                        bl -= 2;
+                        while (bl > 0 && (body[bl-1] == ' ' || body[bl-1] == ';')) bl--;
+                        body[bl] = '\0';
+                    }
+                    if (eval_condition(cp)) {
+                        sh_exec_line(body);
+                    }
+                    i++;
+                    continue;
+                }
+                /* Falls through to multi-line path if no `then`. */
+            }
+            /* Multi-line form follows. */
+        }
+
+        if (strncmp(t, "if ", 3) == 0 || strcmp(t, "if") == 0) {
+            /* Find the matching `fi`, ignoring nested if/fi.  We don't
+             * use find_match's mid output for elif chaining -- we walk
+             * each elif/else inline below so we visit them in order. */
+            int end = find_match(lines, i + 1, to, "if", NULL, "fi",
+                                 NULL, 0, NULL);
+            if (end < 0) { t_writestring("sh: missing fi\n"); return -2; }
+
+            /* `cond_line` points at the current branch's condition line
+             * (the `if [ X ]; then` or `elif [ X ]; then` line).
+             * `body_from` is the first line of that branch's body. */
+            int cond_line  = i;
+            const char *cond_kw = "if";
+            size_t      kw_len  = 2;
             int rc = 0;
-            if (true_branch) {
-                rc = run_block(lines, body_from, body_to);
-            } else if (mid >= 0) {
-                /* Currently treats elif as else (no chained elif).  Good
-                 * enough for the MVP; chained elif is a follow-up. */
-                rc = run_block(lines, else_from, end);
+            int taken = 0;
+            int scan = i + 1;
+
+            while (1) {
+                /* Extract this branch's condition from cond_line. */
+                char *ct = lines[cond_line];
+                while (*ct == ' ' || *ct == '\t') ct++;
+                ct += kw_len;
+                while (*ct == ' ' || *ct == '\t') ct++;
+                static char cond[256];
+                strncpy(cond, ct, sizeof(cond) - 1);
+                cond[sizeof(cond) - 1] = '\0';
+                char *th = strstr(cond, "then");
+                if (th) {
+                    while (th > cond && (th[-1] == ' ' || th[-1] == ';' || th[-1] == '\t'))
+                        th--;
+                    *th = '\0';
+                }
+                /* Find the next elif/else/fi at our depth so we know
+                 * where this branch's body ends. */
+                int depth = 1;
+                int next  = end;   /* default: extends to `fi` */
+                int next_is_else = 0;
+                for (int k = scan; k < end; k++) {
+                    char *kt = lines[k];
+                    while (*kt == ' ' || *kt == '\t') kt++;
+                    if (strncmp(kt, "if ", 3) == 0 || strcmp(kt, "if") == 0) { depth++; continue; }
+                    if (strncmp(kt, "fi", 2) == 0 &&
+                        (kt[2] == '\0' || kt[2] == ' ' || kt[2] == ';')) { depth--; continue; }
+                    if (depth != 1) continue;
+                    if (strncmp(kt, "elif ", 5) == 0) { next = k; break; }
+                    if (strncmp(kt, "else", 4) == 0 &&
+                        (kt[4] == '\0' || kt[4] == ' ' || kt[4] == ';')) {
+                        next = k; next_is_else = 1; break;
+                    }
+                }
+
+                if (!taken && eval_condition(cond)) {
+                    rc = run_block(lines, cond_line + 1, next);
+                    if (rc < 0) return rc;
+                    taken = 1;
+                }
+
+                if (next == end) break;   /* no more branches */
+                if (next_is_else) {
+                    if (!taken)
+                        rc = run_block(lines, next + 1, end);
+                    break;
+                }
+                /* It was an `elif`: loop with cond_line=next. */
+                cond_line = next;
+                cond_kw   = "elif";
+                kw_len    = 4;
+                scan      = next + 1;
             }
             if (rc < 0) return rc;
             i = end + 1;
@@ -469,22 +608,26 @@ static int run_block(char **lines, int from, int to)
             continue;
         }
 
-        /* Plain command line. */
+        /* Plain command line.  Track its exit status in $? so scripts
+         * can branch on it (bash-style). */
         static char copy[512];
         strncpy(copy, lines[i], sizeof(copy) - 1);
         copy[sizeof(copy) - 1] = '\0';
-        sh_last_status = sh_exec_line(copy) ? 0 : 1;
+        publish_status(sh_exec_line(copy) ? 0 : 127);
         i++;
     }
-    return 0;
+    return sh_last_status;
 }
 
 int sh_run_file(const char *path)
 {
-    /* Read into a fixed scratch buffer.  64 KiB is plenty for hand-written
-     * shell scripts; bigger scripts can be split into multiple files and
-     * `sh` chained.  Allocated from the heap to keep the kernel stack lean. */
-    enum { SH_MAX_SCRIPT = 65536 };
+    /* Read into a scratch buffer.  256 KiB covers any realistic shell
+     * script; if a file genuinely exceeds this, the layered fix is to
+     * grow on demand from the heap (vfs has no stat() yet).  Until then
+     * we warn on apparent truncation -- detected when the bytes read
+     * exactly fill the buffer, which the kernel VFS treats as "more may
+     * exist".  Detect, complain, keep going on the prefix. */
+    enum { SH_MAX_SCRIPT = 262144 };
     char    *data = (char *)kmalloc(SH_MAX_SCRIPT);
     uint32_t sz = 0;
     if (!data) return -1;
@@ -496,6 +639,11 @@ int sh_run_file(const char *path)
         return -1;
     }
     data[sz] = '\0';
+    if (sz == SH_MAX_SCRIPT - 1) {
+        t_writestring("sh: warning: script may be truncated at ");
+        /* Crude size print without depending on stdio. */
+        t_writestring("256KiB; split into multiple files and chain via `sh`\n");
+    }
     /* Build an array of line pointers by NUL-terminating each \n. */
     int nlines = 1;
     for (uint32_t i = 0; i < sz; i++) if (data[i] == '\n') nlines++;

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -19,6 +19,7 @@
 #include <kernel/vesa_tty.h>
 #include <kernel/serial.h>
 #include <kernel/vfs.h>
+#include <kernel/sh_script.h>
 #include <kernel/timer.h>
 #include <kernel/task.h>
 #include <kernel/signal.h>
@@ -526,7 +527,7 @@ void shell_readline(char *buf, size_t max)
  *
  * Tokens are separated by spaces.  Returns the number of tokens found.
  * --------------------------------------------------------------------------- */
-static int shell_parse(char *line, char **argv, int max_args)
+int shell_parse(char *line, char **argv, int max_args)
 {
     int argc = 0;
     char *p = line;
@@ -568,6 +569,7 @@ static const shell_cmd_entry_t * const cmd_modules[] = {
     disk_cmds,
     fs_cmds,
     apps_cmds,
+    script_cmds,
     NULL,
 };
 
@@ -606,7 +608,7 @@ static void shell_restore_screen(void)
     vesa_tty_paint_status(vtty_active(), vtty_count());
 }
 
-static int shell_dispatch(int argc, char **argv)
+int shell_dispatch_argv(int argc, char **argv)
 {
     for (int m = 0; cmd_modules[m]; m++) {
         for (int i = 0; cmd_modules[m][i].name; i++) {
@@ -854,6 +856,17 @@ void shell_run(void)
 
         history_push(buf);
 
+        /* Scripting: detect NAME=value first (no command dispatch).
+         * Then $VAR expansion before parse so all downstream paths
+         * (globs, dispatch, fallbacks) see expanded text uniformly. */
+        if (sh_try_assign(buf))
+            continue;
+        static char expanded_buf[SHELL_MAX_INPUT];
+        if (sh_expand(buf, expanded_buf, sizeof(expanded_buf)) == 0) {
+            strncpy(buf, expanded_buf, SHELL_MAX_INPUT - 1);
+            buf[SHELL_MAX_INPUT - 1] = '\0';
+        }
+
         int argc = shell_parse(buf, argv, SHELL_MAX_ARGS);
         if (argc == 0)
             continue;
@@ -865,7 +878,7 @@ void shell_run(void)
         argc = shell_expand_globs(argc, argv, SHELL_MAX_ARGS,
                                   glob_buf, sizeof(glob_buf));
 
-        if (!shell_dispatch(argc, argv)) {
+        if (!shell_dispatch_argv(argc, argv)) {
             t_setcolor(SHELL_ERROR_COLOR_VGA);
             t_writestring("Unknown command '");
             t_writestring(argv[0]);

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -622,9 +622,16 @@ int shell_dispatch_argv(int argc, char **argv)
     }
 
     /* Path-style invocation: `/abs/path[.elf]` or `./relative[.elf]`.
-     * Resolved by the VFS so `./foo` is interpreted relative to the CWD. */
+     * Resolved by the VFS so `./foo` is interpreted relative to the CWD.
+     * Bash-style: if the path ends in `.sh` (or any non-ELF text file),
+     * run it through the shell-script interpreter instead of exec()ing. */
     const char *cmd = argv[0];
     if (cmd[0] == '/' || (cmd[0] == '.' && cmd[1] == '/')) {
+        size_t cl = strlen(cmd);
+        if (cl > 3 && cmd[cl-3] == '.' && cmd[cl-2] == 's' && cmd[cl-1] == 'h') {
+            sh_run_file(cmd);
+            return 1;
+        }
         if (try_exec_path(cmd, argc, argv)) {
             /* Any ELF could have painted to the FB; restore unconditionally. */
             shell_restore_screen();

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -658,29 +658,38 @@ int shell_dispatch_argv(int argc, char **argv)
         }
     }
 
-    /* makbox multicall fallback: PATH didn't have argv[0] as its own ELF,
-     * so try `makbox.elf <argv[0]> <rest...>`.  This is the busybox dispatch
-     * trick adapted for a FAT32 world without symlinks: ls/cat/cp/mv/rm/echo
-     * etc. all live as applets inside the single makbox binary. */
-    static char makbox_argv0[] = "makbox";
-    for (int p = 0; s_app_path[p]; p++) {
-        size_t dlen = strlen(s_app_path[p]);
-        if (dlen + sizeof(makbox_argv0) >= VFS_PATH_MAX)
-            continue;
-        strncpy(path_buf, s_app_path[p], VFS_PATH_MAX - 1);
-        strncpy(path_buf + dlen, makbox_argv0, VFS_PATH_MAX - 1 - dlen);
-        path_buf[dlen + sizeof(makbox_argv0) - 1] = '\0';
+    /* makbox multicall fallback: only for the applets makbox actually
+     * owns (busybox-style fs utilities).  Anything else falls through to
+     * the shell's "unknown command" path -- we don't want random typos
+     * routed into makbox just to have it print its usage banner. */
+    static const char *MAKBOX_APPLETS[] = {
+        "ls", "cat", "cp", "mv", "rm", "rmdir", "echo", "pwd", NULL
+    };
+    int is_makbox_applet = 0;
+    for (int a = 0; MAKBOX_APPLETS[a]; a++) {
+        if (strcmp(argv[0], MAKBOX_APPLETS[a]) == 0) { is_makbox_applet = 1; break; }
+    }
+    if (is_makbox_applet) {
+        static char makbox_argv0[] = "makbox";
+        for (int p = 0; s_app_path[p]; p++) {
+            size_t dlen = strlen(s_app_path[p]);
+            if (dlen + sizeof(makbox_argv0) >= VFS_PATH_MAX)
+                continue;
+            strncpy(path_buf, s_app_path[p], VFS_PATH_MAX - 1);
+            strncpy(path_buf + dlen, makbox_argv0, VFS_PATH_MAX - 1 - dlen);
+            path_buf[dlen + sizeof(makbox_argv0) - 1] = '\0';
 
-        /* Build new argv: [makbox, <original argv[0]>, <original args...>]. */
-        char *new_argv[SHELL_MAX_ARGS + 1];
-        int new_argc = 0;
-        new_argv[new_argc++] = makbox_argv0;
-        for (int i = 0; i < argc && new_argc < SHELL_MAX_ARGS + 1; i++)
-            new_argv[new_argc++] = argv[i];
+            /* Build new argv: [makbox, <original argv[0]>, <original args...>]. */
+            char *new_argv[SHELL_MAX_ARGS + 1];
+            int new_argc = 0;
+            new_argv[new_argc++] = makbox_argv0;
+            for (int i = 0; i < argc && new_argc < SHELL_MAX_ARGS + 1; i++)
+                new_argv[new_argc++] = argv[i];
 
-        if (try_exec_path(path_buf, new_argc, new_argv)) {
-            shell_restore_screen();
-            return 1;
+            if (try_exec_path(path_buf, new_argc, new_argv)) {
+                shell_restore_screen();
+                return 1;
+            }
         }
     }
 

--- a/src/kernel/arch/i386/shell/shell_cmd_script.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_script.c
@@ -20,7 +20,22 @@ static void cmd_sh(int argc, char **argv)
         t_writestring("usage: sh <script.sh>\n");
         return;
     }
-    sh_run_file(argv[1]);
+    int rc = sh_run_file(argv[1]);
+    /* Persist the script's exit code as $? so callers (interactive or
+     * scripted) can branch on it.  Also echo to serial so ui-test
+     * scenarios can scrape the value. */
+    char buf[16];
+    int n = 0, v = rc;
+    if (v < 0) { buf[n++] = '-'; v = -v; }
+    char tmp[12]; int t = 0;
+    do { tmp[t++] = (char)('0' + (v % 10)); v /= 10; } while (v && t < (int)sizeof(tmp));
+    while (t > 0) buf[n++] = tmp[--t];
+    buf[n] = '\0';
+    sh_vars_set("?", buf);
+    extern void Serial_WriteString(const char *);
+    Serial_WriteString("sh: exit=");
+    Serial_WriteString(buf);
+    Serial_WriteString("\n");
 }
 
 static void cmd_read(int argc, char **argv)

--- a/src/kernel/arch/i386/shell/shell_cmd_script.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_script.c
@@ -99,11 +99,36 @@ static void cmd_lbracket(int argc, char **argv)
     sh_vars_set("?", rs);
 }
 
+/* sleep N -- busy-poll the PIT for N seconds.  Yields between checks so
+ * other tasks (including bg-ktest, other shells) keep running. */
+static void cmd_sleep(int argc, char **argv)
+{
+    if (argc < 2) { t_writestring("usage: sleep <secs>\n"); return; }
+    int n = 0;
+    for (const char *p = argv[1]; *p >= '0' && *p <= '9'; p++)
+        n = n * 10 + (*p - '0');
+    if (n <= 0) return;
+    extern uint32_t timer_get_ticks(void);
+    extern void task_yield(void);
+    uint32_t target = timer_get_ticks() + (uint32_t)n * 100u;   /* 100 Hz PIT */
+    while (timer_get_ticks() < target) task_yield();
+}
+
+/* true / false -- standard POSIX status helpers. */
+static void cmd_true(int argc, char **argv)  { (void)argc; (void)argv; }
+static void cmd_false(int argc, char **argv) {
+    (void)argc; (void)argv;
+    sh_vars_set("?", "1");
+}
+
 const shell_cmd_entry_t script_cmds[] = {
     { "sh",     cmd_sh,       0 },
     { "read",   cmd_read,     0 },
     { "env",    cmd_env,      0 },
     { "unset",  cmd_unset,    0 },
+    { "sleep",  cmd_sleep,    0 },
+    { "true",   cmd_true,     0 },
+    { "false",  cmd_false,    0 },
     { "[",      cmd_lbracket, 0 },
     { NULL,     NULL,         0 },
 };

--- a/src/kernel/arch/i386/shell/shell_cmd_script.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_script.c
@@ -1,0 +1,94 @@
+/*
+ * shell_cmd_script.c - shell builtins for sh-style scripting.
+ *
+ * Exposes `sh`, `read`, `env`, `unset`, `export` (alias for assignment),
+ * and the `[` test builtin so users can write conditional commands.
+ * The heavy lifting (variable table, $VAR expansion, control flow) is
+ * in sh_script.c.
+ */
+
+#include <kernel/sh_script.h>
+#include <kernel/tty.h>
+#include <kernel/keyboard.h>
+#include <kernel/shell.h>
+#include <string.h>
+#include "shell_priv.h"
+
+static void cmd_sh(int argc, char **argv)
+{
+    if (argc < 2) {
+        t_writestring("usage: sh <script.sh>\n");
+        return;
+    }
+    sh_run_file(argv[1]);
+}
+
+static void cmd_read(int argc, char **argv)
+{
+    if (argc < 2) {
+        t_writestring("usage: read <VAR>\n");
+        return;
+    }
+    char buf[256];
+    shell_readline(buf, sizeof(buf));
+    sh_vars_set(argv[1], buf);
+}
+
+static int env_print_cb(const char *name, const char *value, void *ctx)
+{
+    (void)ctx;
+    t_writestring(name);
+    t_writestring("=");
+    t_writestring(value);
+    t_writestring("\n");
+    return 0;
+}
+
+static void cmd_env(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    sh_vars_iter(env_print_cb, NULL);
+}
+
+static void cmd_unset(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++)
+        sh_vars_unset(argv[i]);
+}
+
+/* `[ ARGS ]` -- consumed via the dispatcher; result echoed.  Mostly
+ * useful interactively; scripts use it inside if/while which are handled
+ * by sh_run_file's interpreter directly. */
+static void cmd_lbracket(int argc, char **argv)
+{
+    /* The closing `]` is just argv[argc-1]; drop it.  Failure to provide
+     * it isn't fatal -- we still evaluate. */
+    if (argc > 1 && strcmp(argv[argc - 1], "]") == 0) argc--;
+    extern int sh_test_public(int argc, char **argv);
+    /* Inline the test logic via sh_script.c's helper -- exposed
+     * through a tiny wrapper to avoid plumbing.  For now, do the
+     * simple inline. */
+    int rc = 1;
+    if (argc == 2) {
+        rc = (*argv[1]) ? 0 : 1;
+    } else if (argc == 3) {
+        if (strcmp(argv[1], "-z") == 0) rc = (!*argv[2]) ? 0 : 1;
+        else if (strcmp(argv[1], "-n") == 0) rc = ( *argv[2]) ? 0 : 1;
+    } else if (argc == 4) {
+        if (strcmp(argv[2], "=")  == 0) rc = strcmp(argv[1], argv[3]) == 0 ? 0 : 1;
+        else if (strcmp(argv[2], "!=") == 0) rc = strcmp(argv[1], argv[3]) != 0 ? 0 : 1;
+    }
+    /* Stash result in $? so interactive use is observable. */
+    char rs[4];
+    rs[0] = (char)('0' + rc); rs[1] = '\0';
+    sh_vars_set("?", rs);
+}
+
+const shell_cmd_entry_t script_cmds[] = {
+    { "sh",     cmd_sh,       0 },
+    { "read",   cmd_read,     0 },
+    { "env",    cmd_env,      0 },
+    { "unset",  cmd_unset,    0 },
+    { "[",      cmd_lbracket, 0 },
+    { NULL,     NULL,         0 },
+};

--- a/src/kernel/arch/i386/shell/shell_cmd_system.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_system.c
@@ -14,6 +14,7 @@
 #include <kernel/debug.h>
 #include <kernel/ktest.h>
 #include <kernel/serial.h>
+#include <kernel/vfs.h>
 
 static void cmd_echo(int argc, char **argv)
 {
@@ -171,7 +172,31 @@ static void cmd_verbose(int argc, char **argv)
  * Module table
  * --------------------------------------------------------------------------- */
 
+/* date -- one-line wall clock readout, scriptable.
+ *
+ * Reads /proc/rtc (procfs already formats YYYY-MM-DD HH:MM:SS from CMOS).
+ * Unlike clock.elf which takes over the framebuffer, this is a single
+ * printf -- safe to call inside a shell script or a backtick context
+ * once we have command substitution. */
+static void cmd_date(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    char buf[64];
+    uint32_t got = 0;
+    if (vfs_read_file("/proc/rtc", buf, sizeof(buf) - 1, &got) != 0 || got == 0) {
+        t_writestring("date: /proc/rtc unavailable\n");
+        return;
+    }
+    buf[got] = '\0';
+    /* /proc/rtc emits "YYYY-MM-DD HH:MM:SS\n"; pass through verbatim. */
+    t_writestring(buf);
+    if (got > 0 && buf[got - 1] != '\n') t_putchar('\n');
+}
+
 const shell_cmd_entry_t system_cmds[] = {
+    { "datetime", cmd_date     },   /* canonical: one line "YYYY-MM-DD HH:MM:SS" */
+    { "date",     cmd_date     },   /* alias */
+    { "time",     cmd_date     },   /* alias */
     { "echo",     cmd_echo     },
     { "meminfo",  cmd_meminfo  },
     { "uptime",   cmd_uptime   },

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -92,9 +92,12 @@ extern const shell_cmd_entry_t disk_cmds[];
 extern const shell_cmd_entry_t fs_cmds[];
 extern const shell_cmd_entry_t apps_cmds[];
 extern const shell_cmd_entry_t man_cmds[];
+extern const shell_cmd_entry_t script_cmds[];
 
 /* shell.c – REPL core */
 void shell_readline(char *buf, size_t max);
+int  shell_parse(char *line, char **argv, int max_args);
+int  shell_dispatch_argv(int argc, char **argv);
 
 /* shell_glob.c – wildcard (* and ?) expansion of argv tokens via VFS. */
 int  shell_expand_globs(int argc, char **argv, int argv_cap,

--- a/src/kernel/include/kernel/sh_script.h
+++ b/src/kernel/include/kernel/sh_script.h
@@ -1,0 +1,65 @@
+/*
+ * sh_script.h - bash-flavoured scripting for the Makar shell.
+ *
+ * Surface area kept deliberately small: per-shell-task variable table,
+ * $VAR expansion, NAME=value assignment, `read VAR`, `sh script.sh`,
+ * `#` comments, and a line-oriented if/while/for parser.
+ *
+ * Per-shell-task isolation: the variable table hangs off task_t.script_vars
+ * so each VT's shell owns its own environment.  Matches the per-VT-palette
+ * env-var model -- variables don't leak across VTs.
+ */
+#ifndef MAKAR_SH_SCRIPT_H
+#define MAKAR_SH_SCRIPT_H
+
+#include <stddef.h>
+
+/* --- variable table ------------------------------------------------------- */
+
+/* Fetch the value of NAME for the calling task.  Returns NULL if unset.
+ * Pointer is valid until the next sh_vars_set / sh_vars_clear call. */
+const char *sh_vars_get(const char *name);
+
+/* Set NAME=value for the calling task.  Creates the table on first call;
+ * grows it as needed.  Returns 0 on success, -1 on OOM. */
+int sh_vars_set(const char *name, const char *value);
+
+/* Unset NAME.  No-op if not present. */
+void sh_vars_unset(const char *name);
+
+/* Iterate: callback receives each name/value pair until it returns non-zero.
+ * Used by `env` / debugging dumps. */
+typedef int (*sh_vars_iter_cb)(const char *name, const char *value, void *ctx);
+void sh_vars_iter(sh_vars_iter_cb cb, void *ctx);
+
+/* Free the calling task's table.  Called by task_exit cleanup. */
+void sh_vars_free_for(void *task);
+
+/* --- line-level execution ------------------------------------------------- */
+
+/* Expand $VAR / ${VAR} in `in`, write result to `out` (up to outsz-1).
+ * Unset variables expand to empty string.  Returns 0 on success, -1 if
+ * output would overflow. */
+int sh_expand(const char *in, char *out, size_t outsz);
+
+/* Detect and apply `NAME=value` assignment at the start of `line`.
+ * Returns 1 if line was an assignment (and applied it), 0 otherwise.
+ * value is shell-expanded before storage. */
+int sh_try_assign(const char *line);
+
+/* Strip trailing # comment (outside single/double quotes) from line. */
+void sh_strip_comment(char *line);
+
+/* Execute a single already-expanded, comment-stripped line through the
+ * shell dispatcher.  Empty / whitespace-only lines are no-ops.
+ * Returns the dispatcher's return code (1=found, 0=not found). */
+int sh_exec_line(char *line);
+
+/* --- script execution ----------------------------------------------------- */
+
+/* Run a script file from the VFS.  Reads, splits into lines, walks with
+ * the if/while/for interpreter.  Returns 0 on success, -1 on I/O error,
+ * -2 on parse error. */
+int sh_run_file(const char *path);
+
+#endif /* MAKAR_SH_SCRIPT_H */

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -97,6 +97,14 @@ typedef struct task {
      * frames or jumps to garbage EIPs in ring-3.  NULL for tasks that
      * aren't exec'ing a userspace program. */
     void         *exec_params;
+
+    /* --- shell scripting state ---
+     * Per-shell-task variable table for sh-style scripting (NAME=value,
+     * $VAR expansion, `read` builtin).  Each VT's shell owns its own
+     * table; variables don't leak across VTs.  NULL for non-shell tasks.
+     * Allocated lazily on first assignment by sh_vars_set().  See
+     * src/kernel/arch/i386/shell/sh_vars.c. */
+    void         *script_vars;
 } task_t;
 
 /*

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -64,6 +64,7 @@ install: all
 	rm -f $(ISODIR)/apps/ls.elf $(ISODIR)/apps/cp.elf $(ISODIR)/apps/mv.elf \
 	      $(ISODIR)/apps/rm.elf $(ISODIR)/apps/echo.elf $(ISODIR)/apps/fsutil.elf
 	cp $(PROGS) $(ISODIR)/apps/
+	cp demo.sh $(ISODIR)/apps/
 
 install-headers:
 

--- a/src/userspace/demo.sh
+++ b/src/userspace/demo.sh
@@ -4,12 +4,15 @@
 
 echo === Makar shell-script demo ===
 
+sleep 1
+sleep 1
 # 1. plain commands (makbox applets)
 echo
 echo -- 1. plain commands --
 pwd
 echo cwd-ok
 
+sleep 1
 # 2. variable assignment + $VAR + ${VAR}
 echo
 echo -- 2. variables --
@@ -18,12 +21,14 @@ GREETING=hello
 echo $GREETING, ${NAME}!
 echo current name is $NAME
 
+sleep 1
 # 3. cat through an expanded path
 echo
 echo -- 3. expansion into command args --
 PROC=/proc/uname
 cat $PROC
 
+sleep 1
 # 4. unset
 echo
 echo -- 4. unset --
@@ -31,16 +36,19 @@ THROWAWAY=keep
 unset THROWAWAY
 echo throwaway-now: $THROWAWAY-end
 
+sleep 1
 # 5. env (dump table)
 echo
 echo -- 5. env dump --
 env
 
+sleep 1
 # 6. # comments inline -- nothing prints after this
 echo done-with-comment   # this trailing fragment is a comment
 echo
 echo -- 6. comments handled --
 
+sleep 1
 # 7. string tests via [ ... ]
 echo
 echo -- 7. string tests --
@@ -53,6 +61,7 @@ fi
 if [ -z "" ]; then echo z-ok; fi
 if [ -n yes ]; then echo n-ok; fi
 
+sleep 1
 # 8. integer tests
 echo
 echo -- 8. integer tests --
@@ -65,6 +74,7 @@ if [ $A -eq 7 ]; then echo eq-ok; fi
 if [ $A -ge 7 ]; then echo ge-ok; fi
 if [ $B -le 4 ]; then echo le-ok; fi
 
+sleep 1
 # 9. if / elif / else / fi  (chained elif)
 echo
 echo -- 9. elif chain --
@@ -79,6 +89,7 @@ else
 echo elif-fell-through
 fi
 
+sleep 1
 # 10. for ... in WORDS
 echo
 echo -- 10. for loop --
@@ -86,6 +97,7 @@ for x in alpha beta gamma; do
 echo for: $x
 done
 
+sleep 1
 # 11. for with variable substitution
 echo
 echo -- 11. for over variable --
@@ -94,6 +106,7 @@ for w in $WORDS; do
 echo word: $w
 done
 
+sleep 1
 # 12. while with countdown
 echo
 echo -- 12. while loop --
@@ -103,6 +116,7 @@ echo countdown: $N
 if [ $N = 3 ]; then N=2; elif [ $N = 2 ]; then N=1; else N=0; fi
 done
 
+sleep 1
 # 13. exit code observable via $?
 echo
 echo -- 13. exit code in dollar-question --
@@ -112,10 +126,11 @@ echo after-true: $?
 nonsense-command-that-does-not-exist
 echo after-bad: $?
 
-# 14. clock.elf integration
+sleep 1
+# 14. cmdline wall clock (one-liner, scriptable)
 echo
-echo -- 14. clock.elf --
-/cdrom/apps/clock.elf
+echo -- 14. datetime --
+datetime
 
 echo
 echo === demo complete ===

--- a/src/userspace/demo.sh
+++ b/src/userspace/demo.sh
@@ -1,59 +1,120 @@
-# demo.sh -- shows what the Makar shell scripting layer can do.
-# Run with:  sh /cdrom/apps/demo.sh
+# demo.sh -- exercise every part of the Makar shell scripting layer.
+# Run with:  sh /cdrom/apps/demo.sh   (or /hd/apps/demo.sh)
+# No user input required -- safe to invoke from ui-test.
 
 echo === Makar shell-script demo ===
 
-# 1. Plain commands -- pwd is a makbox applet
+# 1. plain commands (makbox applets)
 echo
-echo -- pwd --
+echo -- 1. plain commands --
 pwd
+echo cwd-ok
 
-# 2. Variables + expansion
+# 2. variable assignment + $VAR + ${VAR}
+echo
+echo -- 2. variables --
 NAME=tester
 GREETING=hello
-echo
-echo -- variables --
-echo $GREETING $NAME
-echo from cwd: $(pwd)   # no command substitution yet; literal
+echo $GREETING, ${NAME}!
+echo current name is $NAME
 
-# 3. cat through a $VAR-expanded path
-PROC=/proc/uname
+# 3. cat through an expanded path
 echo
-echo -- cat $PROC --
+echo -- 3. expansion into command args --
+PROC=/proc/uname
 cat $PROC
 
-# 4. if / then / else / fi
+# 4. unset
 echo
-echo -- if branches --
+echo -- 4. unset --
+THROWAWAY=keep
+unset THROWAWAY
+echo throwaway-now: $THROWAWAY-end
+
+# 5. env (dump table)
+echo
+echo -- 5. env dump --
+env
+
+# 6. # comments inline -- nothing prints after this
+echo done-with-comment   # this trailing fragment is a comment
+echo
+echo -- 6. comments handled --
+
+# 7. string tests via [ ... ]
+echo
+echo -- 7. string tests --
 if [ $NAME = tester ]; then
-echo if-branch: NAME is tester
+echo str-eq-ok
+fi
+if [ $NAME != stranger ]; then
+echo str-neq-ok
+fi
+if [ -z "" ]; then echo z-ok; fi
+if [ -n yes ]; then echo n-ok; fi
+
+# 8. integer tests
+echo
+echo -- 8. integer tests --
+A=7
+B=4
+if [ $A -gt $B ]; then echo gt-ok; fi
+if [ $B -lt $A ]; then echo lt-ok; fi
+if [ $A -ne $B ]; then echo ne-ok; fi
+if [ $A -eq 7 ]; then echo eq-ok; fi
+if [ $A -ge 7 ]; then echo ge-ok; fi
+if [ $B -le 4 ]; then echo le-ok; fi
+
+# 9. if / elif / else / fi  (chained elif)
+echo
+echo -- 9. elif chain --
+COLOR=blue
+if [ $COLOR = red ]; then
+echo elif-wrong-red
+elif [ $COLOR = green ]; then
+echo elif-wrong-green
+elif [ $COLOR = blue ]; then
+echo elif-correct-blue
 else
-echo else-branch: NAME is something else
+echo elif-fell-through
 fi
 
-# 5. for ... in
+# 10. for ... in WORDS
 echo
-echo -- for loop --
+echo -- 10. for loop --
 for x in alpha beta gamma; do
-echo  loop: $x
+echo for: $x
 done
 
-# 6. while ... do ... done (use a counter via assignment + test)
+# 11. for with variable substitution
 echo
-echo -- while loop --
+echo -- 11. for over variable --
+WORDS=one two three
+for w in $WORDS; do
+echo word: $w
+done
+
+# 12. while with countdown
+echo
+echo -- 12. while loop --
 N=3
 while [ $N -gt 0 ]; do
-echo  countdown: $N
-N=$N
-# decrement via simple replacement -- one-shot for 3..1
-if [ $N = 3 ]; then N=2; else
-  if [ $N = 2 ]; then N=1; else N=0; fi
-fi
+echo countdown: $N
+if [ $N = 3 ]; then N=2; elif [ $N = 2 ]; then N=1; else N=0; fi
 done
 
-# 7. wall clock
+# 13. exit code observable via $?
 echo
-echo -- clock.elf --
+echo -- 13. exit code in dollar-question --
+true
+echo after-true: $?
+# An unknown command sets $? to 127.
+nonsense-command-that-does-not-exist
+echo after-bad: $?
+
+# 14. clock.elf integration
+echo
+echo -- 14. clock.elf --
 /cdrom/apps/clock.elf
 
 echo

--- a/src/userspace/demo.sh
+++ b/src/userspace/demo.sh
@@ -1,0 +1,60 @@
+# demo.sh -- shows what the Makar shell scripting layer can do.
+# Run with:  sh /cdrom/apps/demo.sh
+
+echo === Makar shell-script demo ===
+
+# 1. Plain commands -- pwd is a makbox applet
+echo
+echo -- pwd --
+pwd
+
+# 2. Variables + expansion
+NAME=tester
+GREETING=hello
+echo
+echo -- variables --
+echo $GREETING $NAME
+echo from cwd: $(pwd)   # no command substitution yet; literal
+
+# 3. cat through a $VAR-expanded path
+PROC=/proc/uname
+echo
+echo -- cat $PROC --
+cat $PROC
+
+# 4. if / then / else / fi
+echo
+echo -- if branches --
+if [ $NAME = tester ]; then
+echo if-branch: NAME is tester
+else
+echo else-branch: NAME is something else
+fi
+
+# 5. for ... in
+echo
+echo -- for loop --
+for x in alpha beta gamma; do
+echo  loop: $x
+done
+
+# 6. while ... do ... done (use a counter via assignment + test)
+echo
+echo -- while loop --
+N=3
+while [ $N -gt 0 ]; do
+echo  countdown: $N
+N=$N
+# decrement via simple replacement -- one-shot for 3..1
+if [ $N = 3 ]; then N=2; else
+  if [ $N = 2 ]; then N=1; else N=0; fi
+fi
+done
+
+# 7. wall clock
+echo
+echo -- clock.elf --
+/cdrom/apps/clock.elf
+
+echo
+echo === demo complete ===

--- a/tests/scripts/hello.sh
+++ b/tests/scripts/hello.sh
@@ -1,0 +1,9 @@
+# hello.sh - basic scripting smoke test
+NAME=world
+echo Hello $NAME
+if [ $NAME = world ]; then
+echo if-branch ran
+fi
+for x in a b c; do
+echo loop $x
+done

--- a/tests/ui_runner.sh
+++ b/tests/ui_runner.sh
@@ -249,6 +249,12 @@ sendkey ret'
 
     # Mirror shell output to COM1 for the rest of the session.  The flag
     # is sticky so we only set it once for the whole shared-VM run.
+    # A wakeup <ret> first absorbs any first-post-boot keystroke-loss
+    # race -- without it the leading `v` of `verbose on` lands during
+    # the loading-screen-to-prompt handoff and gets dropped, leaving
+    # `erbose on` which makbox rejects.
+    send_script 'sendkey ret'
+    sleep 0.6
     send_script 'sendkey v
 sendkey e
 sendkey r

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -744,9 +744,57 @@ sendkey ret" \
     assert_serial_contains "name=foo"
 }
 
+test_demo_script() {
+    # End-to-end run of the bundled scripting demo: exercises every
+    # feature (vars, expansion, comments, env, [, integer + string
+    # tests, elif chain, for, while, $?, clock).  Assert on markers
+    # the script emits for each section so a regression in any layer
+    # surfaces as a failing assertion.
+    reset_shell
+    it "demo-script" \
+"sendkey s
+sendkey h
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey d
+sendkey e
+sendkey m
+sendkey o
+sendkey dot
+sendkey s
+sendkey h
+sendkey ret" \
+        12
+    assert_serial_contains \
+        "Makar shell-script demo" \
+        "cwd-ok" \
+        "hello, tester!" \
+        "str-eq-ok" \
+        "n-ok" \
+        "gt-ok" \
+        "eq-ok" \
+        "elif-correct-blue" \
+        "for: gamma" \
+        "word: three" \
+        "countdown: 1" \
+        "after-true: 0" \
+        "demo complete"
+}
+
 # --- Driver -----------------------------------------------------------------
 
-ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd shell_scripting_vars)
+ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd shell_scripting_vars demo_script)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -722,9 +722,31 @@ sendkey ret"
     assert_serial_contains "[makbox:pwd]"
 }
 
+test_shell_scripting_vars() {
+    # Bash-flavoured scripting smoke: assign NAME=foo, dump env, verify
+    # the variable round-trips through the per-shell-task table.
+    reset_shell
+    it "shell-scripting-vars" \
+"sendkey n
+sendkey a
+sendkey m
+sendkey e
+sendkey equal
+sendkey f
+sendkey o
+sendkey o
+sendkey ret
+sendkey e
+sendkey n
+sendkey v
+sendkey ret" \
+        1.5
+    assert_serial_contains "name=foo"
+}
+
 # --- Driver -----------------------------------------------------------------
 
-ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd)
+ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd shell_scripting_vars)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary

Final PR in the #154 multi-PR split.  Bundles:

1. **Bash-flavoured scripting in the kernel shell** — vars, `$VAR` / `${VAR}` / `$?` expansion, `NAME=value`, `read`, `sh script.sh`, `[ test ]`, `#` comments, multi-line + single-line `if/elif/else/fi`, `while`, `for`, `;`-split for multi-statement lines.
2. **Shrink the default HDD image** 512 → 96 MiB and **mirror ISO content** (`/apps`, `/docs`, `/src`) onto `/hd`.
3. **Bundled `demo.sh`** exercising every scripting feature, no user input required.
4. **makbox dispatch tightened** — only fall back to makbox for actual applet names; typos hit "Unknown command" instead of makbox's usage banner.
5. **New builtins:** `datetime` / `date` / `time` (one-line `YYYY-MM-DD HH:MM:SS` from `/proc/rtc`), `sleep N`, `true`, `false`.

## Scripting surface

```sh
NAME=value           # per-task assignment, RHS shell-expanded
echo $NAME $?         # $VAR / ${VAR} / $? expansion in any command
env                  # dump the calling task's variable table
unset NAME [...]
read VAR
sh script.sh
./script.sh           # .sh path dispatches through the interpreter
[ TEST ]             # string + integer tests
# comment

if [ X ]; then ... elif [ Y ]; then ... else ... fi
if [ X ]; then CMD; fi
while [ X ]; do ... done
for VAR in WORDS; do ... done
```

Multi-statement lines split on `;` with `then`/`do` gluing + body peeling, so `if [ X ]; then A; elif [ Y ]; then B; else C; fi` parses as a proper chain.

### One-line wall clock

```sh
datetime             # YYYY-MM-DD HH:MM:SS
date                 # alias
time                 # alias
```

Reads `/proc/rtc`.  Scriptable; fullscreen clock is still `clock.elf`.

### makbox restriction

Old behaviour: any unknown command fell into `makbox <name>` which then printed `makbox: unknown applet 'name'` plus its usage banner.

New behaviour: shell dispatch only routes to makbox for the actual applet names (`ls cat cp mv rm rmdir echo pwd`).  Random typos hit the shell's `Unknown command 'X' - try 'lsman'.` path instead, matching the "shell handles unknowns, makbox handles fsutils" split the user asked for.

### demo.sh

Bundled at `/cdrom/apps/demo.sh` and `/hd/apps/demo.sh`.  Runs every section with markers (`cwd-ok`, `str-eq-ok`, `gt-ok`, `elif-correct-blue`, `countdown: 1`, `after-true: 0`, `=== demo complete ===`, etc.) so a regression in any layer is loud.  `sleep 1` between sections gives visible pacing in GUI mode.  Section 14 uses the new `datetime` builtin.

Run with:
```sh
sh /cdrom/apps/demo.sh
/cdrom/apps/demo.sh
```

## HDD image

- `HDD_SIZE_MB` default: **512 → 96**
- HDD now copies `/work/isodir/{docs,src}` → `/hd/{docs,src}`, matching the ISO

## ui_runner.sh

`start_qemu` prepends a wakeup `<ret>` before sending `verbose on`, fixing the first-post-boot keystroke-loss race that produced `makbox: unknown applet 'erbose'` on GUI runs.

## Architecture

- `kernel/sh_script.h` — public API
- `sh_script.c` — variable table, `$VAR`/`$?` expansion, assignment, `#` strip, in-process `[ test ]`, single-line + multi-line `if/elif/else/fi`, `while`, `for`, `;`-split preprocessor with keyword-aware gluing/peeling
- `shell_cmd_script.c` — `sh`/`read`/`env`/`unset`/`sleep`/`true`/`false`/`[`
- `shell_cmd_system.c` — `datetime`/`date`/`time`
- `shell.c` REPL — `sh_try_assign` + `sh_expand` happen **before** `shell_parse`; path-style `.sh` invocation dispatches through `sh_run_file`; makbox fallback restricted to the applet allow-list

Per-shell-task isolation: `task_t.script_vars` initialised NULL on `task_create`, freed via `sh_vars_free_for()` in the task reaper.

## Docs

- `CLAUDE.md` — makbox restriction, scripting layer, new builtins, `clock.elf` note
- `docs/roadmap.md` — slice 18 (scripting) shipped
- `docs/scripting.md` — new, per-feature reference + limitations

## Validation

- `./run.sh iso build` — clean
- `./run.sh ui shell_scripting_vars` — pass
- `demo.sh` runs end-to-end through `=== demo complete ===` and `datetime` in section 14

## Known limitations (deferred follow-ups)

- No command substitution (`$(cmd)`)
- No subshells / pipes / `&` (needs `fork()` — PR #164 foundation)

## Context

Last of the multi-PR split from #154:
- [x] PR-A..F (#157–#162, all merged)
- [x] **PR-G: this PR** — scripting + HDD shrink + ISO/HDD parity + demo.sh + makbox restriction + datetime
- [ ] PR-H: #164 — `fork()` foundation
