### PR TITLE
Add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ name: Release
 #   makar-hdd.img  – installed HDD image (MBR + FAT32 + GRUB 2)
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for releases. It enables manual triggering of the release workflow using the `workflow_dispatch` event.