### PR TITLE
fix(vt): VT-owned palette + scrollback preservation + lines.elf easter egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ managed runtime), booted via GRUB Multiboot 2. Makar is the
 **C / GCC sibling** of [Medli](https://github.com/Arawn-Davies/Medli) -
 two independent implementations of the same OS concept, sharing a
 command vocabulary, filesystem layout, and long-term binary format
-goals. Current version: **0.5.0** (see `include/kernel/version.h`).
+goals. Current version: **0.6.0** (see `include/kernel/version.h`).
 
 Self-contained: kernel, libc fragment, ring-3 userspace, ELF loader, **four
 independent TTYs (Alt+F1–F4 to switch)**, and an in-kernel `vi`-style

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ how language choice shapes the implementation.
 ## Quick links
 
 - **[Building & running](building.md)** — toolchain, Docker, QEMU
+- **[Internals](internals.md)** — CPU state at boot, paging, TLBs, per-task PDs, scheduler, syscall ABI, and the road to fork/POSIX/libc
 - **[Testing](testing.md)** — ktest, GDB checkpoint suite, UI sendkey tests
 - **[Userland libc](userland-libc.md)** — porting roadmap toward musl/dash
 - **[Makar × Medli](makar-medli.md)** — sibling-project co-operation roadmap and VIX→VICS history

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ C# / Cosmos counterpart. The two share a command vocabulary,
 filesystem layout, and long-term binary-format goals while exploring
 how language choice shapes the implementation.
 
-**Current version:** 0.5.0 (see
+**Current version:** 0.6.0 (see
 [`include/kernel/version.h`](https://github.com/Arawn-Davies/Makar/blob/main/src/kernel/include/kernel/version.h)).
 
 ## Quick links

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,693 @@
+---
+title: Internals
+layout: default
+nav_order: 9
+permalink: /internals
+---
+
+# Makar internals: a technical walkthrough
+
+This document is for readers who want the *why*. The per-subsystem reference
+pages (`docs/kernel/*.md`) explain *what* each module does; this one walks the
+machine top-to-bottom — CPU state at boot, paging, TLB management, per-task
+address spaces, the scheduler, ring-3 entry, the syscall ABI — and finishes
+with a frank assessment of what stands between the current model and a real
+POSIX/libc userspace (`fork()`, signals under fork, musl/dash).
+
+i386 protected mode, 32-bit, single CPU. No SMP. No PAE. No long mode.
+The decisions below are pitched for that target.
+
+---
+
+## 1. CPU state at handoff
+
+GRUB boots us in 32-bit protected mode via the Multiboot 2 protocol. When
+`_start` (in `src/kernel/arch/i386/boot/boot.S`) takes control:
+
+| Register / state | Value |
+|---|---|
+| EAX | `0x36D76289` (Multiboot 2 magic) |
+| EBX | physical address of the Multiboot 2 information structure |
+| CS  | flat 32-bit code segment installed by GRUB (we replace it) |
+| DS/ES/FS/GS/SS | flat data segments (we replace these too) |
+| EFLAGS.IF | 0 — interrupts disabled |
+| CR0.PG | 0 — **paging is OFF**, addresses are physical |
+| CR0.PE | 1 — protected mode is on |
+| CR4.PSE | 0 — large pages are off |
+| A20 gate | enabled (GRUB handles this) |
+
+`_start` immediately installs a minimal stack (`stack_top`, 16 KiB BSS), saves
+EAX/EBX for `kernel_main`, and falls through to C. We're still on GRUB's GDT
+at this point; the very first thing `kernel_main` does is reload a GDT we own
+(`init_descriptor_tables`). Until that runs, we cannot enter ring 3, cannot
+use a TSS, and cannot trust the segment limits — GRUB's segments are flat but
+their privilege levels and types aren't our problem to debug.
+
+The kernel image is linked with `link.ld` to load at **1 MiB** (`0x100000`),
+which puts it above the BIOS legacy area and BDA. No high-half mapping — we
+run identity-mapped in low memory. This is a deliberate simplification: a
+high-half kernel would force every page directory to mirror the high PDEs and
+makes early-boot debugging fiddlier; the cost is that user-space addresses
+above 256 MiB can't be used by ring-3 (we cap user at the kernel identity
+window, see §5).
+
+---
+
+## 2. Descriptor tables
+
+### GDT
+
+Six entries, all flat (base 0, limit 4 GiB):
+
+| Selector | Index | DPL | Type | Use |
+|---|---|---|---|---|
+| `0x00`   | 0 | -   | null         | required |
+| `0x08`   | 1 | 0   | code, exec/read | kernel CS |
+| `0x10`   | 2 | 0   | data, read/write | kernel DS/ES/FS/GS/SS |
+| `0x18`   | 3 | 3   | code, exec/read | user CS |
+| `0x20`   | 4 | 3   | data, read/write | user DS/ES/FS/GS |
+| `0x28`   | 5 | 0   | TSS (32-bit available) | task-state, see below |
+
+Three things matter here:
+
+- **Flat segmentation.** Every selector covers all of 4 GiB. Paging does all
+  the protection work. Segmentation is reduced to "what's the CPL of this
+  selector" — exactly the model Linux/NT/most modern PMs use.
+- **DPL=3 user segments.** Ring-3 code loads CS=0x1B and SS=0x23 (note the
+  RPL bits `0x3`). The `iret` frame in `ring3.S` sets these explicitly.
+- **Single TSS.** We don't use hardware task switching — that path is slower
+  and uglier than software switching on every x86 since the P6. The TSS
+  exists *only* to hold `tss.esp0`, the kernel-stack pointer the CPU loads on
+  a privilege-level transition (ring-3 → ring-0 via `int 0x80` or an
+  interrupt). Updated by `tss_set_kernel_stack` on every context switch into
+  a user task.
+
+### IDT
+
+256 entries, all 32-bit interrupt gates. Generated stubs in `isr_asm.S` push
+a fake error code (where the CPU didn't), push the vector number, and jump to
+`isr_common_stub` which pushes the full register set, calls into C, and
+restores. The interrupt gate type clears IF on entry; we keep it clear for
+the duration of the syscall handler (see §10) — a deliberate simplification
+that means a syscall can't be preempted, only voluntarily yielded.
+
+DPL on every IDT gate is **zero**, *except* the syscall gate at 0x80, which is
+DPL=3. Ring-3 cannot raise an arbitrary interrupt; the only doorbell it has
+is `int 0x80` (and `int3` debug, which we also expose).
+
+---
+
+## 3. Physical memory manager
+
+`src/kernel/arch/i386/mm/pmm.c`. A bitmap allocator, one bit per 4 KiB frame,
+indexed from physical address 0. Bootstrap is the tricky part:
+
+1. Walk the Multiboot 2 memory-map tag. Each `mmap_entry` describes a
+   contiguous physical range and its type (available, reserved, ACPI
+   reclaimable, etc.). We track only `MULTIBOOT_MEMORY_AVAILABLE` ranges.
+2. Compute the total managed frames, allocate the bitmap *inside* one of the
+   available ranges (bumped past the kernel image so we don't clobber
+   ourselves), and mark the bitmap's own footprint as used.
+3. Mark every non-available range as used (so frame allocation never returns
+   a frame we don't actually own — ACPI tables, MMIO holes, the EBDA).
+4. Mark frame 0 as used. We never return the null page. This is what makes
+   `vmm_map_page(pd, 0x00000000, ...)` a guaranteed-NULL deref rather than
+   accidentally mapping the IVT.
+
+`pmm_alloc_frame` is a linear scan from the last-allocated index, wrapping
+on the way back. That's not O(1), but it's O(bits/64) with `bsf`-friendly
+access patterns, and the bitmap fits in 4 KiB even for 128 MiB of RAM, so
+this is well below the noise floor on every hot path that calls it.
+
+`PMM_ALLOC_ERROR` is `(uint32_t)-1`. Callers check it; the kernel doesn't
+panic on OOM at this layer because the allocator can be called from contexts
+where panicking is worse than gracefully failing (e.g., a faulting user-page
+allocator that can return a signal instead).
+
+---
+
+## 4. Paging
+
+`src/kernel/arch/i386/mm/paging.c`. The kernel installs **one** page
+directory at `paging_kernel_pd`. The first 64 PDEs are populated with 4 MiB
+PSE large-page entries (`PS=1, PRESENT=1, RW=1`) mapping virtual `0` →
+physical `0` through virtual `0x10000000` → physical `0x10000000`. That gives
+us a flat **256 MiB identity window** that the kernel runs in.
+
+`paging_init` does the actual mode flip in this order, which matters:
+
+```c
+/* 1. CR4.PSE: tell the CPU PDEs with PS=1 are 4 MiB pages.
+ *    Must precede CR0.PG=1 or the first faulted PDE walk will treat
+ *    PS=1 as "this is a normal PDE pointing at PT 0x800000". */
+cr4 |= (1u << 4);
+asm volatile("mov %0, %%cr4" :: "r"(cr4) : "memory");
+
+/* 2. Load CR3 with the kernel PD's physical address.  This populates
+ *    the TLB tagger but doesn't actually map anything until PG=1. */
+asm volatile("mov %0, %%cr3" :: "r"(&pd) : "memory");
+
+/* 3. CR0.PG: turn paging on.  Immediately after this instruction
+ *    retires, every linear address is page-translated.  The kernel
+ *    is identity-mapped so EIP stays valid. */
+cr0 |= (1u << 31);
+asm volatile("mov %0, %%cr0" :: "r"(cr0) : "memory");
+```
+
+Three things worth a lecture call-out:
+
+- **PSE before PG.** If you flip PG before PSE, the CPU walks the PDE with
+  `PS=1` and treats bits `[31:12]` as a page-table base address, which is
+  catastrophic. Some emulators (QEMU TCG) tolerate the wrong order; real
+  hardware does not.
+- **CR3 reload is itself a full TLB flush** (except for entries tagged with
+  the global bit, which we don't use). So the moment PG goes on, the TLB is
+  cold; the next instruction fetch fills one 4 MiB TLB entry for the EIP
+  page. No `invlpg` needed.
+- **No global pages.** We never set the G bit on kernel PDEs. The right thing
+  long-term is `CR4.PGE=1` + `G=1` on the kernel identity window so a CR3
+  reload during context switch doesn't flush the kernel TLB. Today every
+  `vmm_switch` re-fills the kernel TLB entries on first use. Cheap on a
+  hobby OS (256 MiB / 4 MiB = 64 TLB fills), worth fixing on the day we
+  benchmark scheduler throughput.
+
+### Page-fault delivery
+
+Vector 14. The hardware pushes the faulting linear address into CR2 and a
+4-bit error code onto the stack:
+
+```
+bit 0: P     1 if a protection violation (rather than not-present)
+bit 1: W/R   1 on write, 0 on read
+bit 2: U/S   1 if from ring 3
+bit 3: RSVD  1 if a reserved-bit was set in a page-table entry
+bit 4: I/D   1 on an instruction fetch (PAE/long mode only)
+```
+
+`debug/page_fault.c` decodes these and prints a panic screen. There is no
+page-fault *handler* yet — every fault is fatal. The eventual demand-paged
+allocator and CoW (§11) live here.
+
+---
+
+## 5. Per-task address spaces (VMM)
+
+`src/kernel/arch/i386/mm/vmm.c`. Every task created with `task_create_user`
+gets its own page directory. Construction (`vmm_create_pd`):
+
+1. `pmm_alloc_frame` for the PD itself.
+2. `memset` to zero, then walk the kernel PD and copy every present PDE
+   (indices 0–63 — the 256 MiB identity window plus anything `heap_init` or
+   `vesa_init` added). This is the **kernel-PDE-mirroring** model — every
+   user PD has the kernel mapped at the same virtual addresses as the kernel
+   sees itself.
+3. Leave indices 64–1023 zero. That's the user-space range, 3.75 GiB worth,
+   though we only ever populate two slots:
+   - `USER_CODE_BASE = 0x40000000` (PDE 256) — one 4 KiB page for code.
+   - `USER_STACK_TOP = 0xBFFF0000` (PDE 767) — one 4 KiB page for stack.
+
+The mirror is a one-time snapshot, not a live shadow. If something maps a new
+kernel PDE *after* `vmm_create_pd` runs (e.g., the heap grows past 16 MiB), the
+existing user PDs miss it. The heap is pre-mapped at boot to its full 16 MiB
+window precisely to dodge this. The proper fix is the global-page approach
+above, or a small "kernel PDE update" propagation routine.
+
+### Mapping a page
+
+`vmm_map_page` is the only routine that allocates **4 KiB page tables**. If
+the target PDE is unpopulated, it allocates a frame, zeros it, installs it as
+the PT with `PRESENT|WRITABLE|USER` (note: the PDE flags must permit user
+access if any single PTE in it does; the CPU walks both). Then it sets the
+PTE with the caller's flags.
+
+The user range deliberately has `PAGE_USER` on PDEs so ring-3 can walk in.
+The kernel-mirrored PDEs use 4 MiB pages without `PAGE_USER`, which makes
+*any* ring-3 attempt to read or write a kernel address trap with U/S=1 in the
+PFE — clean privilege separation enforced by hardware, not software.
+
+### TLB management
+
+This is the section your manager will ask the most pointed questions about.
+
+- **`vmm_switch(pd)`** writes CR3, which on every x86 since the i486 flushes
+  the entire non-global TLB. That's what we have on every context switch
+  (`schedule()` calls it whenever the destination task has a different PD
+  than the source). On a 100 Hz scheduler with 8 tasks, that's at worst a
+  few hundred flushes/second — fine.
+- **`vmm_unmap_page`** invokes `invlpg` *only if the current CR3 matches the
+  PD being mutated*. Otherwise the stale entry lives in whichever
+  hypothetical TLB belongs to the other-task's CR3 (which doesn't exist on
+  this CPU — TLBs are per-physical-CPU, and CR3 reload is the
+  scaling-equivalent on uniprocessor). When we switch back to that PD, CR3
+  reload flushes it. Net: correct on uniprocessor, *broken* on SMP without
+  a proper TLB-shootdown IPI. We are not SMP.
+- **`vmm_map_page`** does **no** TLB invalidation. The mapped page wasn't
+  present before, so the TLB couldn't have a cached translation for it.
+  This is the standard "lazy mapping" path and it's safe by construction —
+  the only failure mode is if you `unmap` then immediately `map` the same
+  vaddr; we handle that explicitly elsewhere.
+
+### Why 4 MiB pages for the kernel
+
+Because they cost one TLB slot per 4 MiB instead of 1024 slots for the same
+range. The full kernel identity window (256 MiB) fits in **64** TLB entries,
+and most x86 CPUs since the P6 have a split TLB with a dedicated 4 MiB
+section large enough to hold the whole kernel map indefinitely. Combined
+with no global bit (next bullet), this is the dominant reason context-switch
+overhead on Makar is dominated by `mov %cr3` itself (a ~100-cycle
+serialising instruction), not by re-faulting kernel TLB entries.
+
+### Why the heap maps eagerly
+
+`heap_init` calls `paging_map_region(HEAP_START, HEAP_MAX - HEAP_START)` —
+16 MiB worth — at boot. That eagerly installs the PT entries in the kernel
+PD before any user PD is cloned, so the mirror in `vmm_create_pd` catches
+them all. A lazier heap (map on first touch) would force us to either
+propagate kernel-PDE updates on every fault or use global pages. Pick your
+poison; on a 128-MiB-RAM hobby OS, the 16 MiB eager allocation is the
+cheaper one to spell out.
+
+---
+
+## 6. Kernel heap
+
+`src/kernel/arch/i386/mm/heap.c`. First-fit linked-list allocator over a
+single 16 MiB region. Each block has a header:
+
+```c
+typedef struct block_hdr {
+    uint32_t size;      /* payload size, NOT including header */
+    uint32_t free : 1;
+    uint32_t      : 31;
+} block_hdr_t;
+```
+
+`kmalloc(n)` walks from `heap_head`, picks the first free block whose
+`size >= n`, splits if the leftover would hold at least a header + 16 bytes,
+and returns the payload pointer (`block + 1`). `kfree(p)` flips the free bit
+and coalesces forward (rightward) — it does **not** coalesce backward,
+because the list has no `prev` pointer. This is a known small-O fragmentation
+hazard; if it ever bites we add a `prev` field and pay the 4 extra bytes per
+header.
+
+No alignment guarantees beyond 4 bytes. Not a buddy allocator, not a slab
+allocator. Sufficient for a kernel where the hot allocations are a handful
+of `task_t` and `vesa_pane_t` and a few KiB of FAT32 buffers.
+
+---
+
+## 7. Tasking
+
+`src/kernel/arch/i386/proc/task.c`. Fixed-size pool of 8 `task_t` slots,
+round-robin scheduler, voluntary `task_yield()` *and* preemptive timer-driven
+yields (PIT 100 Hz, `SCHED_QUANTUM=4` ticks → 40 ms time slice).
+
+### `task_t` (abbreviated)
+
+```c
+typedef struct task {
+    uint32_t  pid;
+    char     *name;
+    char      name_buf[TASK_NAME_MAX];
+
+    /* Scheduler state */
+    enum task_state state;     /* RUNNABLE / RUNNING / DEAD */
+    uint32_t        esp;       /* saved kernel-stack pointer */
+    uint8_t        *stack;     /* kernel stack base */
+
+    /* Address space (NULL for kernel-only tasks) */
+    uint32_t       *page_dir;
+    uint32_t        user_brk;
+
+    /* TTY / fd / signals */
+    int             tty;
+    fd_table_t     *fd_table;
+    sig_handler_t   sig_handlers[NSIG];
+    uint32_t        sig_pending, sig_mask;
+
+    /* Cwd, exec params, fb_touched, kticks, unkillable, ... */
+
+    struct task *next;
+} task_t;
+```
+
+### Context switch (`task_asm.S`)
+
+```
+void task_switch(uint32_t *old_esp, uint32_t new_esp);
+```
+
+The asm pushes EDI, ESI, EBX, EBP and pushfd onto the *current* stack, writes
+the resulting ESP into `*old_esp`, loads ESP from `new_esp`, popfd, and pops
+the four callee-saved regs. Then `ret` — which on the new task pops the
+return address the *previous* call to `task_switch` left there. Net effect:
+control returns into the function that called `task_switch` last time, on the
+new task's stack, with that task's EFLAGS (and therefore its IF) restored.
+
+We save *only* callee-saved registers because the caller (always the C
+`schedule()` function) has already spilled what the ABI doesn't require us to
+preserve. This is the same trick Linux uses for its `__switch_to` family.
+
+### Preemption + the `in_schedule` guard
+
+`timer_callback` calls `schedule()` from IRQ 0 context. `schedule()` can also
+be entered cooperatively via `task_yield`. Both paths now go through a
+re-entrancy guard:
+
+```c
+static volatile int in_schedule = 0;
+
+static inline uint32_t irq_save_disable(void) {
+    uint32_t f; asm volatile("pushfd; popl %0; cli" : "=r"(f));
+    return f;
+}
+
+static void schedule(void) {
+    uint32_t saved = irq_save_disable();
+    if (in_schedule) { irq_restore(saved); return; }
+    in_schedule = 1;
+    ...
+    in_schedule = 0;
+    irq_restore(saved);
+}
+```
+
+Why: without the guard, a preemptive timer tick that arrives *while* a
+cooperatively-yielded `schedule()` is mid-list-walk would corrupt the
+runqueue. The `cli` is the standard one-CPU mutex; `in_schedule` is the
+re-entrancy bit that turns nested calls into no-ops instead of deadlocks.
+The `irq_save_disable` form is important — we re-enable IF only if the
+caller had it on, so syscalls (which keep IF=0 for the duration) don't have
+their flag flipped under them.
+
+### Reaper
+
+`task_exit` flips state to `TASK_DEAD` and yields. The next `schedule()`
+that runs on a different PD frees the dead task's PD via `pmm_free_frame`
+(plus the heap-allocated PT pages it owns). We deliberately don't free the
+PD inline because the current CR3 may *be* that PD; the CR3 switch in
+`vmm_switch` must happen before we hand the frame back to the PMM. This is
+exactly the "delayed reaper" pattern Linux uses for `free_task_struct`.
+
+---
+
+## 8. Ring-3 entry
+
+`src/kernel/arch/i386/proc/ring3.S`. `ring3_enter(entry, stack_top)` builds
+a 5-word `iret` frame:
+
+```
+[ESP+16]  SS    = 0x23   (user data, RPL=3)
+[ESP+12]  ESP   = stack_top
+[ESP+ 8]  EFLAGS = saved | IF  (we want IF=1 in ring 3)
+[ESP+ 4]  CS    = 0x1B   (user code, RPL=3)
+[ESP+ 0]  EIP   = entry
+```
+
+Loads DS/ES/FS/GS with `0x23`, then `iret`. Hardware unwinds CS:EIP/SS:ESP
+*and* sets CPL from CS's RPL, in a single atomic step. Returns to ring 3
+without ever existing in an intermediate "still in ring 0 but with user
+segments" state. This is the entire reason `iret` is used for ring transitions
+rather than a `jmp far` sequence — it's the only way to flip CPL atomically.
+
+The caller's responsibility before `ring3_enter`:
+
+1. `tss_set_kernel_stack(top_of_kernel_stack)` — so the *next* `int 0x80`
+   knows where to set ESP after the privilege flip.
+2. `vmm_switch(pd)` — load the user PD into CR3.
+
+ELF loading (`elf_exec`) maps `USER_CODE_BASE` to a freshly-allocated frame,
+copies the program text in, maps a user stack page below `USER_STACK_TOP`,
+constructs argc/argv on that stack, and jumps through `ring3_enter`. We have
+no dynamic loader; binaries are statically linked freestanding ELFs.
+
+---
+
+## 9. Syscall ABI
+
+`int 0x80`, Linux i386 convention. EAX = syscall number; EBX/ECX/EDX/ESI/EDI
+= arg0..arg4. Return value comes back in EAX.
+
+```
+ring 3                                          ring 0
+  ─────                                          ─────
+  mov eax, SYS_WRITE                           
+  mov ebx, fd                                  
+  mov ecx, buf                                 
+  mov edx, len                                 
+  int 0x80      ──────────────────►            isr_common_stub
+                                                pushes regs, calls C
+                                                                  │
+                                                                  ▼
+                                                syscall_handler(regs)
+                                                  - dispatch on regs->eax
+                                                  - write result to regs->eax
+                                                                  │
+                ◄──────────────────             iret w/ saved EFLAGS
+  result in EAX                                  (IF restored to user 1)
+```
+
+The trap gate at IDT[0x80] is DPL=3 so ring 3 can fire it. Inside the
+handler, IF stays 0 — interrupts are masked for the syscall's duration.
+This is the simplest thread-safety story: a syscall can't be preempted, so
+no syscall handler needs to be reentrant or take locks against IRQ context.
+The cost is latency — a slow syscall (FAT32 read, IDE PIO) holds the IRQ
+mask for milliseconds. Acceptable on a single-task interactive shell; the
+fix is to *enable* IF inside the handler once we're past the regs-save and
+no longer running on a possibly-corrupt stack, the same pattern Linux uses
+for `local_irq_enable()` inside its syscall path. The plumbing is there
+(`irq_save_disable` etc.); we just haven't pulled the trigger.
+
+The full table lives at `src/kernel/include/kernel/syscall.h`. Numbers 1..49
+match Linux/i386 exactly (EXIT, READ, WRITE, OPEN, CLOSE, LSEEK, KILL, BRK,
+SIGNAL, FCNTL...). 100, 158, 200–217 are Makar-only extensions for terminal
+ops, signal returns, and the new pixel framebuffer API.
+
+### `int 0x80` vs `sysenter`
+
+Modern Linux on i686 uses `sysenter` (CSE-enabled fast syscalls) when the CPU
+supports it, falling back to `int 0x80` on ancient hardware. We use `int 0x80`
+exclusively. Pros: simple. Cons: ~80–120 cycles latency vs ~20 cycles for
+`sysenter`. On a hobby OS where the hot path is a shell at 1 syscall/second
+on average, this doesn't move the needle. The day we run a real workload it
+becomes a 2-day port (set up MSR_IA32_SYSENTER_*, write a sysenter entry stub,
+flip the libc to use it).
+
+---
+
+## 10. Interrupts
+
+Single 8259A pair, remapped from BIOS-default (IRQs at vectors 8–15, conflict
+with exceptions) to vectors **32–47**. PIT on IRQ 0 = vector 32; PS/2
+keyboard on IRQ 1 = vector 33; IDE on IRQ 14 = vector 46.
+
+The remap dance (`pic_remap`):
+
+```c
+outb(PIC1_CMD, 0x11);   outb(PIC2_CMD, 0x11);   /* init, expect ICW2-4 */
+outb(PIC1_DATA, 0x20);  outb(PIC2_DATA, 0x28);  /* offsets 32 / 40    */
+outb(PIC1_DATA, 0x04);  outb(PIC2_DATA, 0x02);  /* cascade IRQ 2      */
+outb(PIC1_DATA, 0x01);  outb(PIC2_DATA, 0x01);  /* 8086 mode          */
+outb(PIC1_DATA, 0x00);  outb(PIC2_DATA, 0x00);  /* mask = none        */
+```
+
+After each IRQ handler returns, the dispatcher writes `0x20` (EOI) to the
+appropriate PIC. The slave-PIC IRQs (8..15) require EOI to both. The kernel
+never enters this path with IF=1 — IDT gates clear IF on entry and `iret`
+restores the user's IF on return.
+
+We do not use the APIC. We do not use the HPET. The PIT at 100 Hz drives
+both the scheduler and `sys_uptime()`. Adopting the APIC would buy us
+per-CPU timers (irrelevant pre-SMP) and per-IRQ programmable priorities
+(useful for IDE-vs-keyboard contention, but not enough to justify the port).
+
+---
+
+## 11. The road to fork() and a POSIX libc
+
+This is the section where the hand-waving stops. Below is the actual sequence
+of things that would have to land, in order, for `dash` (or, eventually,
+`bash`) to run.
+
+### 11.1 `fork()`: what's actually involved
+
+POSIX `fork()` semantics:
+1. Atomically create a child process that is a copy of the parent, except
+   for: a different PID, a different parent PID, copies of all open file
+   descriptors that share the underlying open-file descriptions (so seeks
+   in the child see the parent's seeks), the child sees `fork() == 0`,
+   the parent sees `fork() == child_pid`.
+2. The child's address space is a logical copy of the parent's — same
+   contents, **independent writes**. Almost universally implemented as
+   **copy-on-write**: both PDs share physical frames, both marked
+   read-only, the page-fault handler clones a frame on the first write.
+
+On Makar today:
+
+- **PD clone.** Easy. Walk the parent PD, for each present PTE in the user
+  range allocate a new frame, copy the contents, install in the child PD.
+  CoW is an optimisation, not a correctness requirement.
+- **CoW.** Walk both PDs, set `WRITABLE=0` on every shared PTE, set a custom
+  software bit in the PTE flags (we have three reserved bits, `[11:9]`, that
+  the CPU ignores) marking it CoW. Add a page-fault handler that intercepts
+  W/R=1, P=1, our-cow-bit=1 faults: allocate a new frame, copy, install
+  writable in the faulting PD, decrement a refcount on the original frame,
+  free if zero. The refcount needs a `pmm_ref_inc`/`pmm_ref_dec` API. None
+  of this is novel; it's a 200-line patch with no architectural blockers.
+- **PID allocation.** Today PIDs are dense `pool_index + 2`. `fork()` needs
+  a monotonic counter that doesn't repeat for the lifetime of the system
+  (otherwise `waitpid` can race with PID reuse). Trivial: bump-allocate from
+  a `uint32_t s_next_pid`.
+- **fd-table dup.** The fd table is per-task (`kernel/fd.h`). `fork` must
+  duplicate it, sharing the *open-file descriptions* — i.e., the underlying
+  `vfs_node_t *` + offset state — rather than the descriptors. Today the
+  fd-table entry IS the (kind, vnode, off) tuple, with no separate
+  open-file struct. To make `seek` in the parent visible in the child after
+  fork (POSIX requirement), the open-file state needs to be heap-allocated
+  with a refcount, and the fd entry becomes a pointer to it. ~150 lines.
+- **Return-value split.** The parent returns the child PID; the child
+  returns 0. Our `task_create` returns `task_t *`; the caller of `fork` is
+  the parent (and will see the child PID). The child's first instruction
+  is whatever EIP we put in its saved-register frame; we set EAX=0 in the
+  frame and the saved-EIP to the instruction *after* the `int 0x80` from
+  `fork`. The cleanest model is to enter the child through a small assembly
+  trampoline that loads zero into EAX and jumps to the saved user EIP from
+  the fork-syscall sigframe. Linux does the same.
+
+Estimated effort: **a weekend, plus a week of test-suite hardening**.
+
+### 11.2 vfork() vs posix_spawn()
+
+If you only need fork-then-immediately-exec (which is what the shell does
+~98% of the time), there are two cheaper alternatives:
+
+- **`vfork()`**: child shares the parent's address space and the parent is
+  *suspended* until the child execs or exits. Avoids the CoW dance entirely.
+  Used to be the standard "fast fork" before CoW. Still in POSIX.1-2001 as
+  legacy. We could implement it in an afternoon: child gets a fresh task_t
+  with the parent's PD borrowed (no clone), parent's `wait_for_child` flag
+  set, scheduler skips the parent until child exits or execs (which switches
+  to a new PD).
+- **`posix_spawn()`**: a single syscall that does fork+setup+exec in the
+  kernel. No address-space duplication needed at all — the kernel allocates
+  a fresh PD, loads the new image, installs file actions. This is what musl
+  ships and what Android's bionic relies on heavily. **This is the cheapest
+  path** to running `dash` and is the route I'd take first.
+
+The downside of starting with vfork/spawn rather than fork is that anything
+that calls `fork()` without an `exec()` (e.g., a shell that wants to run a
+function body in a subshell, or `python -c 'import os; os.fork()'`) breaks.
+For an interactive shell that's a real limitation. So: ship posix_spawn
+first to unblock dash; ship fork+CoW second to unblock the long tail.
+
+### 11.3 Signals under fork
+
+We already have a per-task `sig_handlers[NSIG]` table and Linux-style mask /
+pending bitmaps. `fork()` must:
+
+- Copy `sig_handlers` byte-for-byte (POSIX: child inherits dispositions).
+- Copy `sig_mask` (POSIX: child inherits mask).
+- **Clear `sig_pending`** (POSIX: pending signals are NOT inherited).
+- Inside the child, on first return-from-syscall, `sig_deliver` runs as
+  usual against the cleared pending set.
+
+Pretty mechanical. The non-trivial part is the *sigframe* on the user
+stack: if a signal handler is mid-flight at the moment of fork, the child
+inherits both the alternate ring-3 stack frame and the pending handler. We
+already build a sigframe in `signal.c` for `SYS_SIGNAL` user handlers; the
+trampoline (`SYS_SIGRETURN`) restores cleanly. Fork inherits it without
+modification.
+
+### 11.4 musl libc port
+
+musl is small, MIT-licensed, designed for embedded/static linking, and has
+a very thin syscall shim layer (`musl/arch/i386/syscall_arch.h`). The port:
+
+1. **Static-only.** No dynamic linker yet (we'd need `ld-musl.so.1`,
+   `dlopen`, and rtld). Compile with `musl-gcc --static`.
+2. **Syscall surface.** musl uses ~110 Linux syscalls. We have ~30. The
+   list of gaps that block a static `dash` build (in priority order):
+   `dup2`, `pipe`, `wait4`, `waitpid`, `getpid`, `getppid`, `umask`,
+   `chdir` (we have `cd` builtin only — fix that),  `fstat`/`stat`,
+   `getdents` (we have `SYS_LS_DIR` which returns a pre-rendered blob; a
+   `getdents`-style streaming API is needed for `opendir`/`readdir`),
+   `ioctl` (at least `TIOCGWINSZ` for terminal size — we have `SYS_TERM_SIZE`
+   to plumb to that).
+3. **`brk`/`sbrk`.** Done (SYS_BRK 45). musl's allocator uses it directly.
+4. **`mmap` (anonymous).** musl's allocator falls back to `mmap` for large
+   allocations. We don't have it. Implementing `mmap(MAP_ANONYMOUS)` as a
+   call to `vmm_map_page` for an arbitrary range is straightforward; the
+   tricky bit is virtual-address allocation (we need a per-task "mmap arena"
+   with a free-region tree). A bump allocator from `0xC0000000` downward is
+   the laziest correct option.
+5. **TLS.** musl wants `set_thread_area` (i386's old-school per-task GDT
+   slot for FS). Set up GDT entry 6 as a per-task TLS slot, write its base
+   on context switch. ~50 lines.
+
+Estimated effort: **two weekends, plus a week of debugging static-linked
+dash booting cold**. The standard arithmetic on a libc port is that the
+first 80% takes 20% of the time and the last 20% (vfork-not-fork-special-
+cases, restartable syscalls, signal-safe libc primitives) takes the rest.
+
+### 11.5 Why dash before bash
+
+Both are POSIX shells. dash is ~150 KiB, no GNU extensions, no command-line
+editing, no job control beyond the POSIX minimum. bash is ~1 MiB, depends on
+readline (which depends on termcap, which depends on terminfo lookup —
+another two-day port), and uses ~20 more syscalls than dash (most around
+job control and signal-safety in interactive mode).
+
+The realistic path: ship posix_spawn → port musl → build static dash → fix
+the gaps that dash exposes (there will be three or four) → declare victory.
+bash-on-Makar is a separate, larger project.
+
+### 11.6 An in-kernel C compiler
+
+`tcc` (the Tiny C Compiler, ~200 KiB) compiles C to ELF in memory and writes
+the output via `vfs_write_file`. No fork needed — it's a single-binary
+operation. Once musl is static, building tcc against it gives us a
+self-hosting "write source, compile, run" loop on bare metal — the CP/M
+target. This is the slice we'd actually demo to your manager once §11.1–11.4
+land.
+
+---
+
+## 12. Things worth knowing that don't fit elsewhere
+
+- **No floating point in the kernel.** `-mno-sse -mgeneral-regs-only` in
+  CFLAGS. Saves us from having to save/restore FPU state on every context
+  switch. User tasks aren't gated from FP (we just haven't set `CR0.MP` or
+  installed an `#NM` handler, so the first user FP instruction faults).
+- **No SMP**, intentionally. The single biggest implementation simplification
+  in the whole codebase. Every "lock" we'd need on SMP is a no-op on UP
+  with IF discipline.
+- **No virtual memory paging-out**, intentionally. RAM > working set on every
+  realistic Makar workload. The infrastructure to swap (page tables,
+  reference counting, an LRU walker) is large; the gain is zero.
+- **Per-task fd table lives in the heap**, not in the task struct. This means
+  a slot-recycled `task_t` doesn't carry stale fds, but it also means
+  `task_create` does an allocation. The allocation is amortised by the
+  fixed-size 8-task pool — we hit `kmalloc` at most 8 times per boot.
+- **The `unkillable` flag on shell tasks** is a hack to keep the four shell
+  tasks alive across rogue `kill -9` from a misbehaving userland. Linux's
+  equivalent is "PID 1 cannot receive SIGKILL except from itself"; Makar's
+  is a single bit checked in `sig_deliver`. Honest about being a hack.
+
+---
+
+## References
+
+- Intel SDM Vol. 3A, ch. 3-5 (segmentation, paging, control registers).
+- AMD64 System Programmer's Manual Vol. 2 (the descriptions of CR0/3/4
+  flag semantics are clearer than Intel's, even for 32-bit i386).
+- *Operating Systems: Three Easy Pieces* (Arpaci-Dusseau), chapters on
+  CoW fork, scheduling, paging — pitched at the level your manager will
+  recognise.
+- OSDev wiki: [Paging](https://wiki.osdev.org/Paging),
+  [Higher Half Kernel](https://wiki.osdev.org/Higher_Half_Kernel) (why we
+  *don't*), [TLB](https://wiki.osdev.org/TLB).
+- Linux source for sanity-checking the conventions: `arch/x86/include/asm/`
+  for IDT, GDT, TSS layout; `kernel/fork.c` for the canonical CoW fork
+  implementation.
+- musl: `arch/i386/syscall_arch.h` and `src/process/posix_spawn*` for the
+  fast-path-without-fork model we'd port first.

--- a/docs/kernel/procfs.md
+++ b/docs/kernel/procfs.md
@@ -20,7 +20,7 @@ caller's buffer. No on-disk storage; nothing is cached between reads.
 | `/proc/cpuinfo` | CPUID leaves 0 + 1 | `vendor_id`, `cpu family`, `model`, `stepping`, `flags` (fpu/tsc/msr/pae/apic/cmov/mmx/sse/sse2/sse3/sse4_1/sse4_2), `arch i386 (protected mode)` |
 | `/proc/meminfo` | `pmm_managed_count()` + `pmm_free_count()` + `heap_used/free()` | Linux-style key/value: `MemTotal`, `MemFree`, `MemAvailable`, `MemUsed`, `Buffers` (0), `Cached` (0), `HeapTotal`, `HeapUsed`, `HeapFree`, `PageSize`, `FreeFrames`, `TotalFrames`.  `MemTotal` reflects the bootloader-available frame pool minus the null page + kernel image (cached at `pmm_init`). |
 | `/proc/tasks` | Walk `task_pool[]`, skip `TASK_DEAD` | `PID NAME STATE TTY TICKS CWD`.  Dead-but-not-yet-reclaimed slots are filtered so userspace tools (maktop / `cat /proc/tasks`) only see live work. |
-| `/proc/uname` | `MAKAR_VERSION` + build macros + `timer_get_ticks()` | `Makar 0.5.0 (i386) built <date> <time>` + uptime ticks |
+| `/proc/uname` | `MAKAR_VERSION` + build macros + `timer_get_ticks()` | `Makar <MAKAR_VERSION> (i386) built <date> <time>` + uptime ticks |
 
 ## VFS integration
 

--- a/docs/makar-medli.md
+++ b/docs/makar-medli.md
@@ -19,7 +19,7 @@ UX conventions, command vocabulary, and (eventually) binary formats.
 | **Target** | i686, ELF32, multiboot 2 (GRUB) | x86, Cosmos PE |
 | **Repo** | [Arawn-Davies/Makar](https://github.com/Arawn-Davies/Makar) | [Arawn-Davies/Medli](https://github.com/Arawn-Davies/Medli) |
 | **Path separator** | `/` (Unix) | `\` (DOS-style, `Paths.Separator = @"\"`) |
-| **Current version** | 0.5.0 | (see Medli repo) |
+| **Current version** | 0.6.0 | (see Medli repo) |
 
 The path-separator divergence is **intentional** — Makar follows
 Linux/Unix conventions because that is what the C tooling, FAT32 LFN

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1268,6 +1268,12 @@ static int slot_for_current(void)
  */
 unsigned char keyboard_poll(void)
 {
+    /* Mirror keyboard_getchar: apps using O_NONBLOCK stdin (maktop, clock)
+     * never hit the blocking path, so without this drain a vtty_switch
+     * deferred from IRQ never lands and the status bar / FB stay stale
+     * until something else calls keyboard_getchar. */
+    vtty_drain_pending();
+
     int s = slot_for_current();
     if (s >= 0) {
         kb_slot_t *slot = &kb_slots[s];

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -38,6 +38,7 @@
 #include <kernel/serial.h>
 #include <kernel/vga.h>
 #include <kernel/vesa_tty.h>
+#include <kernel/vesa.h>
 #include <kernel/ide.h>
 #include <kernel/timer.h>
 #include <string.h>
@@ -272,6 +273,75 @@ void syscall_dispatch(registers_t *regs)
         if (cl + 1 > size) { regs->eax = (uint32_t)-1; break; }
         memcpy(buf, cwd, cl + 1);
         regs->eax = cl;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_FB_INFO(216): query framebuffer pixel geometry.
+     * Returns (width << 16) | height when VESA is up, 0 when VGA-only.
+     * Userspace uses this to pick pixel vs character-cell drawing.
+     * ------------------------------------------------------------------ */
+    case SYS_FB_INFO: {
+        const vesa_fb_t *fb = vesa_get_fb();
+        if (!fb || !vesa_tty_is_ready()) { regs->eax = 0; break; }
+        uint32_t w = fb->width  & 0xFFFFu;
+        uint32_t h = fb->height & 0xFFFFu;
+        regs->eax = (w << 16) | h;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_DRAW_LINE(217): Bresenham line in framebuffer pixels.
+     * EBX = (x0 << 16) | (y0 & 0xFFFF)
+     * ECX = (x1 << 16) | (y1 & 0xFFFF)
+     * EDX = 24-bit RGB
+     *
+     * Clipped to [0, fb->width) x [0, drawable_height) where
+     * drawable_height excludes the bottom status row -- the same
+     * carve-out SYS_TERM_SIZE reports in cell units, just expressed
+     * in pixels for graphical apps.  Returns 0 on success, (uint32_t)-1
+     * if no pixel framebuffer is available (VGA-only boot).
+     * ------------------------------------------------------------------ */
+    case SYS_DRAW_LINE: {
+        const vesa_fb_t *fb = vesa_get_fb();
+        if (!fb || !vesa_tty_is_ready()) { regs->eax = (uint32_t)-1; break; }
+        int32_t x0 = (int32_t)(int16_t)(regs->ebx >> 16);
+        int32_t y0 = (int32_t)(int16_t)(regs->ebx & 0xFFFFu);
+        int32_t x1 = (int32_t)(int16_t)(regs->ecx >> 16);
+        int32_t y1 = (int32_t)(int16_t)(regs->ecx & 0xFFFFu);
+        uint32_t rgb = regs->edx & 0xFFFFFFu;
+
+        /* Drawable area excludes the status row.  vesa_tty_get_rows()
+         * is in cell units; cell_h derives from the FB / row count so
+         * we honour whatever font scale the operator selected. */
+        uint32_t rows = vesa_tty_get_rows();
+        uint32_t cell_h = rows ? (fb->height / rows) : 0;
+        int32_t y_max = (int32_t)fb->height;
+        if (cell_h && y_max > (int32_t)cell_h
+            && VESA_TTY_STATUS_ROWS > 0)
+            y_max -= (int32_t)(cell_h * VESA_TTY_STATUS_ROWS);
+        int32_t x_max = (int32_t)fb->width;
+
+        int32_t dx =  (x1 > x0) ? (x1 - x0) : (x0 - x1);
+        int32_t dy = -((y1 > y0) ? (y1 - y0) : (y0 - y1));
+        int32_t sx = (x0 < x1) ? 1 : -1;
+        int32_t sy = (y0 < y1) ? 1 : -1;
+        int32_t err = dx + dy;
+        for (;;) {
+            if (x0 >= 0 && x0 < x_max && y0 >= 0 && y0 < y_max)
+                vesa_put_pixel((uint32_t)x0, (uint32_t)y0, rgb);
+            if (x0 == x1 && y0 == y1) break;
+            int32_t e2 = err * 2;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+
+        /* Mark fb_touched so the shell's post-exit cleanup wipes the
+         * FB and repaints the VT's backing grid.  Without this the
+         * stray pixels we just drew would persist under the next
+         * prompt. */
+        { task_t *cur = task_current(); if (cur) cur->fb_touched = 1; }
+        regs->eax = 0;
         break;
     }
 

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -235,6 +235,10 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->pid         = next_pid++;
     t->kticks      = 0;
     t->unkillable  = 0;     /* default: ordinary task, no protection   */
+    t->fb_touched  = 0;     /* clean slate even when reclaiming a DEAD slot
+                             * whose prior occupant ran a fullscreen ELF;
+                             * otherwise shell_exec_elf would clear-screen
+                             * for every subsequent line-mode child. */
     t->fd_table    = new_fds;
     t->exec_params = NULL;
     t->script_vars = NULL;

--- a/src/kernel/arch/i386/proc/vix.c
+++ b/src/kernel/arch/i386/proc/vix.c
@@ -29,9 +29,8 @@
 #define VIX_CLR_STATUS  0x70u
 #define VIX_CLR_GUTTER  0x08u  /* dim grey on black */
 #define VIX_CLR_WARN    make_color(COLOR_LIGHT_RED, COLOR_BLACK)
-#define VIX_SHELL_VGA   0x1Fu
-#define VIX_SHELL_FG    0xFFFFFFu
-#define VIX_SHELL_BG    0x0000AAu
+/* VIX_SHELL_* removed: vix no longer owns the post-exit palette.
+ * shell_restore_screen reapplies the focused VT's scheme. */
 #define VIX_GUTTER_FG   0x808080u
 #define VIX_GUTTER_BG   0x000000u
 #define VIX_TEXT_FG     0xFFFFFFu
@@ -470,13 +469,10 @@ void vix_edit(const char *path, vesa_pane_t *pane)
         if (c >= ' ' && c <= '~')   { vix_insert_char(c); continue; }
     }
 
-    terminal_set_colorscheme(VIX_SHELL_VGA);
-    if (vesa_tty_is_ready()) {
-        vesa_tty_setcolor(VIX_SHELL_FG, VIX_SHELL_BG);
+    /* Palette restore is the VT layer's job: shell_restore_screen() is
+     * called by shell_dispatch after fullscreen commands return and now
+     * re-applies the per-VT colour scheme before repainting the backing
+     * grid.  vix only restores the caret style it tampered with. */
+    if (vesa_tty_is_ready())
         vesa_tty_set_caret_style(saved_caret);
-        /* No pane_clear / paint_buf / paint_status here - shell_dispatch
-         * calls shell_restore_screen() after any fullscreen command
-         * returns, which repaints the focused VT's backing grid and the
-         * status bar in one place. */
-    }
 }

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -603,6 +603,16 @@ static void shell_restore_screen(void)
 {
     if (!vesa_tty_is_ready())
         return;
+    /* Re-apply the per-VT colour scheme first so vt->fg/bg are back at
+     * the values the operator expects.  Fullscreen apps (kernel-builtin
+     * vix, ring-3 maktop/clock) leave vt->fg/bg pointed at whatever
+     * their last cell painted with; without this the next prompt would
+     * inherit that palette.  This is the VT-layer's job, not the
+     * application's. */
+    int tty = 0;
+    task_t *t = task_current();
+    if (t && t->tty >= 0 && t->tty < 4) tty = t->tty;
+    shell_apply_scheme_for_tty(tty);
     vt_buf_t *vt = vtty_buf_current();
     if (vt) vesa_tty_paint_buf(vt);
     vesa_tty_paint_status(vtty_active(), vtty_count());

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -713,6 +713,17 @@ int shell_dispatch_argv(int argc, char **argv)
  * --------------------------------------------------------------------------- */
 static void shell_print_prompt(void)
 {
+    /* Reassert the per-VT colour scheme on every prompt.  The terminal
+     * colour is global VGA state -- any error path, builtin, or
+     * cross-VT switch that mutated it would otherwise bleed into the
+     * next user-visible line.  Touching it here once per REPL turn
+     * means the VT layer owns its palette and no individual command
+     * has to clean up after itself. */
+    int tty = 0;
+    task_t *t = task_current();
+    if (t && t->tty >= 0 && t->tty < 4) tty = t->tty;
+    shell_apply_scheme_for_tty(tty);
+
     t_writestring(SHELL_USERNAME "@" SHELL_HOSTNAME " ");
     t_writestring(vfs_getcwd());
     t_writestring("~> ");
@@ -871,7 +882,12 @@ void shell_run(void)
             if (!prev || !*prev) {
                 t_setcolor(SHELL_ERROR_COLOR_VGA);
                 t_writestring("!!: no previous command\n\n");
-                t_setcolor(SHELL_COLOR_VGA);
+                /* Reapply per-VT scheme rather than the medli default --
+                 * SHELL_COLOR_VGA is white-on-blue and would clobber
+                 * the focused VT's palette. */
+                { int tty = 0; task_t *tc = task_current();
+                  if (tc && tc->tty >= 0 && tc->tty < 4) tty = tc->tty;
+                  shell_apply_scheme_for_tty(tty); }
                 continue;
             }
             strncpy(buf, prev, SHELL_MAX_INPUT - 1);
@@ -909,7 +925,8 @@ void shell_run(void)
             t_writestring("Unknown command '");
             t_writestring(argv[0]);
             t_writestring("' - try 'lsman'.\n\n");
-            t_setcolor(SHELL_COLOR_VGA);
+            /* shell_print_prompt reapplies the per-VT scheme; no need
+             * to fall back to SHELL_COLOR_VGA here. */
         }
     }
 }

--- a/src/kernel/arch/i386/shell/shell_cmd_apps.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_apps.c
@@ -18,6 +18,9 @@
 #include <kernel/ide.h>
 #include <kernel/fat32.h>
 #include <kernel/keyboard.h>
+#include <kernel/vt.h>
+#include <kernel/vesa_tty.h>
+#include <string.h>
 
 /* cmd_ring3test is defined in proc/usertest.c. */
 void cmd_ring3test(int argc, char **argv);
@@ -175,6 +178,30 @@ void shell_exec_elf(const char *path, int argc, char **argv)
      * routes focus + KEY_FOCUS_GAIN back to the child, not the shell. */
     if (self) vtty_set_foreground(self->tty, t);
 
+    /* Snapshot the focused VT's backing grid BEFORE the child runs so we
+     * can hand the scrollback back when it exits.  This is the same idea
+     * as xterm's alternate-screen / smcup-rmcup pair (and what Linux's
+     * `console_save_state` does around curses apps): the operator should
+     * see their previous prompts and command history return, with the
+     * fullscreen app's drawing wiped.  Heap-allocated so this scales
+     * with the (cols x rows) grid; freed unconditionally after exit. */
+    vt_buf_t  *vt = vtty_buf_current();
+    vt_cell_t *snap_cells   = NULL;
+    uint32_t   snap_n       = 0;
+    uint32_t   snap_cur_col = 0, snap_cur_row = 0;
+    uint32_t   snap_fg      = 0, snap_bg      = 0;
+    if (vt && vt->cells) {
+        snap_n     = vt->cols * vt->rows;
+        snap_cells = (vt_cell_t *)kmalloc(snap_n * sizeof(vt_cell_t));
+        if (snap_cells) {
+            memcpy(snap_cells, vt->cells, snap_n * sizeof(vt_cell_t));
+            snap_cur_col = vt->cur_col;
+            snap_cur_row = vt->cur_row;
+            snap_fg      = vt->fg;
+            snap_bg      = vt->bg;
+        }
+    }
+
     /* Wait for the child to finish.  Ctrl+C is now delivered as SIGINT
      * straight to the focused task (the child); the kernel's default-
      * terminate action in sig_deliver kills it on the next schedule
@@ -197,14 +224,30 @@ void shell_exec_elf(const char *path, int argc, char **argv)
     keyboard_set_raw(0);
 
     /* Only clean up after FULLSCREEN apps (those that touched the
-     * framebuffer via SYS_PUTCH_AT / SYS_TTY_CLEAR).  Line-mode
-     * children like cat / hello / makbox-fallback-on-typo write only
-     * via SYS_WRITE which scrolls normally; clearing after them would
-     * wipe their output.  Fullscreen apps that exited cleanly already
-     * called sys_shell_clear themselves -- doing it again is a no-op
-     * cost but rescues SIGKILL'd ones that never got the chance. */
-    if (t->fb_touched)
+     * framebuffer via SYS_PUTCH_AT / SYS_TTY_CLEAR / SYS_DRAW_LINE).
+     * Line-mode children like cat / hello / makbox-fallback-on-typo
+     * write only via SYS_WRITE which scrolls normally; clearing after
+     * them would wipe their output.
+     *
+     * Restore the pre-exec backing grid so the user's shell scrollback
+     * comes back, with the app's drawing erased.  paint_buf (called
+     * from shell_dispatch_argv -> shell_restore_screen) does the actual
+     * pixel work; we just overwrite the cells.  We skip the old
+     * shell_clear_screen() call here because that wiped the grid -- the
+     * whole point of the snapshot is to keep the operator's history. */
+    if (t->fb_touched && vt && vt->cells && snap_cells && snap_n == vt->cols * vt->rows) {
+        memcpy(vt->cells, snap_cells, snap_n * sizeof(vt_cell_t));
+        vt->cur_col = snap_cur_col;
+        vt->cur_row = snap_cur_row;
+        vt->fg      = snap_fg;
+        vt->bg      = snap_bg;
+    } else if (t->fb_touched) {
+        /* No snapshot available (alloc failed or VT geometry changed
+         * mid-exec, e.g. setmode while a child was running) -- fall
+         * back to the old behaviour. */
         shell_clear_screen();
+    }
+    if (snap_cells) kfree(snap_cells);
 }
 
 static void cmd_exec(int argc, char **argv)

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -21,7 +21,7 @@
 /* Shell version - independent of the kernel version (<kernel/version.h>).
  * The shell is conceptually a separate component; bump this when shell
  * features change, MAKAR_VERSION when the kernel itself changes. */
-#define SHELL_VERSION    "0.6.0"
+#define SHELL_VERSION    "0.2.0"
 
 #define BUILD_DATE __DATE__
 #define BUILD_TIME __TIME__

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -41,6 +41,14 @@
 #define SYS_SHELL_CLEAR  213  /* void shell_clear(void)     - same as `clear`     */
 #define SYS_UPTIME       214  /* uint32_t uptime_ticks(void) - 100 Hz timer ticks */
 #define SYS_GETCWD       215  /* int getcwd(char *buf, size_t size) - copy task cwd */
+#define SYS_FB_INFO      216  /* uint32_t fb_info(void) - VESA only; 0 if VGA-only.
+                                * Returns (width << 16) | height when available. */
+#define SYS_DRAW_LINE    217  /* int draw_line(uint32_t xy0, uint32_t xy1,
+                                *               uint32_t rgb)
+                                * Bresenham line in framebuffer pixels.  Coords
+                                * packed (x << 16) | y.  Returns 0 on success,
+                                * (uint32_t)-1 if pixel mode unavailable.
+                                * Clipped to drawable area (status row excluded). */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -14,7 +14,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf maktop.elf clock.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf sigtest.elf maktop.elf clock.elf lines.elf
 
 
 all: $(PROGS)
@@ -50,6 +50,9 @@ maktop.elf: crt0.o maktop.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 clock.elf: crt0.o clock.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+lines.elf: crt0.o lines.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 

--- a/src/userspace/clock.c
+++ b/src/userspace/clock.c
@@ -202,6 +202,10 @@ int main(int argc, char **argv, char **envp)
     }
 
     sys_fcntl(0, F_SETFL, 0);
-    sys_shell_clear();
+    /* No sys_shell_clear here: the shell's post-fullscreen restore path
+     * (shell_exec_elf + shell_restore_screen) reapplies the per-VT
+     * palette and wipes the backing grid.  An app reaching into VT
+     * state would just duplicate that work and, before bug-hunt, also
+     * leaked vt->fg/bg = blue from the last cell painted. */
     return 0;
 }

--- a/src/userspace/lines.c
+++ b/src/userspace/lines.c
@@ -1,0 +1,291 @@
+/*
+ * lines.elf - C64/BASIC-style string-art easter egg.
+ *
+ * Two endpoints drift around the screen bouncing off the edges; every
+ * frame we draw the line between them in a fresh colour.  Because the
+ * endpoint velocities are incommensurate the result is the classic
+ * spirograph / moiré pattern from a 1980s BASIC type-in.
+ *
+ * Two render modes:
+ *
+ *   VESA (preferred) - SYS_FB_INFO reports a pixel framebuffer, so we
+ *   draw with SYS_DRAW_LINE at native resolution.  RGB is randomised
+ *   per line so the colour space is huge (no 16-colour limit).
+ *
+ *   VGA / cell-mode fallback - no pixel FB, so we Bresenham over
+ *   character cells with the CP437 full-block glyph in cycling VGA
+ *   colours.  Chunky but at least visible on hardware without VBE.
+ *
+ * Quits on 'q', 'Q', F10, or Ctrl+C.  Non-blocking stdin so the line
+ * pump never pauses for input -- same idiom maktop / clock use.  The
+ * shell's post-fullscreen restore path repaints the focused VT's
+ * backing grid and reapplies the per-VT palette on exit, so we don't
+ * reach into terminal state ourselves.
+ */
+
+#include "syscall.h"
+
+#define MAX_COLS 160
+#define MAX_ROWS 60
+
+/* Bright VGA colours used in cell-mode only.  In pixel mode we
+ * generate full 24-bit RGB instead. */
+static const unsigned char PALETTE_VGA[] = {
+    9, 10, 11, 12, 13, 14, 15,
+};
+#define PALETTE_VGA_N (sizeof(PALETTE_VGA) / sizeof(PALETTE_VGA[0]))
+
+/* ---- shared state ---------------------------------------------------------- */
+
+static unsigned int s_rng;
+static unsigned int rng_next(void)
+{
+    s_rng = s_rng * 1103515245u + 12345u;
+    return (s_rng >> 8) & 0x7FFFFFu;
+}
+
+static int s_abs(int x) { return x < 0 ? -x : x; }
+
+static int read_key_nb(void)
+{
+    unsigned char c;
+    long r = sys_read(0, &c, 1);
+    if (r == 1) return (int)c;
+    return -1;
+}
+
+/* Pick a non-zero velocity in [-v_max..-1] U [1..v_max].  Larger speeds
+ * spread the moiré bands further apart per frame. */
+static int pick_velocity(int v_max)
+{
+    int v = (int)(rng_next() % (unsigned int)v_max) + 1;
+    if (rng_next() & 1) v = -v;
+    return v;
+}
+
+/* Vivid colour: avoid muddy mid-greys by forcing at least one channel
+ * to be near-max.  Keeps the lines saturated against a black background. */
+static unsigned int pick_rgb(void)
+{
+    unsigned int r = rng_next() & 0xFFu;
+    unsigned int g = rng_next() & 0xFFu;
+    unsigned int b = rng_next() & 0xFFu;
+    unsigned int which = rng_next() % 3u;
+    if (which == 0) r |= 0xC0u;
+    else if (which == 1) g |= 0xC0u;
+    else                 b |= 0xC0u;
+    return (r << 16) | (g << 8) | b;
+}
+
+/* ---- pixel-mode renderer (VESA) ------------------------------------------- */
+
+static int  s_px_w, s_px_h;
+static int  s_px0, s_py0, s_px1, s_py1;
+static int  s_pvx0, s_pvy0, s_pvx1, s_pvy1;
+
+static void px_reseed(void)
+{
+    s_px0 = (int)(rng_next() % (unsigned int)s_px_w);
+    s_py0 = (int)(rng_next() % (unsigned int)s_px_h);
+    s_px1 = (int)(rng_next() % (unsigned int)s_px_w);
+    s_py1 = (int)(rng_next() % (unsigned int)s_px_h);
+    s_pvx0 = pick_velocity(7);
+    s_pvy0 = pick_velocity(5);
+    s_pvx1 = pick_velocity(5);
+    s_pvy1 = pick_velocity(7);
+}
+
+static void px_step(void)
+{
+    unsigned int rgb = pick_rgb();
+    sys_draw_line(s_px0, s_py0, s_px1, s_py1, rgb);
+
+    s_px0 += s_pvx0;
+    if      (s_px0 <= 0)            { s_px0 = 0;             s_pvx0 = -s_pvx0; }
+    else if (s_px0 >= s_px_w - 1)   { s_px0 = s_px_w - 1;    s_pvx0 = -s_pvx0; }
+    s_py0 += s_pvy0;
+    if      (s_py0 <= 0)            { s_py0 = 0;             s_pvy0 = -s_pvy0; }
+    else if (s_py0 >= s_px_h - 1)   { s_py0 = s_px_h - 1;    s_pvy0 = -s_pvy0; }
+    s_px1 += s_pvx1;
+    if      (s_px1 <= 0)            { s_px1 = 0;             s_pvx1 = -s_pvx1; }
+    else if (s_px1 >= s_px_w - 1)   { s_px1 = s_px_w - 1;    s_pvx1 = -s_pvx1; }
+    s_py1 += s_pvy1;
+    if      (s_py1 <= 0)            { s_py1 = 0;             s_pvy1 = -s_pvy1; }
+    else if (s_py1 >= s_px_h - 1)   { s_py1 = s_px_h - 1;    s_pvy1 = -s_pvy1; }
+}
+
+/* Wipe the framebuffer by drawing a fan of black lines covering the
+ * canvas.  Simpler than adding a SYS_FB_CLEAR; works because the
+ * drawable height already excludes the status row. */
+static void px_wipe(void)
+{
+    for (int y = 0; y < s_px_h; y += 2)
+        sys_draw_line(0, y, s_px_w - 1, y, 0x000000);
+}
+
+static int run_pixel_mode(void)
+{
+    px_reseed();
+    px_wipe();
+
+    unsigned int frame = 0;
+    unsigned int next  = sys_uptime();
+
+    for (;;) {
+        int c = read_key_nb();
+        if (c >= 0) {
+            if (c == 'q' || c == 'Q' || c == 0x03 || c == (int)KEY_F10) break;
+            /* On VT-switch back to us, repaint by wiping + reseeding;
+             * the focused-VT logic in the kernel already handed the FB
+             * back to us. */
+            if (c == (int)KEY_FOCUS_GAIN) {
+                px_wipe();
+                px_reseed();
+            }
+            continue;
+        }
+        unsigned int now = sys_uptime();
+        if ((int)(now - next) >= 0) {
+            px_step();
+            frame++;
+            /* Periodic wipe + velocity re-roll so the pattern keeps
+             * evolving rather than saturating into a solid colour. */
+            if (frame % 400u == 0u) {
+                px_wipe();
+                s_pvx0 = pick_velocity(7); s_pvy0 = pick_velocity(5);
+                s_pvx1 = pick_velocity(5); s_pvy1 = pick_velocity(7);
+            }
+            next = now + 1;   /* 100 Hz / 1 = 100 lines/sec */
+        }
+        sys_yield();
+    }
+    return 0;
+}
+
+/* ---- cell-mode renderer (VGA fallback) ------------------------------------ */
+
+static int s_cols, s_rows;
+
+static tty_cell_t s_batch[MAX_COLS + MAX_ROWS];
+static int        s_nbatch;
+
+static void cell_flush(void)
+{
+    if (s_nbatch > 0) {
+        sys_putch_at(s_batch, (unsigned int)s_nbatch);
+        s_nbatch = 0;
+    }
+}
+
+static void cell_plot(int col, int row, unsigned char clr)
+{
+    if (col < 0 || row < 0 || col >= s_cols || row >= s_rows - 1) return;
+    s_batch[s_nbatch].col = (unsigned char)col;
+    s_batch[s_nbatch].row = (unsigned char)row;
+    s_batch[s_nbatch].ch  = 0xDB;
+    s_batch[s_nbatch].clr = clr;
+    s_nbatch++;
+    if (s_nbatch == (int)(sizeof(s_batch)/sizeof(s_batch[0])))
+        cell_flush();
+}
+
+static void cell_line(int x0, int y0, int x1, int y1, unsigned char clr)
+{
+    int dx =  s_abs(x1 - x0);
+    int dy = -s_abs(y1 - y0);
+    int sx = (x0 < x1) ? 1 : -1;
+    int sy = (y0 < y1) ? 1 : -1;
+    int err = dx + dy;
+    for (;;) {
+        cell_plot(x0, y0, VGA_CLR(clr, VGA_BLACK));
+        if (x0 == x1 && y0 == y1) break;
+        int e2 = err * 2;
+        if (e2 >= dy) { err += dy; x0 += sx; }
+        if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+    cell_flush();
+}
+
+static int run_cell_mode(void)
+{
+    s_cols = (int)sys_term_cols();
+    s_rows = (int)sys_term_rows();
+    if (s_cols > MAX_COLS) s_cols = MAX_COLS;
+    if (s_rows > MAX_ROWS) s_rows = MAX_ROWS;
+    if (s_cols < 8 || s_rows < 4) return 1;
+
+    sys_tty_clear(VGA_CLR(7, VGA_BLACK));
+
+    int x0 = (int)(rng_next() % (unsigned int)s_cols);
+    int y0 = (int)(rng_next() % (unsigned int)(s_rows - 1));
+    int x1 = (int)(rng_next() % (unsigned int)s_cols);
+    int y1 = (int)(rng_next() % (unsigned int)(s_rows - 1));
+    int vx0 = pick_velocity(3), vy0 = pick_velocity(2);
+    int vx1 = pick_velocity(2), vy1 = pick_velocity(3);
+
+    unsigned int color_idx = 0;
+    unsigned int frame     = 0;
+    unsigned int next      = sys_uptime();
+
+    for (;;) {
+        int c = read_key_nb();
+        if (c >= 0) {
+            if (c == 'q' || c == 'Q' || c == 0x03 || c == (int)KEY_F10) break;
+            if (c == (int)KEY_FOCUS_GAIN) sys_tty_clear(VGA_CLR(7, VGA_BLACK));
+            continue;
+        }
+        unsigned int now = sys_uptime();
+        if ((int)(now - next) >= 0) {
+            unsigned char clr = PALETTE_VGA[color_idx];
+            color_idx = (color_idx + 1) % PALETTE_VGA_N;
+            cell_line(x0, y0, x1, y1, clr);
+
+            x0 += vx0;
+            if      (x0 <= 0)            { x0 = 0;             vx0 = -vx0; }
+            else if (x0 >= s_cols - 1)   { x0 = s_cols - 1;    vx0 = -vx0; }
+            y0 += vy0;
+            if      (y0 <= 0)            { y0 = 0;             vy0 = -vy0; }
+            else if (y0 >= s_rows - 2)   { y0 = s_rows - 2;    vy0 = -vy0; }
+            x1 += vx1;
+            if      (x1 <= 0)            { x1 = 0;             vx1 = -vx1; }
+            else if (x1 >= s_cols - 1)   { x1 = s_cols - 1;    vx1 = -vx1; }
+            y1 += vy1;
+            if      (y1 <= 0)            { y1 = 0;             vy1 = -vy1; }
+            else if (y1 >= s_rows - 2)   { y1 = s_rows - 2;    vy1 = -vy1; }
+
+            frame++;
+            if (frame % 240u == 0u) {
+                sys_tty_clear(VGA_CLR(7, VGA_BLACK));
+                vx0 = pick_velocity(3); vy0 = pick_velocity(2);
+                vx1 = pick_velocity(2); vy1 = pick_velocity(3);
+            }
+            next = now + 2;
+        }
+        sys_yield();
+    }
+    return 0;
+}
+
+int main(int argc, char **argv, char **envp)
+{
+    (void)argc; (void)argv; (void)envp;
+
+    if (sys_fcntl(0, F_SETFL, O_NONBLOCK) != 0) return 1;
+    s_rng = sys_uptime() * 2654435761u + 1u;
+
+    unsigned int info = sys_fb_info();
+    if (info != 0u) {
+        s_px_w = (int)((info >> 16) & 0xFFFFu);
+        s_px_h = (int)( info        & 0xFFFFu);
+        /* Reserve one character row at the bottom for the status bar;
+         * the kernel-side draw clip uses the same carve-out so this
+         * is belt-and-braces but keeps endpoint motion in-bounds. */
+        if (s_px_h > 24) s_px_h -= 24;
+        run_pixel_mode();
+    } else {
+        run_cell_mode();
+    }
+
+    sys_fcntl(0, F_SETFL, 0);
+    return 0;
+}

--- a/src/userspace/maktop.c
+++ b/src/userspace/maktop.c
@@ -757,11 +757,8 @@ int main(int argc, char **argv, char **envp)
     }
 
     sys_fcntl(0, F_SETFL, 0);
-    /* Restore the shell's default palette (same code path as the
-     * `clear` shell builtin and what vix uses on exit).  Our
-     * sys_tty_clear with our own bg colour leaves the screen black,
-     * which doesn't match the operator's expectation of returning to
-     * the shell colours. */
-    sys_shell_clear();
+    /* VT-layer responsibility: the shell's post-fullscreen restore path
+     * reapplies the per-VT palette and wipes the backing grid.  Apps no
+     * longer reach into VT state on exit. */
     return 0;
 }

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -30,6 +30,8 @@
 #define SYS_SHELL_CLEAR  213
 #define SYS_UPTIME       214
 #define SYS_GETCWD       215
+#define SYS_FB_INFO      216
+#define SYS_DRAW_LINE    217
 #define SYS_FCNTL        55
 
 /* fcntl cmds */
@@ -214,6 +216,25 @@ static inline unsigned int sys_uptime(void)
 static inline int sys_getcwd(char *buf, unsigned int size)
 {
     return (int)syscall2(SYS_GETCWD, (long)buf, (long)size);
+}
+
+/* Query pixel-mode framebuffer geometry.  Returns (width << 16) | height
+ * when VESA is up, 0 when VGA-only (graphical apps fall back to cell mode). */
+static inline unsigned int sys_fb_info(void)
+{
+    return (unsigned int)syscall1(SYS_FB_INFO, 0);
+}
+
+static inline unsigned int sys_fb_width(void)  { return (sys_fb_info() >> 16) & 0xFFFFu; }
+static inline unsigned int sys_fb_height(void) { return  sys_fb_info()        & 0xFFFFu; }
+
+/* Bresenham line in framebuffer pixels.  Clipped to the drawable area
+ * (status row excluded).  Returns 0 on success, -1 when no FB. */
+static inline int sys_draw_line(int x0, int y0, int x1, int y1, unsigned int rgb)
+{
+    unsigned int xy0 = ((unsigned int)(x0 & 0xFFFF) << 16) | (unsigned int)(y0 & 0xFFFF);
+    unsigned int xy1 = ((unsigned int)(x1 & 0xFFFF) << 16) | (unsigned int)(y1 & 0xFFFF);
+    return (int)syscall3(SYS_DRAW_LINE, (long)xy0, (long)xy1, (long)rgb);
 }
 
 static inline int sys_open(const char *path, int flags)

--- a/src/userspace/vix.c
+++ b/src/userspace/vix.c
@@ -20,7 +20,8 @@
 #define VIX_CLR_TEXT    VGA_CLR(VGA_LGREY,    VGA_BLACK)
 #define VIX_CLR_STATUS  VGA_CLR(VGA_BLACK,    VGA_LGREY)
 #define VIX_CLR_WARN    VGA_CLR(VGA_LRED,     VGA_BLACK)
-#define VIX_SHELL_CLR   VGA_CLR(VGA_WHITE,    VGA_BLUE)
+/* VIX_SHELL_CLR removed: vix no longer owns the post-exit palette.
+ * shell_restore_screen reapplies the per-VT scheme. */
 
 /* Editor state */
 static char v_lines[VIX_MAX_LINES][VIX_LINE_CAP + 1];
@@ -359,7 +360,8 @@ int main(int argc, char **argv)
         if (c >= ' ' && c <= '~') { vix_insert_char((char)c); continue; }
     }
 
-    /* Restore shell colour scheme. */
-    sys_tty_clear(VIX_SHELL_CLR);
+    /* VT-layer responsibility: shell_restore_screen reapplies the
+     * per-VT palette + wipes the backing grid after a fullscreen
+     * command returns. */
     return 0;
 }

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -17,6 +17,16 @@ HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=tests/ui_runner.sh
 . "$HERE/ui_runner.sh"
 
+# Pull the kernel version from its single source of truth so the
+# glob-proc assertion (and anything else that needs to recognise the
+# /proc/uname banner) stays in sync with the kernel automatically.
+VERSION_H="$HERE/../src/kernel/include/kernel/version.h"
+MAKAR_VERSION=$(awk -F\" '/define[[:space:]]+MAKAR_VERSION/ { print $2; exit }' "$VERSION_H")
+if [ -z "$MAKAR_VERSION" ]; then
+    echo "ui_test.sh: could not extract MAKAR_VERSION from $VERSION_H" >&2
+    exit 1
+fi
+
 # --- Tests ------------------------------------------------------------------
 
 test_glob_proc() {
@@ -33,7 +43,7 @@ sendkey c
 sendkey slash
 sendkey shift-8
 sendkey ret"
-    assert_serial_contains "vendor_id" "MemFree" "Makar 0.5.0"
+    assert_serial_contains "vendor_id" "MemFree" "Makar $MAKAR_VERSION"
 }
 
 test_tab_path() {
@@ -792,9 +802,229 @@ sendkey ret" \
         "demo complete"
 }
 
+test_bughunt_clock_exit_palette() {
+    # Bug-hunt: after clock.elf exits, the shell prompt should reappear on
+    # the current VT's palette (VT0 -- green on black), not white-on-blue.
+    # We snapshot at three points: (a) clock running, (b) immediately after
+    # 'q', (c) after running 'pwd' on the restored prompt.
+    CURRENT_NAME=bughunt-clock-exit
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey c
+sendkey l
+sendkey o
+sendkey c
+sendkey k
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    sleep 1.5
+    echo "screendump $LOGDIR/$CURRENT_NAME.running.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey q'
+    sleep 0.8
+    echo "screendump $LOGDIR/$CURRENT_NAME.exited.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    sleep 0.6
+    echo "screendump $LOGDIR/$CURRENT_NAME.after-pwd.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey l
+sendkey s
+sendkey ret'
+    sleep 0.6
+    echo "screendump $LOGDIR/$CURRENT_NAME.after-ls.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+    assert_serial_contains "[makbox:pwd]"
+}
+
+test_bughunt_vix_exit_palette() {
+    # Bug-hunt: vix exit should land back on the VT's palette (green/black
+    # on VT0), not white-on-blue (the loading-screen palette).
+    CURRENT_NAME=bughunt-vix-exit
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey v
+sendkey i
+sendkey x
+sendkey spc
+sendkey slash
+sendkey t
+sendkey m
+sendkey p
+sendkey ret'
+    sleep 1.5
+    echo "screendump $LOGDIR/$CURRENT_NAME.running.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    # Ctrl-Q to quit (no edits, so single press suffices).
+    send_script 'sendkey ctrl-q'
+    sleep 0.8
+    echo "screendump $LOGDIR/$CURRENT_NAME.exited.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    sleep 0.6
+    echo "screendump $LOGDIR/$CURRENT_NAME.after-pwd.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+    assert_serial_contains "[makbox:pwd]"
+}
+
+test_bughunt_vix_palette_on_vt3() {
+    # VT3's scheme is black-on-white -- the inverse of the (legacy)
+    # hardcoded post-vix scheme.  After vix exits on VT3 the prompt
+    # must come back black-on-white, not white-on-blue.  Confirms the
+    # palette restoration is genuinely per-VT, not a VT0-only special
+    # case.
+    CURRENT_NAME=bughunt-vix-palette-vt3
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script 'sendkey alt-f4'
+    sleep 0.8
+    send_script 'sendkey v
+sendkey i
+sendkey x
+sendkey spc
+sendkey slash
+sendkey t
+sendkey m
+sendkey p
+sendkey ret'
+    sleep 1.5
+    echo "screendump $LOGDIR/$CURRENT_NAME.running.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    send_script 'sendkey ctrl-q'
+    sleep 0.8
+    echo "screendump $LOGDIR/$CURRENT_NAME.exited.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+    # No serial assertion -- pure visual check on the palette.
+}
+
+test_bughunt_status_bar_after_switch() {
+    # Bug-hunt: switching INTO a VT running a fullscreen ELF (maktop) should
+    # update the status bar so the active-VT highlight matches the new VT.
+    # Currently the highlight stays on the previous VT because
+    # vtty_drain_pending only runs in keyboard_getchar (blocking read), and
+    # maktop uses non-blocking reads via keyboard_poll.
+    CURRENT_NAME=bughunt-status-bar
+    reset_shell
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    # Launch maktop on VT0.
+    send_script 'sendkey e
+sendkey x
+sendkey e
+sendkey c
+sendkey spc
+sendkey slash
+sendkey c
+sendkey d
+sendkey r
+sendkey o
+sendkey m
+sendkey slash
+sendkey a
+sendkey p
+sendkey p
+sendkey s
+sendkey slash
+sendkey m
+sendkey a
+sendkey k
+sendkey t
+sendkey o
+sendkey p
+sendkey dot
+sendkey e
+sendkey l
+sendkey f
+sendkey ret'
+    sleep 1.2
+    # Alt+F2 (shell on VT1), Alt+F1 back to maktop on VT0.
+    send_script 'sendkey alt-f2'
+    sleep 0.6
+    send_script 'sendkey alt-f1'
+    sleep 1.2
+    echo "screendump $LOGDIR/$CURRENT_NAME.vt0-maktop.ppm" \
+        | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    # Tear down: 'q' to maktop.
+    send_script 'sendkey q'
+    sleep 0.6
+    send_script 'sendkey p
+sendkey w
+sendkey d
+sendkey ret'
+    sleep 0.8
+
+    CURRENT_SEGMENT=$LOGDIR/$CURRENT_NAME.serial
+    CURRENT_DUMP=$LOGDIR/$CURRENT_NAME.ppm
+    CURRENT_FAILED=0
+    rm -f "$CURRENT_SEGMENT" "$CURRENT_DUMP"
+    echo "screendump $CURRENT_DUMP" | nc -U "$MONITOR_SOCK" >/dev/null
+    sleep 0.2
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$CURRENT_SEGMENT"
+    assert_serial_contains "[makbox:pwd]"
+}
+
 # --- Driver -----------------------------------------------------------------
 
-ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd shell_scripting_vars demo_script)
+ALL_TESTS=(glob_proc tab_path exec_hello cd_root per_tty_cwd calc_brackets ctrlc_kills_child no_dead_in_proctasks typo_doesnt_clear vt_roundtrip_keeps_maktop_focused vt_all_roundtrips user_sigusr1_handler makbox_pwd shell_scripting_vars demo_script bughunt_clock_exit_palette bughunt_vix_exit_palette bughunt_status_bar_after_switch)
 
 declare -a TO_RUN
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary

Started as a three-bug hunt; grew into a full pass on VT-layer ownership of palette + scrollback state, a new pixel-drawing syscall pair, a C64-style easter egg, version cleanups, and a deep-dive internals doc.

### Bug fixes (the original scope)

- **Post-fullscreen screen clears every command** — `task_t.fb_touched` leaked across DEAD-slot reclaim in `task_create`; next line-mode child inherited it and `shell_exec_elf` cleared the buffer every dispatch. Fixed by zeroing `fb_touched` alongside `kticks`/`unkillable` in the reclaim path (Linux `dup_task_struct`-style).
- **Status bar stale when switching to a VT running maktop/clock** — `vtty_drain_pending` ran only inside `keyboard_getchar`; `O_NONBLOCK` stdin apps hit `keyboard_poll` instead. Drain now runs at the top of `keyboard_poll` too.
- **VIX exit reverted to white-on-blue** — kernel-builtin vix hardcoded its post-exit palette. Moved palette restoration into `shell_restore_screen` (the VT layer owns it). Removed app-side `sys_shell_clear`/`sys_tty_clear` exit calls from kernel `vix.c` and `userspace/{vix,clock,maktop}.c`.

### VT layer takes ownership of palette + scrollback

- `shell_print_prompt` reasserts the per-VT colour scheme on every REPL turn. `terminal_color` is global VGA state; any error path, builtin, or cross-VT switch that mutated it would otherwise bleed into the next user-visible line. This caught the "blue-and-white scheme bleeding through after `lines`" symptom — the actual culprit was the hardcoded `t_setcolor(SHELL_COLOR_VGA)` (medli white-on-blue) restore in the `!!` and Unknown-command error paths; removed.
- `shell_exec_elf` snapshots the focused VT's backing grid (cells + cursor + fg/bg) **before** spawning the child, then on exit overwrites the cells from the snapshot instead of `shell_clear_screen()`. `paint_buf` renders the snapshot back over the FB. Same idea as xterm's `smcup`/`rmcup` or Linux's console save/restore around curses apps. Falls back to the old clear-screen behaviour only when the alloc fails or geometry changed mid-exec (e.g., `setmode` while a child runs).

### New pixel-drawing syscalls + lines.elf

- `SYS_FB_INFO(216)` reports framebuffer geometry as `(width<<16)|height`, 0 when VGA-only.
- `SYS_DRAW_LINE(217)` walks Bresenham through `vesa_put_pixel`, clipped to the drawable area (status row excluded — same carve-out `SYS_TERM_SIZE` uses, just in pixels). Sets `fb_touched`.
- `lines.elf` — C64/BASIC-style spirograph easter egg. Pixel-perfect 24-bit-RGB endpoints bouncing off the edges in pixel mode; falls back to character-cell Bresenham with cycling VGA palette in VGA-only mode. Quits on `q`/`Q`/`F10`/Ctrl+C and the new scrollback-snapshot path means exit drops you back into your shell history with no debris.

### Version cleanup

- `MAKAR_VERSION` stays at 0.6.0; `SHELL_VERSION` bumped to 0.2.0 (per the long-standing comment in `shell_priv.h`: the shell is conceptually a separate component).
- README/docs refreshed; `docs/kernel/procfs.md` example de-hardcoded to `<MAKAR_VERSION>`.
- `tests/ui_test.sh` extracts `MAKAR_VERSION` from `include/kernel/version.h` at startup so the `glob-proc` assertion never bit-rots on a bump.

### Docs

- New `docs/internals.md`: CPU state at the Multiboot 2 handoff, descriptor-table choices, paging (the exact CR4.PSE → CR3 → CR0.PG order and why getting it wrong dies on real hardware), per-task VMM with the kernel-PDE-mirroring tradeoff, TLB management (CR3 reload as full flush, `invlpg` only when the PD is current, what breaks on a hypothetical SMP port), the first-fit heap, the scheduler and its `in_schedule` re-entrancy guard, ring-3 entry, the `int 0x80` ABI, the PIC remap.
- Closing section: the road to fork/POSIX/libc — CoW mechanics with reserved PTE bits + a refcounted frame allocator, `vfork` vs `posix_spawn` and why ship spawn first to unblock dash, signal inheritance under fork, the musl syscall gap-list in priority order, why dash before bash, tcc as the CP/M-style demo target.

## Test plan

- [x] `./run.sh iso build` — clean build
- [x] `tests/ui_test.sh glob-proc` — PASS (version assertion now version-h-driven)
- [x] `bughunt_clock_exit_palette` — VT0 green/black preserved across post-clock commands
- [x] `bughunt_vix_exit_palette` — VT0 green/black after kernel-vix exit, no blue bleed
- [x] `bughunt_status_bar_after_switch` — VT0 highlighted yellow while maktop runs on it
- [x] `bughunt_vix_palette_on_vt3` — VT3 black/white after vix exit, VT3 highlighted
- [x] `lines` headless smoke: pixel-mode spirograph during; Ctrl+C drops back to prior scrollback, no pixel debris, VT0 palette intact
- [x] setmode-error + Unknown-command bleed repro — both now render in VT0 palette, no white-on-blue
- [x] Manual graphical: `./run.sh iso boot`, run `lines`/`clock`/`vix`, Alt+F1..F4 round-trip