### PR TITLE
userspace apps self-hosting

### DIFF
--- a/src/kernel/arch/i386/fs/tmpfs.c
+++ b/src/kernel/arch/i386/fs/tmpfs.c
@@ -1,8 +1,8 @@
 /*
  * tmpfs.c - synthetic, writable /tmp directory.  See kernel/tmpfs.h.
  *
- * Flat table of in-RAM scratch files.  Each file is lazily allocated
- * from the kernel heap on first write; later writes overwrite the
+ * Flat in-RAM scratch directory.  File records and payload buffers are
+ * allocated from the kernel heap on demand; later writes overwrite the
  * buffer wholesale (no ring, unlike logfs).  The intended consumer is
  * tcc(1) producing an ELF in /tmp before the shell `exec`s it.
  */
@@ -13,19 +13,18 @@
 #include <string.h>
 #include <stddef.h>
 
-#define TMPFS_MAX_FILES   16
 #define TMPFS_NAME_MAX    64
-#define TMPFS_FILE_CAP    (512u * 1024u)   /* 512 KiB per file -- ample for hello.elf */
+#define TMPFS_FILE_MAX    (16u * 1024u * 1024u)
 
-typedef struct {
+typedef struct tmpfile {
     char     name[TMPFS_NAME_MAX];
     char    *buf;
     uint32_t cap;
     uint32_t len;
-    int      in_use;
+    struct tmpfile *next;
 } tmpfile_t;
 
-static tmpfile_t s_files[TMPFS_MAX_FILES];
+static tmpfile_t *s_files;
 
 /* Strip the leading '/' from a tmpfs-relative path, rejecting deeper paths
  * (/tmp is flat).  Returns the bare name, or NULL for "/" / malformed. */
@@ -41,34 +40,29 @@ static const char *leaf_name(const char *path)
 /* Find an existing file by bare name. */
 static tmpfile_t *find(const char *name)
 {
-    for (int i = 0; i < TMPFS_MAX_FILES; i++)
-        if (s_files[i].in_use && strcmp(s_files[i].name, name) == 0)
-            return &s_files[i];
+    for (tmpfile_t *f = s_files; f; f = f->next)
+        if (strcmp(f->name, name) == 0) return f;
     return NULL;
 }
 
-/* Find or lazily create a heap-backed file by bare name.  Returns NULL
- * if the name is too long, the table is full, or the heap allocation
- * fails. */
+/* Find or lazily create a heap-backed file record by bare name.  Returns
+ * NULL if the name is too long or the heap allocation fails. */
 static tmpfile_t *find_or_create(const char *name)
 {
     tmpfile_t *f = find(name);
     if (f) return f;
     if (strlen(name) >= TMPFS_NAME_MAX) return NULL;
 
-    for (int i = 0; i < TMPFS_MAX_FILES; i++) {
-        if (s_files[i].in_use) continue;
-        char *buf = (char *)kmalloc(TMPFS_FILE_CAP);
-        if (!buf) return NULL;
-        strncpy(s_files[i].name, name, TMPFS_NAME_MAX - 1);
-        s_files[i].name[TMPFS_NAME_MAX - 1] = '\0';
-        s_files[i].buf    = buf;
-        s_files[i].cap    = TMPFS_FILE_CAP;
-        s_files[i].len    = 0;
-        s_files[i].in_use = 1;
-        return &s_files[i];
-    }
-    return NULL;   /* table full */
+    f = (tmpfile_t *)kmalloc(sizeof(tmpfile_t));
+    if (!f) return NULL;
+    strncpy(f->name, name, TMPFS_NAME_MAX - 1);
+    f->name[TMPFS_NAME_MAX - 1] = '\0';
+    f->buf  = NULL;
+    f->cap  = 0;
+    f->len  = 0;
+    f->next = s_files;
+    s_files = f;
+    return f;
 }
 
 /* -------------------------------------------------------------------------
@@ -94,7 +88,13 @@ long tmpfs_write(const char *path, const void *buf, uint32_t len)
     if (!name) return -1;
     tmpfile_t *f = find_or_create(name);
     if (!f) return -1;
-    if (len > f->cap) return -1;       /* refuse oversized write */
+    if (len > TMPFS_FILE_MAX) return -1;       /* refuse oversized write */
+    if (len > f->cap) {
+        char *newbuf = (char *)krealloc(f->buf, len);
+        if (!newbuf) return -1;
+        f->buf = newbuf;
+        f->cap = len;
+    }
     if (len > 0 && buf)
         memcpy(f->buf, buf, len);
     f->len = len;
@@ -117,9 +117,8 @@ int tmpfs_ls(const char *path)
                                               : ": No such entry\n");
         return -1;
     }
-    for (int i = 0; i < TMPFS_MAX_FILES; i++) {
-        if (!s_files[i].in_use) continue;
-        t_writestring(s_files[i].name);
+    for (tmpfile_t *f = s_files; f; f = f->next) {
+        t_writestring(f->name);
         t_putchar('\n');
     }
     return 0;
@@ -131,10 +130,9 @@ int tmpfs_complete(const char *dir, const char *prefix,
     (void)dir;   /* /tmp is flat; dir is always "/tmp" */
     if (!cb) return -1;
     size_t plen = prefix ? strlen(prefix) : 0;
-    for (int i = 0; i < TMPFS_MAX_FILES; i++) {
-        if (!s_files[i].in_use) continue;
-        if (plen == 0 || strncmp(s_files[i].name, prefix, plen) == 0)
-            cb(s_files[i].name, 0, ctx);
+    for (tmpfile_t *f = s_files; f; f = f->next) {
+        if (plen == 0 || strncmp(f->name, prefix, plen) == 0)
+            cb(f->name, 0, ctx);
     }
     return 0;
 }
@@ -150,13 +148,14 @@ long tmpfs_size(const char *path)
 int tmpfs_delete(const char *path)
 {
     const char *name = leaf_name(path);
-    tmpfile_t  *f    = name ? find(name) : NULL;
-    if (!f) return -1;
+    if (!name) return -1;
+    tmpfile_t **link = &s_files;
+    while (*link && strcmp((*link)->name, name) != 0)
+        link = &(*link)->next;
+    if (!*link) return -1;
+    tmpfile_t *f = *link;
+    *link = f->next;
     kfree(f->buf);
-    f->buf    = NULL;
-    f->cap    = 0;
-    f->len    = 0;
-    f->name[0] = '\0';
-    f->in_use = 0;
+    kfree(f);
     return 0;
 }

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -890,6 +890,33 @@ const char *vfs_hd_fsname(const char *name)
     return (mi >= 0) ? backend_name(s_mounts[mi].backend) : "none";
 }
 
+void vfs_print_mounts(void)
+{
+    int any = 0;
+    for (int i = 0; i < s_nmounts; i++) {
+        vfs_mount_t *m = &s_mounts[i];
+        if (m->backend == VFS_BACKEND_NONE) continue;
+
+        any = 1;
+        t_writestring(m->mountpoint);
+        t_writestring(" type ");
+        t_writestring(backend_name(m->backend));
+        if (m->backend == VFS_BACKEND_EXT2 ||
+            m->backend == VFS_BACKEND_FAT32 ||
+            m->backend == VFS_BACKEND_ISO9660) {
+            t_writestring(" drive ");
+            t_dec(m->drive);
+            if (m->backend != VFS_BACKEND_ISO9660) {
+                t_writestring(" lba ");
+                t_dec(m->lba);
+            }
+        }
+        t_putchar('\n');
+    }
+    if (!any)
+        t_writestring("(no mounted filesystems)\n");
+}
+
 void vfs_prepare_shutdown(void)
 {
     /* Flush every HD-backed mount on the way down. */

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -292,6 +292,22 @@ static void test_tmpfs(void)
     KTEST_ASSERT(vfs_delete_file("/tmp/probe.bin") == 0);
     KTEST_ASSERT(vfs_file_exists("/tmp/probe.bin") == 0);
 
+    /* Dynamic file records: more than the historical 16-slot table should
+     * work, and deleting them should release the records again. */
+    char path[] = "/tmp/many-00.tmp";
+    for (int i = 0; i < 24; i++) {
+        path[10] = (char)('0' + (i / 10));
+        path[11] = (char)('0' + (i % 10));
+        KTEST_ASSERT(vfs_write_file(path, "x", 1) == 0);
+        KTEST_ASSERT(vfs_file_exists(path) == 1);
+    }
+    for (int i = 0; i < 24; i++) {
+        path[10] = (char)('0' + (i / 10));
+        path[11] = (char)('0' + (i % 10));
+        KTEST_ASSERT(vfs_delete_file(path) == 0);
+        KTEST_ASSERT(vfs_file_exists(path) == 0);
+    }
+
     ktest_summary();
 }
 

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -37,6 +37,19 @@ static char s_history[SHELL_HISTORY_SIZE][SHELL_MAX_INPUT];
 static int  s_hist_count = 0;  /* valid entries (capped at SHELL_HISTORY_SIZE) */
 static int  s_hist_head  = 0;  /* index of the next write slot                 */
 
+int shell_cancel_requested(void)
+{
+    if (!sig_check_and_clear(SIGINT))
+        return 0;
+
+    /* Ctrl-C is also routed as a byte for readline/raw-mode consumers.
+     * Built-ins do not read stdin while they run, so drain the matching
+     * byte now; otherwise the next prompt would immediately see ^C. */
+    while (keyboard_poll()) {}
+    t_writestring("^C\n");
+    return 1;
+}
+
 static void history_push(const char *line)
 {
     if (!line || !*line)

--- a/src/kernel/arch/i386/shell/shell_cmd_fs.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_fs.c
@@ -40,8 +40,13 @@ static const char *mountpoint_name(const char *mp)
  * was retired with the /mnt/hd slot. */
 static void cmd_mount(int argc, char **argv)
 {
+    if (argc == 1) {
+        vfs_print_mounts();
+        return;
+    }
+
     if (argc < 3 || strncmp(argv[1], "/dev/", 5) != 0) {
-        t_writestring("Usage: mount /dev/hdaN /mnt/<name>\n");
+        t_writestring("Usage: mount [ /dev/hdaN /mnt/<name> ]\n");
         return;
     }
 

--- a/src/kernel/arch/i386/shell/shell_cmd_man.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_man.c
@@ -115,8 +115,9 @@ static const man_entry_t man_table[] = {
     },
     { "mount",
       "bind a FAT32 or ext2 volume at /mnt/<name>",
-      "Usage: mount /dev/hdaN /mnt/<name>\n\n"
-      "Binds the named device to an empty mountpoint.  Create the mountpoint\n"
+      "Usage: mount [ /dev/hdaN /mnt/<name> ]\n\n"
+      "With no arguments, lists mounted/in-use VFS mountpoints.\n"
+      "With arguments, binds the named device to an empty mountpoint.  Create the mountpoint\n"
       "first with `mkdir /mnt/<name>` (the legacy numeric form and the /mnt/hd\n"
       "default were retired in favour of explicit, Linux-style mountpoints).\n"
     },
@@ -240,11 +241,15 @@ void cmd_lsman(int argc, char **argv)
     t_writestring("-------         -----------\n");
 
     for (int k = 0; man_table[k].name; k++) {
+        if (shell_cancel_requested())
+            return;
         t_writestring("  ");
         print_padded(man_table[k].name, COL);
         t_writestring(man_table[k].brief);
         t_putchar('\n');
     }
+    if (shell_cancel_requested())
+        return;
     t_putchar('\n');
     t_writestring("Run 'man <cmd>' for full details.\n");
 }

--- a/src/kernel/arch/i386/shell/shell_priv.h
+++ b/src/kernel/arch/i386/shell/shell_priv.h
@@ -105,6 +105,7 @@ extern const shell_cmd_entry_t script_cmds[];
 void shell_readline(char *buf, size_t max);
 int  shell_parse(char *line, char **argv, int max_args);
 int  shell_dispatch_argv(int argc, char **argv);
+int  shell_cancel_requested(void);
 
 /* shell_glob.c – wildcard (* and ?) expansion of argv tokens via VFS. */
 int  shell_expand_globs(int argc, char **argv, int argv_cap,

--- a/src/kernel/include/kernel/tmpfs.h
+++ b/src/kernel/include/kernel/tmpfs.h
@@ -6,8 +6,10 @@
  *
  * /tmp is a scratch ramdisk for programs that need a writable filesystem
  * without first having to mkfs+mount a real disk.  Cousins of logfs:
- * same flat per-name table, same lazy heap allocation on first write,
+ * same flat namespace, heap-backed file records created on first write,
  * but with OVERWRITE semantics instead of logfs's append-only ring.
+ * There is no fixed file-table limit; available kernel heap is the real
+ * limit, with a per-file guard to keep one write from consuming all RAM.
  * That makes it suitable as a tcc(1) output sink: a successive
  * sys_open(O_TRUNC) + sys_write loop replaces the file rather than
  * tacking on the end of the previous run.
@@ -29,7 +31,7 @@
 long tmpfs_read(const char *path, void *buf, uint32_t bufsz, uint32_t *out_sz);
 
 /* Replace the contents of a tmpfs file (creating it on first write).
- * Returns the byte count written, or -1 on bad path / table full /
+ * Returns the byte count written, or -1 on bad path / oversize write /
  * OOM.  Unlike logfs_write this overwrites - there is no ring. */
 long tmpfs_write(const char *path, const void *buf, uint32_t len);
 

--- a/src/kernel/include/kernel/vfs.h
+++ b/src/kernel/include/kernel/vfs.h
@@ -114,6 +114,7 @@ int         vfs_mount_hd(uint8_t drive, uint32_t lba, const char *name, int *out
 int         vfs_umount_hd(const char *name);
 int         vfs_hd_mounted(void);
 const char *vfs_hd_fsname(const char *name);
+void        vfs_print_mounts(void);
 
 /* Empty-mountpoint management (Linux-style: a mountpoint is a directory under
  * /mnt that `mount` later binds a filesystem into).

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -23,7 +23,7 @@ PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf s
 # OS image so tcc(1) can link against it as -lc.  The objects are also
 # linked individually into a few legacy app recipes (alloctest, filetest)
 # below to give the archive passive ui-test coverage.
-LIBC_OBJS=malloc.o stdio.o setjmp.o string.o tcc_compat.o dirent.o
+LIBC_OBJS=malloc.o stdio.o stdlib.o setjmp.o string.o tcc_compat.o dirent.o
 
 # tcc.elf is only built when the vendored snapshot at vendor/tinycc/ is
 # populated (see build-tcc.sh).  The artefact lands here at the top of
@@ -32,7 +32,7 @@ TCC_ELF=$(wildcard tcc.elf)
 
 # Headers shipped to /usr/include on the OS image so userland (and
 # tcc-compiled programs) can resolve `#include <name.h>` directly.
-SYSROOT_HEADERS=malloc.h stdio.h stdlib.h ctype.h setjmp.h string.h syscall.h dirent.h errno.h
+SYSROOT_HEADERS=malloc.h stdio.h stdlib.h ctype.h setjmp.h string.h syscall.h dirent.h errno.h stdarg.h
 
 
 all: $(PROGS) libc.a

--- a/src/userspace/makbox.c
+++ b/src/userspace/makbox.c
@@ -87,7 +87,13 @@ static int cmd_cat(int argc, char **argv)
                 return 1;
             }
             if (n == 0) break;
-            sys_write(1, buf, (unsigned int)n);
+            for (long off = 0; off < n; ) {
+                long chunk = n - off;
+                if (chunk > 256) chunk = 256;
+                sys_write(1, (const char *)buf + off, (unsigned int)chunk);
+                off += chunk;
+                sys_yield();
+            }
         }
         sys_close(fd);
     }

--- a/src/userspace/stdarg.h
+++ b/src/userspace/stdarg.h
@@ -1,0 +1,20 @@
+/*
+ * stdarg.h -- tiny i386 varargs support for freestanding userspace.
+ *
+ * Makar's ring-3 ABI is i386 cdecl, so variadic arguments live on the
+ * caller stack and va_list is a byte pointer.
+ */
+#ifndef _USERSPACE_STDARG_H
+#define _USERSPACE_STDARG_H
+
+typedef char *va_list;
+
+#define va_start(ap, last) ((ap) = ((char *)&(last)) + ((sizeof(last) + 3u) & ~3u))
+#define va_arg(ap, type)   ((ap) += ((sizeof(type) + 3u) & ~3u), \
+                            *(type *)((ap) - ((sizeof(type) + 3u) & ~3u)))
+#define va_copy(dst, src)  ((dst) = (src))
+#define va_end(ap)         ((void)(ap))
+
+typedef va_list __gnuc_va_list;
+
+#endif /* _USERSPACE_STDARG_H */

--- a/src/userspace/stdio.c
+++ b/src/userspace/stdio.c
@@ -137,7 +137,7 @@ static void sb_num(sb_t *s, unsigned long v, unsigned int base,
     while (ti--) sb_put(s, tmp[ti]);
 }
 
-int vsnprintf(char *buf, unsigned int sz, const char *fmt, __builtin_va_list ap)
+int vsnprintf(char *buf, unsigned int sz, const char *fmt, va_list ap)
 {
     sb_t s = { buf, sz, 0 };
     for (const char *p = fmt; *p; p++) {
@@ -147,25 +147,25 @@ int vsnprintf(char *buf, unsigned int sz, const char *fmt, __builtin_va_list ap)
         if (*p == '0') { pad = '0'; p++; }
         while (*p >= '0' && *p <= '9') { width = width*10 + (*p - '0'); p++; }
         switch (*p) {
-        case 'c': sb_put(&s, (char)__builtin_va_arg(ap, int)); break;
+        case 'c': sb_put(&s, (char)va_arg(ap, int)); break;
         case 's': {
-            const char *str = __builtin_va_arg(ap, const char *);
+            const char *str = va_arg(ap, const char *);
             if (!str) str = "(null)";
             int len = 0; while (str[len]) len++;
             while (len < width) { sb_put(&s, pad); len++; }
             sb_str(&s, str); break;
         }
         case 'd': case 'i': {
-            int v = __builtin_va_arg(ap, int);
+            int v = va_arg(ap, int);
             unsigned long uv = (v < 0) ? (unsigned long)(-(long)v) : (unsigned long)v;
             sb_num(&s, uv, 10, 0, v < 0, width, pad);
             break;
         }
-        case 'u': sb_num(&s, __builtin_va_arg(ap, unsigned int), 10, 0, 0, width, pad); break;
-        case 'x': sb_num(&s, __builtin_va_arg(ap, unsigned int), 16, 0, 0, width, pad); break;
-        case 'X': sb_num(&s, __builtin_va_arg(ap, unsigned int), 16, 1, 0, width, pad); break;
+        case 'u': sb_num(&s, va_arg(ap, unsigned int), 10, 0, 0, width, pad); break;
+        case 'x': sb_num(&s, va_arg(ap, unsigned int), 16, 0, 0, width, pad); break;
+        case 'X': sb_num(&s, va_arg(ap, unsigned int), 16, 1, 0, width, pad); break;
         case 'p': sb_put(&s,'0'); sb_put(&s,'x');
-                  sb_num(&s, (unsigned long)(unsigned int)__builtin_va_arg(ap, void *), 16, 0, 0, 8, '0'); break;
+                  sb_num(&s, (unsigned long)(unsigned int)va_arg(ap, void *), 16, 0, 0, 8, '0'); break;
         case '%': sb_put(&s, '%'); break;
         default:  sb_put(&s, '%'); sb_put(&s, *p); break;
         }
@@ -176,18 +176,18 @@ int vsnprintf(char *buf, unsigned int sz, const char *fmt, __builtin_va_list ap)
 
 int snprintf(char *buf, unsigned int sz, const char *fmt, ...)
 {
-    __builtin_va_list ap; __builtin_va_start(ap, fmt);
+    va_list ap; va_start(ap, fmt);
     int n = vsnprintf(buf, sz, fmt, ap);
-    __builtin_va_end(ap);
+    va_end(ap);
     return n;
 }
 
 int fprintf(FILE *f, const char *fmt, ...)
 {
     static char scratch[2048];
-    __builtin_va_list ap; __builtin_va_start(ap, fmt);
+    va_list ap; va_start(ap, fmt);
     int n = vsnprintf(scratch, sizeof(scratch), fmt, ap);
-    __builtin_va_end(ap);
+    va_end(ap);
     fwrite(scratch, 1, (unsigned int)n, f);
     return n;
 }
@@ -195,9 +195,9 @@ int fprintf(FILE *f, const char *fmt, ...)
 int printf(const char *fmt, ...)
 {
     static char scratch[2048];
-    __builtin_va_list ap; __builtin_va_start(ap, fmt);
+    va_list ap; va_start(ap, fmt);
     int n = vsnprintf(scratch, sizeof(scratch), fmt, ap);
-    __builtin_va_end(ap);
+    va_end(ap);
     fwrite(scratch, 1, (unsigned int)n, stdout);
     return n;
 }

--- a/src/userspace/stdio.h
+++ b/src/userspace/stdio.h
@@ -11,6 +11,7 @@
 #define _USERSPACE_STDIO_H
 
 #include "syscall.h"
+#include "stdarg.h"
 
 #define STDIO_BUFSZ 1024
 
@@ -37,7 +38,7 @@ int   feof  (FILE *f);
 /* Format helpers.  Supported conversions: %s %c %d %i %u %x %X %p %%
  * and the field-width prefix (e.g. %5d, %08x).  No floats (no FPU). */
 int snprintf (char *buf, unsigned int sz, const char *fmt, ...);
-int vsnprintf(char *buf, unsigned int sz, const char *fmt, __builtin_va_list ap);
+int vsnprintf(char *buf, unsigned int sz, const char *fmt, va_list ap);
 int fprintf  (FILE *f, const char *fmt, ...);
 int printf   (const char *fmt, ...);
 

--- a/src/userspace/stdlib.c
+++ b/src/userspace/stdlib.c
@@ -1,0 +1,60 @@
+#include "stdlib.h"
+#include "stdarg.h"
+
+int sscanf(const char *s, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    int matched = 0;
+    while (*fmt) {
+        if (isspace((unsigned char)*fmt)) {
+            while (isspace((unsigned char)*s)) s++;
+            fmt++;
+            continue;
+        }
+        if (*fmt != '%') {
+            if (*s != *fmt) break;
+            s++;
+            fmt++;
+            continue;
+        }
+        fmt++;
+        int width = 0;
+        while (*fmt >= '0' && *fmt <= '9') {
+            width = width * 10 + (*fmt - '0');
+            fmt++;
+        }
+        if (*fmt == 'd' || *fmt == 'i' || *fmt == 'u' || *fmt == 'x') {
+            int base = (*fmt == 'x') ? 16 : 10;
+            while (isspace((unsigned char)*s)) s++;
+            char *end;
+            long v = strtol(s, &end, base);
+            if (end == s) break;
+            if (*fmt == 'u' || *fmt == 'x') *va_arg(ap, unsigned int *) = (unsigned int)v;
+            else                            *va_arg(ap, int *) = (int)v;
+            s = end;
+            matched++;
+            fmt++;
+        } else if (*fmt == 's') {
+            while (isspace((unsigned char)*s)) s++;
+            char *out = va_arg(ap, char *);
+            int wrote = 0;
+            while (*s && !isspace((unsigned char)*s) && (width == 0 || wrote < width))
+                out[wrote++] = *s++;
+            out[wrote] = '\0';
+            if (wrote == 0) break;
+            matched++;
+            fmt++;
+        } else if (*fmt == 'c') {
+            char *out = va_arg(ap, char *);
+            if (!*s) break;
+            *out = *s++;
+            matched++;
+            fmt++;
+        } else {
+            break;
+        }
+    }
+    va_end(ap);
+    return matched;
+}

--- a/src/userspace/stdlib.h
+++ b/src/userspace/stdlib.h
@@ -124,53 +124,7 @@ static inline void qsort(void *base, unsigned int nmemb, unsigned int sz,
     }
 }
 
-/* sscanf: tiny subset -- %d, %u, %x, %s, %c, optional width.  Returns
- * the number of successfully matched conversions (POSIX). */
-static inline int sscanf(const char *s, const char *fmt, ...)
-{
-    __builtin_va_list ap; __builtin_va_start(ap, fmt);
-    int matched = 0;
-    while (*fmt) {
-        if (isspace((unsigned char)*fmt)) {
-            while (isspace((unsigned char)*s)) s++;
-            fmt++; continue;
-        }
-        if (*fmt != '%') {
-            if (*s != *fmt) break;
-            s++; fmt++; continue;
-        }
-        fmt++;                  /* consume '%' */
-        int width = 0;
-        while (*fmt >= '0' && *fmt <= '9') { width = width*10 + (*fmt - '0'); fmt++; }
-        if (*fmt == 'd' || *fmt == 'i' || *fmt == 'u' || *fmt == 'x') {
-            int base = (*fmt == 'x') ? 16 : 10;
-            while (isspace((unsigned char)*s)) s++;
-            char *end;
-            long v = strtol(s, &end, base);
-            if (end == s) break;
-            if (*fmt == 'u' || *fmt == 'x') *__builtin_va_arg(ap, unsigned int *) = (unsigned int)v;
-            else                              *__builtin_va_arg(ap, int *)         = (int)v;
-            s = end; matched++; fmt++;
-        } else if (*fmt == 's') {
-            while (isspace((unsigned char)*s)) s++;
-            char *out = __builtin_va_arg(ap, char *);
-            int wrote = 0;
-            while (*s && !isspace((unsigned char)*s) && (width == 0 || wrote < width)) {
-                out[wrote++] = *s++;
-            }
-            out[wrote] = '\0';
-            if (wrote == 0) break;
-            matched++; fmt++;
-        } else if (*fmt == 'c') {
-            char *out = __builtin_va_arg(ap, char *);
-            if (!*s) break;
-            *out = *s++; matched++; fmt++;
-        } else {
-            break;              /* unknown conversion */
-        }
-    }
-    __builtin_va_end(ap);
-    return matched;
-}
+/* sscanf: tiny subset -- %d, %u, %x, %s, %c, optional width. */
+int sscanf(const char *s, const char *fmt, ...);
 
 #endif /* _USERSPACE_STDLIB_H */

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -141,6 +141,14 @@ sendkey ret"
     assert_serial_contains "root"
 }
 
+test_mount_noargs() {
+    it "mount-noargs" \
+"$(keys "mount")
+sendkey ret"
+    assert_serial_contains "/ type " "/dev type devfs" "/proc type procfs"
+    assert_serial_not_contains "Usage: mount"
+}
+
 test_calc_brackets() {
     # Full arithmetic exercise of calc.elf: every operator (+ - * / %),
     # BIDMAS/operator precedence, nested parentheses, and the
@@ -494,6 +502,22 @@ $(keys "pwd")
 sendkey ret" \
         2.0
     assert_serial_contains "[makbox:pwd]"
+}
+
+test_ctrlc_cat() {
+    # makbox cat installs a SIGINT handler and writes in small yielded
+    # chunks, so Ctrl+C should stop a large stream promptly and return the
+    # shell to an interactive prompt.
+    it "ctrlc-cat" \
+"$(keys "cat /log/kernel.log")
+sendkey ret
+PAUSE 0.2
+sendkey ctrl-c
+PAUSE 0.4
+$(keys "echo after-cat")
+sendkey ret" \
+        4.0
+    assert_serial_contains "status=130" "after-cat"
 }
 
 test_makbox_pwd() {
@@ -917,6 +941,261 @@ sendkey ret" \
     assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
 }
 
+TCC_COMPILE_FAILED=0
+
+tcc_compile_user_app() {
+    local app=$1
+    local timeout=${2:-90}
+
+    TCC_COMPILE_FAILED=0
+    reset_shell
+    CURRENT_NAME=tcc-rebuild-$app
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script "$(keys "tcc /src/userspace/$app.c -o /tmp/tcc-rebuilt.elf")
+sendkey ret"
+    if ! wait_for_serial '\[shell:ready vt=0\]' "$sb1" "$timeout"; then
+        echo "  - stage1: tcc compile of $app.c never returned to prompt"
+        TCC_COMPILE_FAILED=1
+    fi
+    local compile_segment=$LOGDIR/$CURRENT_NAME.compile.serial
+    dd if="$SERIAL_LOG" bs=1 skip="$sb1" 2>/dev/null > "$compile_segment"
+    if grep -qE -- '(^|[[:space:]])error:' "$compile_segment"; then
+        echo "  - stage1: tcc reported an error for $app.c"
+        awk 'BEGIN { RS=""; ORS="" } { gsub(/\r/, ""); gsub(/[ \t]+/, " "); print }' \
+            "$compile_segment" \
+            | awk -v max=800 '{
+                if (length($0) > max) print "  - compile: " substr($0, 1, max) " ...[truncated]"
+                else print "  - compile: " $0
+              }'
+        TCC_COMPILE_FAILED=1
+    fi
+}
+
+tcc_assert_compile_ok() {
+    if [ "$TCC_COMPILE_FAILED" != "0" ]; then
+        CURRENT_FAILED=1
+    fi
+}
+
+test_tcc_rebuild_help() {
+    tcc_compile_user_app help 60
+    it_until "tcc-rebuild-help" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        '\[shell:ready vt=0\]' 15
+    assert_serial_contains "vix <file>"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_diskinfo() {
+    tcc_compile_user_app diskinfo 60
+    it_until "tcc-rebuild-diskinfo" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        '\[shell:ready vt=0\]' 15
+    assert_serial_contains "drive 0: ATA"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_sigtest() {
+    tcc_compile_user_app sigtest 60
+    it_until "tcc-rebuild-sigtest" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        "sigtest: SIGUSR1 handler ran" 20
+    assert_serial_contains "sigtest: SIGUSR1 handler ran"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_forktest() {
+    tcc_compile_user_app forktest 60
+    it_until "tcc-rebuild-forktest" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        '\[forktest\] PARENT-POST' 20
+    assert_serial_contains "[forktest] PARENT-POST"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_execvetest() {
+    tcc_compile_user_app execvetest 60
+    it_until "tcc-rebuild-execvetest" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        '\[execve-test\] POST-EXEC' 20
+    assert_serial_contains "[execve-test] POST-EXEC"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_alloctest() {
+    tcc_compile_user_app alloctest 90
+    it_until "tcc-rebuild-alloctest" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret" \
+        '\[alloctest\] PASS' 30
+    assert_serial_contains "[alloctest] PASS"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_filetest() {
+    tcc_compile_user_app filetest 90
+    it_until "tcc-rebuild-filetest" \
+"$(keys "mkdir /mnt/scratch")
+sendkey ret
+$(keys "mkfs.ext2 /dev/hda")
+sendkey ret
+$(keys "mount /dev/hda /mnt/scratch")
+sendkey ret
+$(keys "exec /tmp/tcc-rebuilt.elf /mnt/scratch")
+sendkey ret" \
+        '\[filetest\] PASS' 60
+    assert_serial_contains \
+        "[filetest] dir=/mnt/scratch" \
+        "[filetest] create+write+close ok" \
+        "[filetest] reopen+fstat+read ok size=13" \
+        "[filetest] append+close ok" \
+        "[filetest] stat ok size=19" \
+        "[filetest] grow-256k ok" \
+        "[filetest] no-flush-on-rdonly ok" \
+        "[filetest] PASS"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_basic() {
+    tcc_compile_user_app basic 120
+    it_until "tcc-rebuild-basic" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret
+PAUSE 0.8
+$(keys "10 PRINT 2+3")
+sendkey ret
+$(keys "RUN")
+sendkey ret
+$(keys "QUIT")
+sendkey ret" \
+        "READY." 30
+    assert_serial_contains "Makar BASIC" "5" "READY."
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_fdisk() {
+    tcc_compile_user_app fdisk 90
+    it_until "tcc-rebuild-fdisk" \
+"$(keys "exec /tmp/tcc-rebuilt.elf /dev/hda")
+sendkey ret
+PAUSE 0.8
+$(keys "q")
+sendkey ret" \
+        "fdisk>" 20
+    assert_serial_contains "fdisk>"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_cfdisk() {
+    tcc_compile_user_app cfdisk 120
+    it_until "tcc-rebuild-cfdisk" \
+"$(keys "exec /tmp/tcc-rebuilt.elf /dev/hda")
+sendkey ret
+PAUSE 1.2
+sendkey q
+PAUSE 0.8
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 20
+    assert_serial_contains "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_maktop() {
+    tcc_compile_user_app maktop 120
+    it_until "tcc-rebuild-maktop" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret
+PAUSE 1.2
+sendkey q
+PAUSE 0.8
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 20
+    assert_serial_contains "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_clock() {
+    tcc_compile_user_app clock 90
+    it_until "tcc-rebuild-clock" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret
+PAUSE 1.2
+sendkey q
+PAUSE 0.8
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 20
+    assert_serial_contains "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_lines() {
+    tcc_compile_user_app lines 90
+    it_until "tcc-rebuild-lines" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret
+PAUSE 1.2
+sendkey q
+PAUSE 0.8
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 20
+    assert_serial_contains "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_vix() {
+    tcc_compile_user_app vix 120
+    it_until "tcc-rebuild-vix" \
+"$(keys "exec /tmp/tcc-rebuilt.elf /tmp/tcc-vix.txt")
+sendkey ret
+PAUSE 1.2
+sendkey ctrl-q
+PAUSE 0.8
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 20
+    assert_serial_contains "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
+test_tcc_rebuild_kbtester() {
+    tcc_compile_user_app kbtester 120
+    it_until "tcc-rebuild-kbtester" \
+"$(keys "exec /tmp/tcc-rebuilt.elf")
+sendkey ret
+PAUSE 1.2
+sendkey ctrl-c
+PAUSE 1.0
+$(keys "pwd")
+sendkey ret" \
+        '\[makbox:pwd\]' 30
+    assert_serial_contains "KBTESTER_BEGIN" "[makbox:pwd] /"
+    assert_serial_not_contains "Kernel panic" "panic(cpu 0)" "SIGSEGV"
+    tcc_assert_compile_ok
+}
+
 test_tcc_hello_relpath() {
     # cd into the examples dir then `tcc hello-tcc.c -o /tmp/relhello.elf`
     # exercises the kernel's path_resolve (cwd-join for relative inputs)
@@ -1212,11 +1491,19 @@ sendkey ret"
 
 SHELL_TESTS=(glob_proc tab_path tab_cycle typo_doesnt_clear shell_scripting_vars calc_brackets makbox_pwd demo_script)
 CD_PWD_TESTS=(cd_root per_tty_cwd)
-FS_TESTS=(ls_dev ls_mnt mnt_mountpoint filetest)
-POSIX_TESTS=(exec_hello fork_cow fork_execve user_sigusr1_handler ctrlc_kills_child usershell_smoke usershell_execve usershell_history usershell_vars)
-LIBC_TESTS=(tcc_hello tcc_hello_relpath tcc_rebuild_hello tcc_rebuild_calc tcc_rebuild_sh tcc_rebuild_makbox)
-# alloctest dropped from LIBC_TESTS -- now covered by the in-kernel
-# incore.sh driver (see test_incore), which exercises it via exec + $?
+FS_TESTS=(ls_dev ls_mnt mount_noargs mnt_mountpoint filetest)
+POSIX_TESTS=(exec_hello fork_cow fork_execve user_sigusr1_handler ctrlc_kills_child ctrlc_cat usershell_smoke usershell_execve usershell_history usershell_vars)
+TCC_REBUILD_TESTS=(
+    tcc_rebuild_hello tcc_rebuild_calc tcc_rebuild_sh tcc_rebuild_makbox
+    tcc_rebuild_help tcc_rebuild_diskinfo tcc_rebuild_sigtest
+    tcc_rebuild_forktest tcc_rebuild_execvetest tcc_rebuild_alloctest
+    tcc_rebuild_filetest tcc_rebuild_basic tcc_rebuild_fdisk
+    tcc_rebuild_cfdisk tcc_rebuild_maktop tcc_rebuild_clock
+    tcc_rebuild_lines tcc_rebuild_vix tcc_rebuild_kbtester
+)
+LIBC_TESTS=(tcc_hello tcc_hello_relpath "${TCC_REBUILD_TESTS[@]}")
+# alloctest still has the fast in-kernel incore.sh coverage; the TCC
+# rebuild group additionally proves it links against the shipped libc.a.
 INCORE_TESTS=(incore)
 VT_TESTS=(vt_roundtrip_keeps_maktop_focused vt_all_roundtrips)
 BUGHUNT_TESTS=(bughunt_clock_exit_palette bughunt_vix_exit_palette bughunt_status_bar_after_switch)
@@ -1241,6 +1528,7 @@ expand_arg() {
         fs)       printf '%s\n' "${FS_TESTS[@]}" ;;
         posix)    printf '%s\n' "${POSIX_TESTS[@]}" ;;
         libc)     printf '%s\n' "${LIBC_TESTS[@]}" ;;
+        tcc_rebuild|tcc) printf '%s\n' "${TCC_REBUILD_TESTS[@]}" ;;
         incore)   printf '%s\n' "${INCORE_TESTS[@]}" ;;
         vt)       printf '%s\n' "${VT_TESTS[@]}" ;;
         bughunt)  printf '%s\n' "${BUGHUNT_TESTS[@]}" ;;


### PR DESCRIPTION
This pull request makes significant improvements to the tmpfs (in-memory /tmp filesystem) and userland varargs support, removes the fixed limit on the number of tmpfs files, and introduces several usability enhancements for the shell and VFS. The most notable changes are the switch from a fixed-size tmpfs file table to a dynamic, heap-allocated linked list, the addition of a minimal `stdarg.h` for userspace, and the integration of varargs support throughout userland code. There are also new shell and VFS features, improved documentation, and expanded tests.

**tmpfs: Switch to dynamic file records and remove fixed file limit**
- Replaced the fixed-size array for tmpfs files with a dynamically allocated linked list (`tmpfile_t`), allowing an arbitrary number of files limited only by available heap memory. File creation, lookup, deletion, and iteration logic updated accordingly. (`src/kernel/arch/i386/fs/tmpfs.c`, `src/kernel/include/kernel/tmpfs.h`) [[1]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L4-R5) [[2]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L16-R27) [[3]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L44-R65) [[4]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L120-R121) [[5]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L134-R135) [[6]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L153-R159) [[7]](diffhunk://#diff-747bc0cb546b21612142be018a7e4e9a8c3c21754d807b323ebf480c74ba4810L9-R12) [[8]](diffhunk://#diff-747bc0cb546b21612142be018a7e4e9a8c3c21754d807b323ebf480c74ba4810L32-R34)
- Increased per-file maximum size to 16 MiB and now dynamically resizes file buffers as needed on write. (`src/kernel/arch/i386/fs/tmpfs.c`) [[1]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L16-R27) [[2]](diffhunk://#diff-5a1a6413ef66bf516701e8b13c75dff9a16e440a9799a211c1b0f35c05b87641L97-R97)
- Updated documentation to reflect the removal of the fixed file table and the new heap-backed design. (`src/kernel/include/kernel/tmpfs.h`) [[1]](diffhunk://#diff-747bc0cb546b21612142be018a7e4e9a8c3c21754d807b323ebf480c74ba4810L9-R12) [[2]](diffhunk://#diff-747bc0cb546b21612142be018a7e4e9a8c3c21754d807b323ebf480c74ba4810L32-R34)
- Added tests to verify creation and deletion of more than 16 tmpfs files. (`src/kernel/arch/i386/proc/ktest.c`)

**Userland: Add minimal varargs support and update stdio**
- Introduced a minimal `stdarg.h` implementation for userspace (i386 cdecl ABI). (`src/userspace/stdarg.h`, `src/userspace/Makefile`) [[1]](diffhunk://#diff-15bc49b449500c4091569380cb8c7a65aeaa07425a3ef0ae5c9626ea9e24e81bR1-R20) [[2]](diffhunk://#diff-5d0628f8cd8b477114cbfa761b7641c64fda9d674c42e03fd68c8688cbbb252eL35-R35)
- Updated `stdio.c` to use this new varargs support in `snprintf`, `printf`, `fprintf`, and related functions, replacing compiler built-ins. (`src/userspace/stdio.c`, `src/userspace/stdio.h`) [[1]](diffhunk://#diff-0e6306227720a3174edc2fa6ff4b92514c6abecc6815350cd54488e71eef5396L140-R140) [[2]](diffhunk://#diff-0e6306227720a3174edc2fa6ff4b92514c6abecc6815350cd54488e71eef5396L150-R168) [[3]](diffhunk://#diff-0e6306227720a3174edc2fa6ff4b92514c6abecc6815350cd54488e71eef5396L179-R200) [[4]](diffhunk://#diff-f4227ca7d3228707050e13b883e40a477072d740b36413cc8b54775d95a5b0e4R14)
- Added `stdlib.o` to the userspace libc build. (`src/userspace/Makefile`)

**Shell and VFS usability improvements**
- Added `vfs_print_mounts()` to print all mounted filesystems, and exposed it to the shell `mount` command (now lists mounts with no arguments). (`src/kernel/arch/i386/fs/vfs.c`, `src/kernel/include/kernel/vfs.h`, `src/kernel/arch/i386/shell/shell_cmd_fs.c`) [[1]](diffhunk://#diff-22901d7e828430f1ae2eedd004f67482dfa9c717ad7208b277eaafc73267c723R893-R919) [[2]](diffhunk://#diff-29f93fa88be3a73fdd17b3ebca7a8995a068bc679d27c79e7425cc303a2a8cffR117) [[3]](diffhunk://#diff-def1189969a7dd1f52bc22931b1a5c68b7c6dd07a96746c8e2820289fede4eb2R43-R49)
- Improved `mount` command and man page to document new usage. (`src/kernel/arch/i386/shell/shell_cmd_fs.c`, `src/kernel/arch/i386/shell/shell_cmd_man.c`) [[1]](diffhunk://#diff-def1189969a7dd1f52bc22931b1a5c68b7c6dd07a96746c8e2820289fede4eb2R43-R49) [[2]](diffhunk://#diff-313528d0952dc2c06b63ca08fed12cd2d33c65d724a804b7925ba61c86bcb850L118-R120)
- Added `shell_cancel_requested()` to handle Ctrl-C (SIGINT) cleanly in shell built-ins, and used it in the `lsman` command to allow interruption. (`src/kernel/arch/i386/shell/shell.c`, `src/kernel/arch/i386/shell/shell_cmd_man.c`, `src/kernel/arch/i386/shell/shell_priv.h`) [[1]](diffhunk://#diff-c19e9ce76a0bc9107bd4ff01fd16e1443673d2919140879334cbc22550a02721R40-R52) [[2]](diffhunk://#diff-313528d0952dc2c06b63ca08fed12cd2d33c65d724a804b7925ba61c86bcb850R244-R252) [[3]](diffhunk://#diff-718b50c4dd7f0fb9901e09e2383596f05ce1fb67498cfd195b3f65c792f0f144R108)

**Other improvements**
- Updated `makbox.c`'s `cat` command to yield periodically when writing large files, improving responsiveness. (`src/userspace/makbox.c`)
- Added `stdarg.h` to the list of headers installed in the sysroot. (`src/userspace/Makefile`)