### PR TITLE
feat: PCI enumeration, lspci, UEFI/auth/net/USB scaffolding

### DIFF
--- a/CLAUDE.roadmap.md
+++ b/CLAUDE.roadmap.md
@@ -114,6 +114,27 @@ Plan:
 5. **`sudo` builtin** — in `sh.elf`: `sudo <cmd>` prompts for password, re-checks `shadow_verify`, forks child with uid=0.  Kernel side: `SYS_SETUID(23)` restricted to uid=0 or shadow-verified callers.
 6. **`/etc/passwd` + `/home/<user>`** — `vfs_ensure_user_dirs()` creates standard home dirs; `adduser`/`deluser` shell commands.
 
+### UEFI / modern platform support
+
+**Current state:** Makar boots via GRUB 2 Multiboot 2, which acts as a bridge. GRUB itself is UEFI-aware (boots from an ESP, uses GOP for early output), then delivers Makar the same Multiboot 2 info structure regardless of whether the firmware is legacy BIOS or UEFI. This means Makar already boots on UEFI machines today — it just doesn't know or care; GRUB absorbs the difference.
+
+**Short-term (no kernel changes, QEMU testing):**
+- Test with `OVMF` UEFI firmware: `qemu-system-i386 -bios /usr/share/OVMF/OVMF_CODE.fd` — validate framebuffer, ACPI, PCI enumeration all work the same.
+- Test with `-machine q35` (modern PCIe chipset model) vs. the default `-machine pc` (i440FX, classic ISA/PCI). `q35` exposes PCIe root ports and an ICH9 southbridge instead of PIIX3 — `lspci` output will differ and the SATA/AHCI path matters for disk access.
+
+**Medium-term (kernel-visible UEFI differences):**
+1. **GOP framebuffer** — on UEFI/OVMF, Bochs VBE I/O ports (`0x01CE`/`0x01CF`) may be absent; the framebuffer is a GOP linear framebuffer whose address is in the Multiboot 2 framebuffer tag. `vesa.c` already reads the MB2 tag, so this should work — but `bochs_vbe_available()` will return false and the `setmode` command won't be able to switch resolutions at runtime. Proper fix: detect GOP base address and implement mode-setting via GRUB's `videoinfo`/`set gfxmode` or a virtio-GPU device.
+2. **ACPI RSDP on UEFI** — firmware places the RSDP in EFI config tables rather than the EBDA/BIOS ROM scan range. GRUB copies the RSDP pointer into the Multiboot 2 ACPI tag. `acpi.c` currently scans EBDA/ROM; add a fast-path that reads the MB2 ACPI v1/v2 tag first (OSDev: tag type 14/15), falls back to memory scan only on BIOS boots. This also surfaces the **MCFG** table needed for PCIe extended config space.
+3. **q35 / ICH9 differences** — q35 uses an AHCI SATA controller (PCI class 01:06, prog_if 01) rather than legacy IDE. `ide.c` speaks to the legacy 0x1F0/0x170 I/O ports which won't exist on q35. Need an AHCI driver (or fall back to the CD-ROM path for live boots). Disk writes only matter for HDD install flows.
+
+**Long-term — native x86-64 + UEFI:**
+- A 32-bit kernel can boot via UEFI with a 32-bit UEFI firmware (IA-32 UEFI), but these are rare; virtually all modern UEFI firmware is 64-bit.
+- The correct long-term path is a 64-bit kernel: new GDT (long-mode segments), IDT (64-bit gates), paging (4-level PT), SysCall/SysRet ABI, UEFI runtime services for time/NVRAM.
+- A 64-bit Makar would also run natively in the majority of hosted environments (VirtualBox, VMware, Hyper-V, real hardware) without needing GRUB to bridge the bitness gap.
+- **Recommended approach:** keep the i386 build working (it's the development sandbox); start a parallel `arch/x86_64/` subtree once the i386 userspace and driver stack is reasonably complete. The shell, VFS, and userspace ELFs are architecture-independent and would port with minimal changes.
+
+**Modular architecture note:** the driver and subsystem split (`drivers/`, `fs/`, `mm/`, `proc/`, `display/`, `auth/`) already follows a module-per-directory pattern. Extending to x86-64 means a new `arch/x86_64/` alongside `arch/i386/`; shared kernel code (VFS, task scheduler logic, shell, crypto) lives under `kernel/` and is compiled once for whichever arch is targeted. The `make.config` per-arch object list is the seam — each arch provides its own `make.config` naming its objects, and the top-level Makefile picks the right one via `ARCH`.
+
 ### Hardware / platform
 - **USB HID keyboard**: currently PS/2 only. QEMU emulates PS/2 by default; real hardware may need USB HID via OHCI/EHCI.
 - **Network**: RTL8139 driver → lwIP → DHCP/DNS → wget/curl-lite.

--- a/src/kernel/arch/i386/drivers/pci.c
+++ b/src/kernel/arch/i386/drivers/pci.c
@@ -6,6 +6,100 @@ pci_device_t pci_devices[PCI_MAX_DEVICES];
 int          pci_device_count = 0;
 
 /* --------------------------------------------------------------------------
+ * Vendor / device name table.
+ * Source: https://pci-ids.ucw.cz/  (fetched 2026-06-01, curated subset)
+ * device_id == 0xFFFF is a vendor-only sentinel (no device match).
+ * -------------------------------------------------------------------------- */
+typedef struct { uint16_t vendor; uint16_t device; const char *vendor_name; const char *device_name; } pci_id_entry_t;
+
+static const pci_id_entry_t pci_id_table[] = {
+    /* QEMU / bochs (0x1234 not in pci-ids DB, but widely known) */
+    { 0x1234, 0x1111, "QEMU",                                 "Standard VGA" },
+    /* Intel */
+    { 0x8086, 0x1237, "Intel Corporation",                    "440FX - 82441FX PMC [Natoma]" },
+    { 0x8086, 0x7000, "Intel Corporation",                    "82371SB PIIX3 ISA [Natoma/Triton II]" },
+    { 0x8086, 0x7010, "Intel Corporation",                    "82371SB PIIX3 IDE [Natoma/Triton II]" },
+    { 0x8086, 0x7020, "Intel Corporation",                    "82371SB PIIX3 USB [Natoma/Triton II]" },
+    { 0x8086, 0x7111, "Intel Corporation",                    "82371AB/EB/MB PIIX4 IDE" },
+    { 0x8086, 0x100E, "Intel Corporation",                    "82540EM Gigabit Ethernet Controller" },
+    { 0x8086, 0x100F, "Intel Corporation",                    "82545EM Gigabit Ethernet Controller (Copper)" },
+    { 0x8086, 0x10D3, "Intel Corporation",                    "82574L Gigabit Network Connection" },
+    { 0x8086, 0x1502, "Intel Corporation",                    "82579LM Gigabit Network Connection" },
+    { 0x8086, 0x1503, "Intel Corporation",                    "82579V Gigabit Network Connection" },
+    { 0x8086, 0x2415, "Intel Corporation",                    "82801AA AC'97 Audio Controller" },
+    { 0x8086, 0x2445, "Intel Corporation",                    "82801BA/BAM AC'97 Audio Controller" },
+    { 0x8086, 0x2668, "Intel Corporation",                    "ICH6 High Definition Audio Controller" },
+    { 0x8086, 0x2922, "Intel Corporation",                    "ICH9R 6-port SATA Controller [AHCI]" },
+    { 0x8086, 0x2934, "Intel Corporation",                    "ICH9 USB UHCI Controller" },
+    { 0x8086, 0x3A38, "Intel Corporation",                    "ICH10 USB UHCI Controller" },
+    /* Realtek */
+    { 0x10EC, 0x8029, "Realtek Semiconductor",                "RTL-8029(AS) 10/100 Ethernet" },
+    { 0x10EC, 0x8139, "Realtek Semiconductor",                "RTL-8139 PCI Fast Ethernet" },
+    { 0x10EC, 0x8168, "Realtek Semiconductor",                "RTL8111/8168 Gigabit Ethernet" },
+    { 0x10EC, 0x8169, "Realtek Semiconductor",                "RTL8169 Gigabit Ethernet" },
+    { 0x10EC, 0x8125, "Realtek Semiconductor",                "RTL8125 2.5GbE Controller" },
+    { 0x10EC, 0x5229, "Realtek Semiconductor",                "RTS5229 PCIe Card Reader" },
+    { 0x10EC, 0x5250, "Realtek Semiconductor",                "RTS5250 PCIe Card Reader" },
+    /* Red Hat virtio */
+    { 0x1AF4, 0x1000, "Red Hat",                              "Virtio network device" },
+    { 0x1AF4, 0x1001, "Red Hat",                              "Virtio block device" },
+    { 0x1AF4, 0x1002, "Red Hat",                              "Virtio memory balloon" },
+    { 0x1AF4, 0x1003, "Red Hat",                              "Virtio console" },
+    { 0x1AF4, 0x1004, "Red Hat",                              "Virtio SCSI" },
+    { 0x1AF4, 0x1005, "Red Hat",                              "Virtio RNG" },
+    { 0x1AF4, 0x1009, "Red Hat",                              "Virtio filesystem" },
+    { 0x1AF4, 0x1041, "Red Hat",                              "Virtio 1.0 network device" },
+    { 0x1AF4, 0x1042, "Red Hat",                              "Virtio 1.0 block device" },
+    { 0x1AF4, 0x1050, "Red Hat",                              "Virtio 1.0 GPU" },
+    { 0x1AF4, 0x1052, "Red Hat",                              "Virtio 1.0 input" },
+    { 0x1AF4, 0x1110, "Red Hat",                              "QEMU Inter-VM shared memory" },
+    /* QEMU devices (Red Hat 0x1B36) */
+    { 0x1B36, 0x0001, "QEMU",                                 "PCI-PCI bridge" },
+    { 0x1B36, 0x0002, "QEMU",                                 "PCI 16550A Adapter" },
+    { 0x1B36, 0x0008, "QEMU",                                 "PCIe Host bridge" },
+    { 0x1B36, 0x000C, "QEMU",                                 "PCIe Root port" },
+    { 0x1B36, 0x000D, "QEMU",                                 "xHCI Host Controller" },
+    { 0x1B36, 0x0010, "QEMU",                                 "NVM Express Controller" },
+    { 0x1B36, 0x0100, "QEMU",                                 "QXL paravirtual GPU" },
+    /* VMware */
+    { 0x15AD, 0x0405, "VMware",                               "SVGA II Adapter" },
+    { 0x15AD, 0x0770, "VMware",                               "USB2 EHCI Controller" },
+    { 0x15AD, 0x0774, "VMware",                               "USB1.1 UHCI Controller" },
+    { 0x15AD, 0x07B0, "VMware",                               "VMXNET3 Ethernet Controller" },
+    { 0x15AD, 0x07C0, "VMware",                               "PVSCSI Controller" },
+    /* VirtualBox */
+    { 0x80EE, 0xBEEF, "VirtualBox",                           "Graphics Adapter" },
+    { 0x80EE, 0xCAFE, "VirtualBox",                           "Guest Service" },
+    /* AMD */
+    { 0x1022, 0x2000, "AMD",                                  "PCnet32 LANCE" },
+    { 0x1022, 0x7801, "AMD",                                  "FCH SATA Controller [AHCI]" },
+    { 0x1022, 0x7808, "AMD",                                  "FCH USB EHCI Controller" },
+    /* AMD/ATI */
+    { 0x1002, 0x4752, "AMD/ATI",                              "Rage XL PCI" },
+    /* Broadcom */
+    { 0x14E4, 0x1644, "Broadcom",                             "NetXtreme BCM5700 Gigabit Ethernet" },
+    { 0x14E4, 0x1645, "Broadcom",                             "NetXtreme BCM5701 Gigabit Ethernet" },
+    { 0x14E4, 0x165A, "Broadcom",                             "NetXtreme BCM5722 Gigabit Ethernet PCIe" },
+};
+#define PCI_ID_TABLE_SIZE ((int)(sizeof(pci_id_table)/sizeof(pci_id_table[0])))
+
+const char *pci_vendor_name(uint16_t vendor)
+{
+    for (int i = 0; i < PCI_ID_TABLE_SIZE; i++)
+        if (pci_id_table[i].vendor == vendor)
+            return pci_id_table[i].vendor_name;
+    return NULL;
+}
+
+const char *pci_device_name(uint16_t vendor, uint16_t device)
+{
+    for (int i = 0; i < PCI_ID_TABLE_SIZE; i++)
+        if (pci_id_table[i].vendor == vendor && pci_id_table[i].device == device)
+            return pci_id_table[i].device_name;
+    return NULL;
+}
+
+/* --------------------------------------------------------------------------
  * Config-space access via legacy I/O ports 0xCF8 / 0xCFC.
  * PCIe extended config space (MCFG MMIO) will be added when ACPI MCFG
  * parsing is implemented; these helpers cover all devices for now.

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -43,6 +43,7 @@
 #include <kernel/vtty.h>
 #include <kernel/vt.h>
 #include <kernel/ide.h>
+#include <kernel/pci.h>
 #include <kernel/timer.h>
 #include <kernel/rtc.h>
 #include <string.h>
@@ -1455,6 +1456,53 @@ void syscall_dispatch(registers_t *regs)
             for (const char *s = tail; *s && off < cap - 2; s++)
                 buf[off++] = *s;
         }
+        buf[off] = '\0';
+        regs->eax = off;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_PCI_INFO(239): render pci_devices[] as text.
+     * EBX = buf, ECX = bufsz.  Returns bytes written.
+     * ------------------------------------------------------------------ */
+    case SYS_PCI_INFO: {
+        char    *buf = (char *)(uintptr_t)regs->ebx;
+        uint32_t cap = regs->ecx;
+        if (!buf || cap == 0) { regs->eax = 0; break; }
+        uint32_t off = 0;
+
+#define PCI_APPEND(s) do { for (const char *_p = (s); *_p && off < cap - 2; _p++) buf[off++] = *_p; } while(0)
+#define PCI_BYTE_HEX(v) do { \
+    static const char _h[] = "0123456789ABCDEF"; \
+    if (off + 2 < cap) { buf[off++] = _h[((v)>>4)&0xF]; buf[off++] = _h[(v)&0xF]; } } while(0)
+#define PCI_WORD_HEX(v) do { PCI_BYTE_HEX((v)>>8); PCI_BYTE_HEX(v); } while(0)
+#define PCI_DEC(v) do { \
+    char _d[6]; int _i = 5; _d[_i] = '\0'; uint32_t _v = (v); \
+    if (!_v) _d[--_i] = '0'; \
+    else while (_v) { _d[--_i] = (char)('0' + _v % 10); _v /= 10; } \
+    PCI_APPEND(_d + _i); } while(0)
+
+        for (int i = 0; i < pci_device_count && off < cap - 64; i++) {
+            const pci_device_t *d = &pci_devices[i];
+            PCI_BYTE_HEX(d->bus);    buf[off++] = ':';
+            PCI_BYTE_HEX(d->dev);    buf[off++] = '.';
+            buf[off++] = (char)('0' + d->func);
+            PCI_APPEND("  ");
+            PCI_APPEND(pci_class_name(d->class_code, d->subclass));
+            PCI_APPEND(" [");
+            PCI_BYTE_HEX(d->class_code); PCI_BYTE_HEX(d->subclass);
+            PCI_APPEND("]: ");
+            PCI_WORD_HEX(d->vendor_id); buf[off++] = ':'; PCI_WORD_HEX(d->device_id);
+            PCI_APPEND("  (rev "); PCI_BYTE_HEX(d->revision_id); buf[off++] = ')';
+            if (d->irq_line && d->irq_line != 0xFF) {
+                PCI_APPEND("  IRQ="); PCI_DEC(d->irq_line);
+            }
+            buf[off++] = '\n';
+        }
+#undef PCI_APPEND
+#undef PCI_BYTE_HEX
+#undef PCI_WORD_HEX
+#undef PCI_DEC
         buf[off] = '\0';
         regs->eax = off;
         break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1482,17 +1482,25 @@ void syscall_dispatch(registers_t *regs)
     else while (_v) { _d[--_i] = (char)('0' + _v % 10); _v /= 10; } \
     PCI_APPEND(_d + _i); } while(0)
 
-        for (int i = 0; i < pci_device_count && off < cap - 64; i++) {
+        for (int i = 0; i < pci_device_count && off < cap - 96; i++) {
             const pci_device_t *d = &pci_devices[i];
-            PCI_BYTE_HEX(d->bus);    buf[off++] = ':';
-            PCI_BYTE_HEX(d->dev);    buf[off++] = '.';
+            /* BB:DD.F  Class [CCSS]: Vendor Device (rev RR) [IRQ=N] */
+            PCI_BYTE_HEX(d->bus);  buf[off++] = ':';
+            PCI_BYTE_HEX(d->dev);  buf[off++] = '.';
             buf[off++] = (char)('0' + d->func);
             PCI_APPEND("  ");
             PCI_APPEND(pci_class_name(d->class_code, d->subclass));
             PCI_APPEND(" [");
             PCI_BYTE_HEX(d->class_code); PCI_BYTE_HEX(d->subclass);
             PCI_APPEND("]: ");
-            PCI_WORD_HEX(d->vendor_id); buf[off++] = ':'; PCI_WORD_HEX(d->device_id);
+            /* Vendor name (fall back to hex) */
+            const char *vname = pci_vendor_name(d->vendor_id);
+            if (vname) { PCI_APPEND(vname); buf[off++] = ' '; }
+            else { PCI_WORD_HEX(d->vendor_id); buf[off++] = ':'; }
+            /* Device name (fall back to hex) */
+            const char *dname = pci_device_name(d->vendor_id, d->device_id);
+            if (dname) { PCI_APPEND(dname); }
+            else { PCI_WORD_HEX(d->device_id); }
             PCI_APPEND("  (rev "); PCI_BYTE_HEX(d->revision_id); buf[off++] = ')';
             if (d->irq_line && d->irq_line != 0xFF) {
                 PCI_APPEND("  IRQ="); PCI_DEC(d->irq_line);

--- a/src/kernel/include/kernel/pci.h
+++ b/src/kernel/include/kernel/pci.h
@@ -31,5 +31,7 @@ uint16_t    pci_read16 (uint8_t bus, uint8_t dev, uint8_t func, uint8_t off);
 uint8_t     pci_read8  (uint8_t bus, uint8_t dev, uint8_t func, uint8_t off);
 void        pci_write32(uint8_t bus, uint8_t dev, uint8_t func, uint8_t off, uint32_t val);
 const char *pci_class_name(uint8_t class_code, uint8_t subclass);
+const char *pci_vendor_name(uint16_t vendor);
+const char *pci_device_name(uint16_t vendor, uint16_t device);
 
 #endif /* _KERNEL_PCI_H */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -108,6 +108,8 @@
 #define SYS_VT_OPEN_REQUEST 235 /* int vt_open_request(void) - consume Alt+T */
 #define SYS_VT_STATE       236 /* uint32_t vt_state(void) -> active<<16 | mask */
 #define SYS_VT_CLOCK_REQUEST 237 /* int vt_clock_request(void) - consume Alt+F5 */
+#define SYS_PCI_INFO         239 /* int pci_info(char *buf, uint32_t bufsz) - render
+                                  * pci_devices[] as text.  Returns bytes written. */
 #define SYS_INSTALL          238 /* int install(void) - run the Limine installer TUI;
                                   * blocks the calling task until the installer
                                   * exits.  Returns 0 on success, -1 otherwise. */

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -16,7 +16,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf kbtester.elf makbox.elf makmux.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf kbtester.elf makbox.elf makmux.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -56,6 +56,9 @@ ls.elf: crt0.o ls.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 diskinfo.elf: crt0.o diskinfo.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+lspci.elf: crt0.o lspci.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 makbox.elf: crt0.o makbox.o

--- a/src/userspace/lspci.c
+++ b/src/userspace/lspci.c
@@ -1,0 +1,16 @@
+#include "syscall.h"
+
+static char buf[4096];
+
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    int n = sys_pci_info(buf, (unsigned int)sizeof(buf));
+    if (n <= 0) {
+        const char *msg = "lspci: no PCI devices found\n";
+        sys_write(1, msg, 28);
+        return 1;
+    }
+    sys_write(1, buf, (unsigned int)n);
+    return 0;
+}

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -61,6 +61,7 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_WRITE_FILE 205
 #define SYS_LS_DIR     206
 #define SYS_DISK_INFO    207
+#define SYS_PCI_INFO     239
 #define SYS_DELETE_FILE  208
 #define SYS_RENAME_FILE  209
 #define SYS_DELETE_DIR   210
@@ -568,6 +569,12 @@ static inline int sys_ls_dir(const char *path, char *buf, unsigned int bufsz)
 static inline int sys_disk_info(char *buf, unsigned int bufsz)
 {
     return (int)syscall2(SYS_DISK_INFO, (long)buf, (long)bufsz);
+}
+
+/* Get PCI device list as text. Returns bytes written. */
+static inline int sys_pci_info(char *buf, unsigned int bufsz)
+{
+    return (int)syscall2(SYS_PCI_INFO, (long)buf, (long)bufsz);
 }
 
 /* Delete a file. Returns 0 on success, -1 on error. */


### PR DESCRIPTION
## Summary

- **PCI bus enumeration** (`drivers/pci.c` + `include/kernel/pci.h`): legacy I/O port config space (0xCF8/0xCFC), full 256-bus scan at boot, multi-function device support, class/subclass name table
- **`lspci` shell command**: prints every PCI device with bus:dev.func, class, vendor:device, revision, IRQ
- **`outl`/`inl`** added to `asm.h` (32-bit port I/O)
- **`pci_init()`** wired into `kernel_main` after `ide_init`
- **Skeleton dirs** (no build wiring): `drivers/net/rtl8139.{c,h}`, `drivers/usb/usb.{c,h}`, `arch/i386/auth/{sha256,shadow,login}.c` + `auth.h`
- **Roadmap**: full slice plans for PCI→NIC→USB, user accounts→login→sudo, UEFI/modern platform support (OVMF, q35, GOP, ACPI RSDP via MB2 tag, x86-64 long-term path), modular `arch/` layout

## Test plan

- [x] `./run.sh iso build` — clean build
- [x] `./run.sh iso boot` → type `lspci` — should list host bridge, ISA bridge, IDE, VGA, network adapter
- [ ] `./run.sh iso test` — ktest + GDB boot checkpoints pass