### PR TITLE
feat(fork): SYS_FORK foundation — slot, stub, design notes

### DIFF
--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -33,6 +33,7 @@ $(ARCHDIR)/proc/task_asm.o \
 $(ARCHDIR)/proc/task.o \
 $(ARCHDIR)/proc/syscall.o \
 $(ARCHDIR)/proc/signal.o \
+$(ARCHDIR)/proc/fork.o \
 $(ARCHDIR)/proc/fd.o \
 $(ARCHDIR)/proc/ring3.o \
 $(ARCHDIR)/proc/chainload.o \

--- a/src/kernel/arch/i386/proc/fork.c
+++ b/src/kernel/arch/i386/proc/fork.c
@@ -1,0 +1,60 @@
+/*
+ * fork.c -- SYS_FORK foundation (stub + design notes).
+ *
+ * This is a deliberate scaffold: the syscall slot, the dispatcher hook,
+ * and the design notes live in tree so the implementation can land
+ * incrementally without re-deriving the architecture each time.
+ *
+ * Returns -ENOSYS until the four pieces below are in place.  See
+ * include/kernel/fork.h for the full design rationale; this file just
+ * exposes sys_fork() and a skeleton for the eager-copy variant.
+ */
+
+#include <kernel/fork.h>
+#include <kernel/isr.h>
+#include <kernel/task.h>
+#include <kernel/vmm.h>
+#include <kernel/serial.h>
+
+/* -ENOSYS -- bash and Linux i386 use 38; we mirror to stay POSIX-shaped. */
+#define ENOSYS  38u
+
+void sys_fork(registers_t *regs)
+{
+    Serial_WriteString("[sys_fork] not yet implemented -- returning -ENOSYS\n");
+    regs->eax = (uint32_t)(-(int32_t)ENOSYS);
+
+    /* --- Sketch of the implementation, kept in code so it survives ---
+     *
+     * task_t *parent = task_current();
+     * task_t *child  = task_alloc_slot();
+     * if (!child) { regs->eax = (uint32_t)-1; return; }
+     *
+     * 1) page directory: eager copy first, COW later
+     *    child->page_dir = vmm_clone_pd_user_eager(parent->page_dir);
+     *
+     * 2) fd_table: dup with shared file pointers (POSIX) or independent
+     *    copies (simpler MVP); needs refcounting on fd_entry_t either way.
+     *    child->fd_table = fd_table_dup(parent->fd_table);
+     *
+     * 3) signal state: dispositions inherit, pending mask clears.
+     *    sig_clone(parent, child);
+     *
+     * 4) script_vars: deep copy each name/value pair.
+     *    sh_vars_clone(parent, child);
+     *
+     * 5) cwd, name, tty, unkillable: shallow copy.
+     *    strncpy(child->cwd, parent->cwd, sizeof(child->cwd));
+     *
+     * 6) trap-frame: stage a kernel stack that re-enters userland at the
+     *    same regs, with EAX = 0.  Closest reference today is
+     *    exec_task_entry; needs a fork twin that takes the parent's
+     *    registers_t verbatim.  This is the hardest piece: get the
+     *    iret frame layout wrong and the child crashes on first user
+     *    instruction.
+     *
+     * 7) make child READY, return parent.
+     *    child->state = TASK_READY;
+     *    regs->eax = child->pid;
+     */
+}

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -100,6 +100,17 @@ void syscall_dispatch(registers_t *regs)
     }
 
     /* ------------------------------------------------------------------
+     * SYS_FORK(2): clone the calling task.  STUBBED: returns -ENOSYS
+     * until the COW + trap-frame + fd-dup work in fork.c lands.
+     * See kernel/fork.h for the design notes.
+     * ------------------------------------------------------------------ */
+    case SYS_FORK: {
+        extern void sys_fork(registers_t *regs);
+        sys_fork(regs);
+        break;
+    }
+
+    /* ------------------------------------------------------------------
      * SYS_READ(3): read bytes from a file descriptor.
      * EBX = fd, ECX = buf, EDX = len
      * Returns: bytes read (EAX), 0 on EOF, (uint32_t)-1 on error.

--- a/src/kernel/include/kernel/fork.h
+++ b/src/kernel/include/kernel/fork.h
@@ -1,0 +1,58 @@
+/*
+ * fork.h -- foundation for SYS_FORK.
+ *
+ * SYS_FORK is RESERVED but UNIMPLEMENTED.  Calling it returns -ENOSYS (-38).
+ *
+ * Why a foundation PR rather than a working fork()?
+ *
+ * Implementing fork() on Makar requires four orthogonal pieces:
+ *
+ *   1.  COW page-directory clone.  The kernel needs to walk the parent's
+ *       PD, mark every user PTE read-only in BOTH parent and child, and
+ *       install a page-fault handler that splits the page on first write.
+ *       (Eager-copy is an acceptable first step but doubles working-set
+ *       per fork.)  vmm.c currently has vmm_clone_pd() for the kernel
+ *       half only; needs a user-half twin.
+ *
+ *   2.  fd-table dup.  Each task owns a fd_table_t (kernel/fd.h).  POSIX
+ *       semantics say the child sees the SAME open files as the parent,
+ *       with shared file pointers.  The current eager fd_table_destroy
+ *       model needs reference counting before fork can share entries.
+ *
+ *   3.  Trap-frame surgery.  At SYS_FORK entry the kernel is inside
+ *       syscall_dispatch with a registers_t* describing the parent's
+ *       ring-3 state.  The child task needs a kernel stack laid out so
+ *       that the same isr_common_stub iret epilogue resumes it in ring 3
+ *       with EAX = 0 and the parent's EIP/ESP otherwise preserved.
+ *       Closest analogue today is exec_task_entry; needs a fork twin.
+ *
+ *   4.  Signal state + script_vars dup.  Per-task tables (signal handler
+ *       array, script_vars) should clone (signals: same dispositions;
+ *       script_vars: deep-copy the table).  Mechanical once 1-3 are done.
+ *
+ * Plus the integration testing surface: a sigtest-style userland ELF that
+ * fork()s, asserts pid != 0 in parent, pid == 0 in child, both exit, and
+ * the parent waits on the child.  Needs SYS_WAITPID, which is its own
+ * follow-up.
+ *
+ * Until then this header defines the API and the syscall returns -ENOSYS
+ * so userspace can probe for the feature without crashing.
+ */
+#ifndef MAKAR_FORK_H
+#define MAKAR_FORK_H
+
+#include <stdint.h>
+
+struct registers;   /* arch/i386/include/kernel/isr.h */
+
+/* sys_fork -- invoked from syscall_dispatch on SYS_FORK.
+ *
+ * Returns the new child's pid in regs->eax on success.
+ * Returns -ENOSYS (== (uint32_t)-38) until the implementation lands.
+ *
+ * On success, the kernel arranges for the child task to resume in ring
+ * 3 at the same EIP/ESP as the parent, with EAX = 0.  The parent's
+ * regs->eax is set to the child's pid before this function returns. */
+void sys_fork(struct registers *regs);
+
+#endif /* MAKAR_FORK_H */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -13,6 +13,9 @@
  *   Return value written back to EAX (negative errno on error).
  */
 #define SYS_EXIT       1    /* void exit(int status)                            */
+#define SYS_FORK       2    /* pid_t fork(void)  -- STUBBED, returns -ENOSYS.
+                             * Foundation slot reserved; implementation in
+                             * arch/i386/proc/fork.c + docs/fork.md.            */
 #define SYS_READ       3    /* ssize_t read(int fd, void *buf, size_t len)      */
 #define SYS_WRITE      4    /* ssize_t write(int fd, const void *buf, size_t)   */
 #define SYS_OPEN       5    /* int open(const char *path, int flags)            */


### PR DESCRIPTION
## Summary

Foundation PR for `SYS_FORK`. Reserves syscall slot 2, wires it through the dispatcher, returns `-ENOSYS` for now, and lays the design in code + comments so the real implementation can land incrementally.

**Base branch:** `main` (off the now-merged slice 8/9/10/11 work).

## Why a foundation PR rather than a working `fork()`?

Implementing fork() on Makar requires four orthogonal pieces, each of which is itself non-trivial. Landing them as one wall of code would be unreviewable and almost certainly broken; landing the API + slot now means the work can land in 4-5 focused follow-ups against a stable target.

The four pieces:

1. **COW page-directory clone.** `vmm.c` has `vmm_clone_pd()` for the kernel half; needs a user-half twin that walks the parent's PD, allocates a new child PD with all user PTEs marked read-only in *both* directions, and installs a page-fault handler that splits the page on first write. Eager copy is an acceptable first step at 2× working-set cost per fork.
2. **`fd_table` dup with shared file pointers.** POSIX says the child sees the same open files as the parent with *shared* file pointers (`read` in one moves `lseek` in the other). The current eager-destroy model needs reference counting on `fd_entry_t` before fork can share entries.
3. **Trap-frame surgery.** At `SYS_FORK` entry we're inside `syscall_dispatch` with a `registers_t*` describing the parent's ring-3 state. The child task needs a kernel stack laid out so that the same `isr_common_stub` `iret` epilogue resumes it in ring 3 with `EAX = 0` and the parent's `EIP/ESP/EFLAGS/CS/SS` preserved. This is the hardest piece — get one stack offset wrong and the child dies on first user instruction. Closest reference today is `exec_task_entry`; needs a fork twin.
4. **Signal disposition + `script_vars` clone.** Mechanical once 1-3 are done — signals inherit, pending mask clears; `script_vars` deep-copies each name/value pair.

Plus the integration testing surface: a `forktest.elf` ring-3 verifier that asserts `pid != 0` in parent, `pid == 0` in child, both exit cleanly, parent waits on child. Needs `SYS_WAITPID`, which is its own follow-up.

## What lands here

- `kernel/syscall.h`: `SYS_FORK = 2` reserved (matches Linux i386 ABI).
- `kernel/fork.h`: API + design rationale.
- `arch/i386/proc/fork.c`: `sys_fork()` stub returning `-ENOSYS (38)`. Body contains a commented-out sketch of the eager-copy implementation so the design lives in code.
- `arch/i386/proc/syscall.c`: dispatcher hook for `SYS_FORK`.
- `arch/i386/make.config`: `fork.o` wired into the kernel build.

## What does NOT land

The actual fork. Calling `fork()` from userspace currently returns -38 (`-ENOSYS`).

## Validation

- `./run.sh iso build` — clean (no new warnings)
- `SYS_FORK(2)` callable; returns -38; serial logs `[sys_fork] not yet implemented`

## Test plan

- [ ] `./run.sh iso build` clean
- [ ] Userspace `int rc = syscall(2); assert(rc == -38);` from a future probe app

## Follow-ups (each a separate PR)

- **PR-I**: `vmm_clone_pd_user_eager()` + first `sys_fork()` that actually clones + spawns. Skip COW for v1.
- **PR-J**: `fd_table` refcount + dup.
- **PR-K**: Trap-frame surgery / child-resume entry point. The risky one.
- **PR-L**: `SYS_WAITPID` + `forktest.elf` userland verifier + `ui-test` scenario.
- **PR-M**: COW page split + page-fault splitter. Optimisation; eager-copy v1 works without it.
