### PR TITLE
feat: display/1080p, vmode, autologin, vix, statusbar decouple+widgets, named-tab WM, kbd test harness

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,19 +69,35 @@ jobs:
             ccache-${{ runner.os }}-
 
       - name: Build ISOs (kernel + makar.iso + makar-test.iso)
-        run: ./run.sh iso build
+        run: |
+          mkdir -p ci-logs
+          set -o pipefail
+          ./run.sh iso build 2>&1 | tee ci-logs/iso-build.log
 
       - name: Build HDD test image (kernel cached from ISO build)
-        run: ./run.sh hdd build
+        run: |
+          mkdir -p ci-logs
+          set -o pipefail
+          ./run.sh hdd build 2>&1 | tee ci-logs/hdd-build.log
 
       - name: ccache stats
         if: always()
         continue-on-error: true
         run: |
+          mkdir -p ci-logs
           docker run --rm \
             -v "$PWD:/work" -w /work \
             -e CCACHE_DIR=/work/.ccache \
-            makar-build:local ccache -s || echo "(ccache stats unavailable)"
+            makar-build:local ccache -s 2>&1 | tee ci-logs/ccache-stats.log || echo "(ccache stats unavailable)"
+
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: ci-logs/
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -119,14 +135,20 @@ jobs:
           name: makar-build
 
       - name: Run ktest
-        run: ./run.sh ktest
+        run: |
+          mkdir -p ci-logs
+          set -o pipefail
+          ./run.sh ktest 2>&1 | tee ci-logs/ktest-run.log
 
       - name: Upload ktest log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ktest-log
-          path: ktest.log
+          path: |
+            ci-logs/
+            ktest.log
+          if-no-files-found: warn
 
   # ── GDB ISO boot-checkpoint test ───────────────────────────────────────────
   # Boots makar.iso (interactive grub.cfg, default entry 0) under the QEMU
@@ -152,7 +174,10 @@ jobs:
           name: makar-build
 
       - name: Run GDB ISO boot test
-        run: ./run.sh gdb iso
+        run: |
+          mkdir -p ci-logs
+          set -o pipefail
+          ./run.sh gdb iso 2>&1 | tee ci-logs/gdb-iso-run.log
 
       - name: Upload GDB logs
         if: always()
@@ -160,8 +185,10 @@ jobs:
         with:
           name: gdb-iso-logs
           path: |
+            ci-logs/
             gdb-test.log
             gdb-serial.log
+          if-no-files-found: warn
 
   # ── GDB HDD boot test ──────────────────────────────────────────────────────
   # Boots makar-hdd-test.img (no CD-ROM) and verifies the kernel reaches
@@ -187,7 +214,10 @@ jobs:
           name: makar-build
 
       - name: Run GDB HDD boot test
-        run: ./run.sh gdb hdd
+        run: |
+          mkdir -p ci-logs
+          set -o pipefail
+          ./run.sh gdb hdd 2>&1 | tee ci-logs/gdb-hdd-run.log
 
       - name: Upload GDB logs
         if: always()
@@ -195,8 +225,10 @@ jobs:
         with:
           name: gdb-hdd-logs
           path: |
+            ci-logs/
             hdd-test-gdb.log
             hdd-test-serial.log
+          if-no-files-found: warn
 
   # NOTE: UI tests (sendkey + serial grep) live in tests/ui_test.sh and
   # are runnable locally via `./run.sh ui`.  They are intentionally

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ src/kernel/arch/*/dt_asm
 src/userspace/*.o
 src/userspace/*.a
 src/userspace/*.elf
+src/userspace/.tcc.stamp
 
 # Vendored TCC build artefacts (NOT build-stubs -- those are
 # hand-written Makar-flavoured headers, source of truth for the

--- a/HANDOFF-codex.md
+++ b/HANDOFF-codex.md
@@ -1,0 +1,22 @@
+# Handoff — branch `auth-login-installer`
+
+Context: continuing UX/bugfix work. Nothing committed this session. Build via `./run.sh iso build`.
+
+## DONE (in tree, unverified end-to-end unless noted)
+- **mak.sh1 duplicate VT** — TOCTOU race in `vtty_register` (two makmux children claimed slot 0). Fixed with `cli/sti` atomic find-and-claim in `src/kernel/arch/i386/proc/vtty.c`. **User-confirmed fixed.**
+- **Statusbar** (`src/userspace/statusbar.c`) — tabs now centre in the gap between left/right sections (no overlap with cpu/mem/rootfs); default left widget `hostname`→`command` (foreground exe). `SYS_VT_STATE` (`syscall.c`) now reports root slot (8) as focused when makmux isn't running so `command` works on mak.sh0. Installer `.sbrc` updated to `left command`. **User-confirmed fixed.**
+- **ktest devfs boot-mode aware** (`src/kernel/arch/i386/proc/ktest.c`) — HDD boot failed 7/9 (empty ATAPI `/cdrom` size 0). CD asserts now gated on `devfs_node_size(cd)>0`; added `/hda` probe. Verified passing on ISO `./run.sh ktest`.
+- **`sfdisk` not found on `hdd boot`** — `arawn780/gcc-cross-i686-elf:fast` image dropped util-linux/dosfstools. Added on-demand apt install in `generate-hdd.sh` and `run.sh _make_fat32_disk`. **Correct packages: `fdisk` (provides sfdisk — NOT util-linux) + `dosfstools` (mkfs.fat).** losetup already present. Verified in-container.
+- **TCC incremental build** (`build-tcc.sh`) — content-hash stamp `src/userspace/.tcc.stamp` (gitignored) skips the slow tcc.c recompile when inputs unchanged. Hash covers build-tcc.sh + link.ld + crt0.o + libc.a + tinycc *.c/*.h.
+- **Installer docs/src options** (`installer.c`) — new `INSTALL>components` y/N prompts (default yes) before `do_install`; `s_inst_docs`/`s_inst_src` gate `copy_tree("/docs")`/`("/src")`.
+- **Installer task renamed "installer"** during wizard so statusbar `command` widget shows it — `installer_run` is now a thin wrapper around `installer_run_inner` that swaps `task_current()->name`. Added `#include <kernel/task.h>`.
+
+## IN PROGRESS / PENDING
+1. **Bleeding root shell (HIGH PRIORITY, the active task).** On the **post-install reboot only** (not a fresh generated HDD), a `root@makbox:/mnt/root#` prompt shows BEHIND the autologin (arawn) shell. **User confirmed it's STALE PIXELS, not a live task** — input correctly goes to the arawn shell. Live (pre-install) session prompt is `user@…$`. HDD boots via **Limine**. So: a transient sh.elf (defaults `g_username="root"` in `src/userspace/sh.c:53` when no `--user=`) draws a prompt at cwd `/mnt/root`, exits, and the real arawn shell paints on top without a full clear. **Fix direction (per user):** every login shell should `cd $HOME` on startup and `$HOME` set per-user (`/root` for root, `/home/<u>` else); and the session start should fully clear the framebuffer so no prior pixels bleed. Was about to inspect `vesa_tty_clear` (full-FB vs text-area) in `src/kernel/arch/i386/display/vesa_tty.c` and `shell_login_loop` clears (`shell.c` ~1226). Check whether the clear covers the whole LFB.
+2. **`hdd boot` installer has no ISO9660 source** — EXPECTED: `hdd boot` attaches no CD. My edit to attach `makar.iso` as cdrom in run.sh `hdd boot` was **REJECTED by user** — do NOT re-apply without asking. The installer code itself is unbroken (my installer.c diff doesn't touch `find_cdrom`/`g_cd`/iso9660). User may want a different approach.
+3. Lower priority: statusbar `installer` display (#11, done but unverified), docs/src options (#12, done but unverified).
+
+## NOTES
+- Stray headless QEMU probes may be running against `/tmp/hdd-probe.img` (a copy, not `hdd.img`). Kill if found.
+- No AI attribution in commits/PRs (project rule). One commit per work item.
+- To read framebuffer state headlessly: QEMU `-monitor unix:sock` + `screendump x.ppm`; convert PPM→PNG with stdlib `zlib` (no imagemagick on host).

--- a/build-tcc.sh
+++ b/build-tcc.sh
@@ -228,6 +228,33 @@ COMMON_DEFS="\
  -DCONFIG_TCCBOOT \
  -DONE_SOURCE=1"
 
+# ── Incremental build guard ──────────────────────────────────────────────────
+# tcc.c is ~big and the compile dominates a warm rebuild (~16 s).  Skip it when
+# nothing that feeds tcc.elf has changed.  A CONTENT hash (not mtimes) is used
+# because config.h + build-stubs/*.h are regenerated on every run, which would
+# churn mtimes and defeat a timestamp test.  Inputs: this script, link.ld, the
+# linked crt0.o/libc.a, and every tinycc *.c/*.h source.
+TCC_STAMP="$USER_DIR/.tcc.stamp"
+tcc_input_hash() {
+    {
+        cat "$REPO_ROOT/build-tcc.sh" "$USER_DIR/link.ld" \
+            "$USER_DIR/crt0.o" "$USER_DIR/libc.a" 2>/dev/null
+        find "$TCC_DIR" \( -name '*.c' -o -name '*.h' \) -type f -print0 \
+            | sort -z | xargs -0 cat 2>/dev/null
+    } | md5sum | cut -d' ' -f1
+}
+TCC_HASH=$(tcc_input_hash)
+TCC_SKIP_BUILD=
+if [ -f "$USER_DIR/tcc.elf" ] && [ -f "$TCC_DIR/lib/libtcc1.a" ] \
+   && [ -f "$TCC_STAMP" ] && [ "$(cat "$TCC_STAMP" 2>/dev/null)" = "$TCC_HASH" ]; then
+    TCC_SKIP_BUILD=1
+fi
+
+if [ -n "$TCC_SKIP_BUILD" ]; then
+    echo "==> tcc.elf up to date (inputs unchanged); skipping recompile."
+    echo "==> tcc.elf: $(ls -lh src/userspace/tcc.elf 2>/dev/null | awk '{print $5}')"
+else
+
 # ── Compile tcc.o ────────────────────────────────────────────────────────────
 echo "==> Compiling tcc.c ..."
 RUN "cd vendor/tinycc && \
@@ -263,6 +290,10 @@ RUN "cd vendor/tinycc/lib && \
         -c alloca86.S -o alloca86.o && \
     i686-elf-ar rcs libtcc1.a libtcc1.o alloca86.o"
 echo "==> libtcc1.a: $(ls -lh vendor/tinycc/lib/libtcc1.a 2>/dev/null | awk '{print $5}')"
+
+    # Record the input hash so the next build can skip when unchanged.
+    echo "$TCC_HASH" > "$TCC_STAMP"
+fi
 
 # ── Build CRT stubs for TCC's default link sequence ─────────────────────────
 # TCC's default link is: crt1.o + crti.o + <user objects> + -lc + crtn.o

--- a/generate-hdd.sh
+++ b/generate-hdd.sh
@@ -81,8 +81,10 @@ fi
 
 # ---------------------------------------------------------------------------
 # Step 2: create the HDD image inside the compiler container.
-# dosfstools (mkfs.fat), fdisk (sfdisk), grub-pc-bin, and grub-common are
-# all pre-installed in BUILD_IMAGE - no runtime apt-get needed.
+# grub-pc-bin / grub-common and losetup ship in BUILD_IMAGE, but sfdisk
+# (Debian package: fdisk) and mkfs.fat (dosfstools) are NOT guaranteed to
+# be present -- the upstream toolchain image has dropped them.  The inner
+# script installs them on demand (apt-get) when missing.
 # All loop-device work runs as root (--privileged); the final image is
 # chown-ed back to the calling user before the container exits.
 # ---------------------------------------------------------------------------
@@ -104,6 +106,17 @@ set -e
 
 HDD="/work/$HDD_IMG"
 MNT=/mnt/makar-install
+
+# The base toolchain image no longer ships disk tooling; install on demand so
+# `hdd boot` works regardless of which BUILD_IMAGE revision is in use.
+need_pkgs=""
+command -v sfdisk   >/dev/null 2>&1 || need_pkgs="$need_pkgs fdisk"
+command -v mkfs.fat >/dev/null 2>&1 || need_pkgs="$need_pkgs dosfstools"
+if [ -n "$need_pkgs" ]; then
+    echo "==> Installing disk tools:$need_pkgs"
+    apt-get update -qq >/dev/null
+    apt-get install -y --no-install-recommends $need_pkgs >/dev/null
+fi
 
 # Create a blank raw disk image.
 rm -f "$HDD"

--- a/run.sh
+++ b/run.sh
@@ -120,6 +120,8 @@ case "${1:-}" in
         else
             MODE="ktest"; shift 1
         fi ;;
+    kbtest)
+        MODE="kbtest"; shift 1 ;;
     ui)
         MODE="ui"; shift 1 ;;
     gui)
@@ -800,7 +802,38 @@ _clean() {
 _build_iso() {
     local _flags="${1:-}"
     echo "==> Building ISO${_flags:+ ($_flags)}..."
-    _drun -- "${_flags:+$_flags }bash iso.sh"
+    # Forward KERNEL_ARGS (extra GRUB cmdline, e.g. `kbtest`) into the build
+    # container; iso.sh appends it to the interactive menuentry.
+    local _kenv=()
+    [ -n "${KERNEL_ARGS:-}" ] && _kenv=(--env "KERNEL_ARGS=$KERNEL_ARGS")
+    _drun "${_kenv[@]}" -- "${_flags:+$_flags }bash iso.sh"
+}
+
+# Run the in-guest keyboard-injection test (headless QEMU + serial capture).
+# Boots makar.iso (built with `kbtest` on the cmdline) into the normal shell;
+# the kernel keyboard_test_driver injects keys and emits KBTEST markers.  The
+# driver loops forever, so we poll serial for "KBTEST: done" then stop QEMU.
+_run_kbtest() {
+    echo "==> Running keyboard-injection test (headless QEMU)..."
+    local _qemu; _qemu=$(_host_qemu)
+    if [ -z "$_qemu" ]; then echo "==> kbtest needs host qemu-system-i386"; return 1; fi
+    local _log="$REPO_ROOT/kbtest.log"; rm -f "$_log"
+    local _secs="${KBTEST_TIMEOUT:-90}"
+    "$_qemu" -cdrom "$REPO_ROOT/makar.iso" -m 256 -vga std -display none \
+        -serial "file:$_log" -no-reboot >/dev/null 2>&1 &
+    local _qp=$! _i=0
+    while [ "$_i" -lt "$_secs" ]; do
+        grep -q "KBTEST: done" "$_log" 2>/dev/null && break
+        kill -0 "$_qp" 2>/dev/null || break
+        sleep 1; _i=$((_i + 1))
+    done
+    sleep 1; kill "$_qp" 2>/dev/null
+    echo "--- kbtest serial ---"
+    grep -aE "KBTEST:|KBINJECT_OK|PAGE FAULT|panic\(cpu" "$_log" || true
+    if grep -q "KBINJECT_OK" "$_log" 2>/dev/null && ! grep -q "PAGE FAULT\|panic(cpu" "$_log" 2>/dev/null; then
+        echo "==> kbtest PASS"; return 0
+    fi
+    echo "==> kbtest FAIL (see $_log)"; return 1
 }
 
 _build_kernel() {
@@ -924,6 +957,14 @@ case "$MODE" in
 ktest)
     _build_iso "TEST_CMDLINE='test_mode test=ktest' CFLAGS='-O0 -g3' TEST_ISO=1"
     _run_ktest
+    ;;
+
+# ── kbtest ───────────────────────────────────────────────────────────────────
+# Deterministic in-guest keyboard-injection test: boots the normal shell with
+# `kbtest` on the cmdline (kernel injects keys, no HMP) and asserts on serial.
+"kbtest")
+    KERNEL_ARGS="kbtest${KERNEL_ARGS:+ $KERNEL_ARGS}" _build_iso "CFLAGS='-O0 -g3'"
+    _run_kbtest
     ;;
 
 # ── ktest graphical ──────────────────────────────────────────────────────────

--- a/run.sh
+++ b/run.sh
@@ -434,6 +434,10 @@ _make_fat32_disk() {
     rm -f "$REPO_ROOT/$_img"
     _drun --env "MAKAR_DISK_MB=$_sz" -- \
         "IMG='/work/$_img'
+         pkgs=''
+         command -v sfdisk   >/dev/null 2>&1 || pkgs=\"\$pkgs fdisk\"
+         command -v mkfs.fat >/dev/null 2>&1 || pkgs=\"\$pkgs dosfstools\"
+         if [ -n \"\$pkgs\" ]; then apt-get update -qq >/dev/null && apt-get install -y --no-install-recommends \$pkgs >/dev/null; fi
          truncate -s \${MAKAR_DISK_MB}M \"\$IMG\"
          printf 'label: dos\nstart=2048, type=c\n' | sfdisk \"\$IMG\" >/dev/null 2>&1
          mkfs.fat -F 32 -n MAKAR --offset 2048 \"\$IMG\" >/dev/null

--- a/run.sh
+++ b/run.sh
@@ -121,7 +121,11 @@ case "${1:-}" in
             MODE="ktest"; shift 1
         fi ;;
     kbtest)
-        MODE="kbtest"; shift 1 ;;
+        if [ "${2:-}" = "gui" ] || [ "${2:-}" = "graphical" ]; then
+            MODE="kbtest gui"; shift 2
+        else
+            MODE="kbtest"; shift 1
+        fi ;;
     ui)
         MODE="ui"; shift 1 ;;
     gui)
@@ -814,12 +818,17 @@ _build_iso() {
 # the kernel keyboard_test_driver injects keys and emits KBTEST markers.  The
 # driver loops forever, so we poll serial for "KBTEST: done" then stop QEMU.
 _run_kbtest() {
-    echo "==> Running keyboard-injection test (headless QEMU)..."
+    # $1 = "gui" -> visible QEMU window (watch the injection drive the shell);
+    # otherwise headless.  Serial still goes to a file for the assertions.
+    local _disp="-display none"
+    [ "${1:-}" = "gui" ] && { _disp="${QEMU_DISPLAY:+-display $QEMU_DISPLAY}"; echo "==> Running keyboard-injection test (graphical window)..."; } \
+                         || echo "==> Running keyboard-injection test (headless QEMU)..."
     local _qemu; _qemu=$(_host_qemu)
     if [ -z "$_qemu" ]; then echo "==> kbtest needs host qemu-system-i386"; return 1; fi
     local _log="$REPO_ROOT/kbtest.log"; rm -f "$_log"
     local _secs="${KBTEST_TIMEOUT:-90}"
-    "$_qemu" -cdrom "$REPO_ROOT/makar.iso" -m 256 -vga std -display none \
+    # shellcheck disable=SC2086
+    "$_qemu" -cdrom "$REPO_ROOT/makar.iso" -m 256 -vga std $_disp \
         -serial "file:$_log" -no-reboot >/dev/null 2>&1 &
     local _qp=$! _i=0
     while [ "$_i" -lt "$_secs" ]; do
@@ -967,6 +976,11 @@ ktest)
 "kbtest")
     KERNEL_ARGS="kbtest${KERNEL_ARGS:+ $KERNEL_ARGS}" _build_iso "CFLAGS='-O0 -g3'"
     _run_kbtest
+    ;;
+
+"kbtest gui")
+    KERNEL_ARGS="kbtest${KERNEL_ARGS:+ $KERNEL_ARGS}" _build_iso "CFLAGS='-O0 -g3'"
+    _run_kbtest gui
     ;;
 
 # ── ktest graphical ──────────────────────────────────────────────────────────

--- a/run.sh
+++ b/run.sh
@@ -830,7 +830,9 @@ _run_kbtest() {
     sleep 1; kill "$_qp" 2>/dev/null
     echo "--- kbtest serial ---"
     grep -aE "KBTEST:|KBINJECT_OK|PAGE FAULT|panic\(cpu" "$_log" || true
-    if grep -q "KBINJECT_OK" "$_log" 2>/dev/null && ! grep -q "PAGE FAULT\|panic(cpu" "$_log" 2>/dev/null; then
+    if grep -q "KBINJECT_OK" "$_log" 2>/dev/null \
+       && grep -q "KBTEST: ALL PASS" "$_log" 2>/dev/null \
+       && ! grep -q "PAGE FAULT\|panic(cpu" "$_log" 2>/dev/null; then
         echo "==> kbtest PASS"; return 0
     fi
     echo "==> kbtest FAIL (see $_log)"; return 1

--- a/src/kernel/arch/i386/auth/login.c
+++ b/src/kernel/arch/i386/auth/login.c
@@ -12,6 +12,7 @@
  */
 
 #include <kernel/auth.h>
+#include <kernel/vfs.h>
 #include <kernel/vesa_tty.h>
 #include <kernel/tty.h>
 #include <kernel/keyboard.h>
@@ -339,4 +340,52 @@ void auth_logout(void)
 {
     Serial_WriteString("[auth] logout\n");
     login_screen();
+}
+
+/* --------------------------------------------------------------------------
+ * auth_try_autologin: resolve an auto-login user (cmdline arg first, then
+ * /etc/autologin) and, if it exists in /etc/shadow, sign in without a
+ * password.  Returns 0 to fall back to the interactive login prompt.
+ * --------------------------------------------------------------------------*/
+int auth_try_autologin(const char *cmdline_user)
+{
+    char namebuf[64];
+    const char *user = NULL;
+
+    if (cmdline_user && *cmdline_user) {
+        user = cmdline_user;
+    } else {
+        /* First whitespace-delimited token of /etc/autologin. */
+        char fbuf[80];
+        uint32_t sz = 0;
+        if (vfs_read_file("/etc/autologin", fbuf, sizeof(fbuf) - 1, &sz) == 0 && sz > 0) {
+            fbuf[sz] = '\0';
+            const char *p = fbuf;
+            while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') p++;
+            size_t i = 0;
+            while (*p && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r' &&
+                   i < sizeof(namebuf) - 1)
+                namebuf[i++] = *p++;
+            namebuf[i] = '\0';
+            if (namebuf[0]) user = namebuf;
+        }
+    }
+
+    if (!user || !*user)
+        return 0;                       /* no autologin configured */
+
+    if (!shadow_user_exists(user)) {
+        Serial_WriteString("[auth] autologin user not found, requiring login: ");
+        Serial_WriteString((char *)user);
+        Serial_WriteString("\n");
+        return 0;                       /* invalid -> fall back to prompt */
+    }
+
+    size_t i = 0;
+    while (user[i] && i < sizeof(s_current_user) - 1) { s_current_user[i] = user[i]; i++; }
+    s_current_user[i] = '\0';
+    Serial_WriteString("[auth] autologin: ");
+    Serial_WriteString(s_current_user);
+    Serial_WriteString("\n");
+    return 1;
 }

--- a/src/kernel/arch/i386/auth/shadow.c
+++ b/src/kernel/arch/i386/auth/shadow.c
@@ -128,6 +128,12 @@ static int shadow_find(const char *username, char salt[17], char stored[17])
  * Public API
  * -------------------------------------------------------------------------*/
 
+int shadow_user_exists(const char *username)
+{
+    char salt[17], stored[17];
+    return shadow_find(username, salt, stored) == 1 ? 1 : 0;
+}
+
 int shadow_verify(const char *username, const char *password)
 {
     char salt[17], stored[17];

--- a/src/kernel/arch/i386/debug/debug.c
+++ b/src/kernel/arch/i386/debug/debug.c
@@ -177,6 +177,24 @@ static void restore_vga_display(void)
     inb(0x3DA); outb(0x3C0, 0x20);
 }
 
+/* Last-ditch, fault-proof panic notice.  Used only when the normal panic
+ * renderer itself faulted (e.g. it wrote into a framebuffer a mid-switch
+ * setmode left unmapped).  Touches nothing but I/O ports and the VGA text
+ * buffer at 0xB8000, which lives in the first 4 MiB large page and is
+ * therefore present in every page directory -- it cannot fault.  Forces the
+ * CRTC back to text scanout so the message is visible even if the hardware
+ * was in a VESA graphics mode. */
+static void panic_textmode_notice(void)
+{
+    restore_vga_display();
+    for (int i = 0; i < VGA_COLS * VGA_ROWS; i++)
+        VGA_BASE[i] = (uint16_t)(0x4F00u | (uint8_t)' ');   /* white on red */
+    vga_center(VGA_ROWS / 2 - 1, "*** MAKAR KERNEL PANIC ***", 0x4Fu);
+    vga_center(VGA_ROWS / 2 + 1,
+               "Please reboot: power-cycle or Ctrl+Alt+Del. Details on serial.",
+               0x4Fu);
+}
+
 static void render_panic_vga(const char *fault_type, const char *msg,
                               const char *file, const char *func, int line,
                               uint32_t fault_addr, int show_addr,
@@ -589,11 +607,33 @@ static void render_panic_vesa(const vesa_fb_t *fb,
  * Main panic dispatcher
  * ============================================================ */
 
+/* Set once we begin painting a panic.  If the graphical renderer itself
+ * faults -- e.g. it writes into a framebuffer region that a mid-switch
+ * setmode left unmapped -- the page-fault handler re-enters kernel_panic;
+ * without this guard that recurses forever (a CPU exception ignores the
+ * `cli` below), which is exactly the panic loop seen switching to 1080p.
+ * On re-entry we skip the renderer (serial already has the first, complete
+ * report) and just stop the CPU. */
+static volatile int s_in_panic = 0;
+
 static void kernel_panic(const char *fault_type, const char *msg,
                           const char *file, const char *func, int line,
                           uint32_t fault_addr, int show_addr,
                           registers_t *r)
 {
+    if (s_in_panic) {
+        s_in_panic++;
+        Serial_WriteString("panic: nested fault while rendering panic; halting\n");
+        /* First nesting only: try the fault-proof text-mode notice so the
+         * user still sees a reboot instruction.  If even that faults
+         * (s_in_panic > 2, which shouldn't be possible), skip straight to
+         * the halt -- never recurse, never loop. */
+        if (s_in_panic == 2)
+            panic_textmode_notice();
+        for (;;) asm volatile("cli; hlt");
+    }
+    s_in_panic = 1;
+
     /* 1. Serial - always written first; always safe */
     Serial_WriteString("\n\n");
     Serial_WriteString("panic(cpu 0): ");

--- a/src/kernel/arch/i386/display/bochs_vbe.c
+++ b/src/kernel/arch/i386/display/bochs_vbe.c
@@ -11,9 +11,11 @@
 #define VBE_IDX_YRES    0x2u
 #define VBE_IDX_BPP     0x3u
 #define VBE_IDX_ENABLE  0x4u
+#define VBE_IDX_VIDEO_MEMORY_64K  0xAu  /* total VRAM, in 64 KiB units */
 
 #define VBE_DISABLED    0x0000u
 #define VBE_ENABLED     0x0001u
+#define VBE_GETCAPS     0x0002u  /* while set, XRES/YRES/BPP reads return maxima */
 #define VBE_LFB         0x0040u
 
 #define VBE_ID_MIN  0xB0C0u
@@ -40,6 +42,73 @@ bool bochs_vbe_available(void)
 {
     uint16_t id = vbe_read(VBE_IDX_ID);
     return (id >= VBE_ID_MIN && id <= VBE_ID_MAX);
+}
+
+/* Adapter capabilities, probed once and cached.  The DISPI GETCAPS toggle
+ * momentarily clears the ENABLED bit, so we read it a single time (at boot,
+ * before our own mode is programmed) rather than on every setmode -- which
+ * would otherwise blink the screen each time the gate is consulted. */
+static int      s_caps_probed = 0;
+static uint32_t s_max_w, s_max_h, s_max_bpp, s_vram_bytes;
+
+static void probe_caps(void)
+{
+    if (s_caps_probed)
+        return;
+    s_caps_probed = 1;
+
+    if (!bochs_vbe_available())
+        return;
+
+    uint16_t saved = vbe_read(VBE_IDX_ENABLE);
+    vbe_write(VBE_IDX_ENABLE, VBE_GETCAPS);
+    s_max_w   = vbe_read(VBE_IDX_XRES);
+    s_max_h   = vbe_read(VBE_IDX_YRES);
+    s_max_bpp = vbe_read(VBE_IDX_BPP);
+    vbe_write(VBE_IDX_ENABLE, saved);            /* restore the live mode */
+
+    /* VIDEO_MEMORY_64K is not gated by GETCAPS; read it directly. */
+    s_vram_bytes = (uint32_t)vbe_read(VBE_IDX_VIDEO_MEMORY_64K) * 65536u;
+}
+
+uint32_t bochs_vbe_vram_bytes(void)
+{
+    probe_caps();
+    return s_vram_bytes;
+}
+
+void bochs_vbe_caps(uint32_t *max_w, uint32_t *max_h, uint32_t *max_bpp)
+{
+    probe_caps();
+    if (max_w)   *max_w   = s_max_w;
+    if (max_h)   *max_h   = s_max_h;
+    if (max_bpp) *max_bpp = s_max_bpp;
+}
+
+bool bochs_vbe_mode_supported(uint32_t width, uint32_t height, uint32_t bpp)
+{
+    if (!bochs_vbe_available())
+        return false;
+
+    probe_caps();
+
+    /* Honour whichever caps the adapter actually reports (0 = unknown). */
+    if (s_max_w   && width  > s_max_w)   return false;
+    if (s_max_h   && height > s_max_h)   return false;
+    if (s_max_bpp && bpp    > s_max_bpp) return false;
+
+    if (s_vram_bytes) {
+        uint64_t need = (uint64_t)width * height * (bpp / 8u);
+        if (need > s_vram_bytes)
+            return false;
+    }
+
+    /* Adapter reported nothing useful: vouch only for a minimal LFB we know
+     * is broadly safe (720p) and refuse anything larger. */
+    if (!s_max_w && !s_max_h && !s_vram_bytes)
+        return (width <= 1280 && height <= 720);
+
+    return true;
 }
 
 void bochs_vbe_set_mode(uint32_t width, uint32_t height, uint8_t bpp)

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -501,6 +501,11 @@ uint32_t vesa_tty_usable_rows(void)
     return tty_rows;
 }
 
+int vesa_tty_status_enabled(void)
+{
+    return s_status_visible;
+}
+
 /* ---------------------------------------------------------------------------
  * Legacy status-bar entry points.  makmux owns the actual tab bar in
  * userspace; the kernel only reserves the bottom row and offers raw cell

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1222,6 +1222,17 @@ void keyboard_test_driver(void)
             Serial_WriteString("KBTEST: alt-tab FAIL\n");
             pass = 0;
         }
+
+        /* 3: app-tab routing.  Type a fullscreen app in a makmux VT shell ->
+         *    it should open in its own named tab (not replace the shell). */
+        keyboard_inject_text("maktop\n");
+        ksleep(300);            /* sh.elf routes -> kernel queue -> makmux spawns */
+        if (vtty_find_name("maktop") >= 0) {
+            Serial_WriteString("KBTEST: app-tab PASS\n");
+        } else {
+            Serial_WriteString("KBTEST: app-tab FAIL\n");
+            pass = 0;
+        }
     } else {
         Serial_WriteString("KBTEST: alt-tab FAIL (makmux spawned no VTs)\n");
         pass = 0;

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -941,10 +941,10 @@ static void on_make(kc_t kc)
                 default: break;
             }
         }
-        /* Ctrl+Tab: cycle forward through live VT slots.
-         * Ctrl+Shift+Tab: cycle backward.
-         * Useful on Windows hosts where Alt+F4 is pre-mapped. */
-        if (mod_ctrl && kc == KC_TAB) {
+        /* Alt+Tab / Ctrl+Tab: cycle forward through live VT slots.
+         * Alt+Shift+Tab / Ctrl+Shift+Tab: cycle backward.  (Ctrl+Tab kept as
+         * an alias for Windows hosts where Alt+Tab is grabbed by the host WM.) */
+        if ((mod_alt || mod_ctrl) && kc == KC_TAB) {
             int n = vtty_count();
             if (n > 1) {
                 int cur  = vtty_active();
@@ -1195,12 +1195,39 @@ void keyboard_test_driver(void)
     ksleep(80);                 /* let sh.elf reach its first prompt */
 
     Serial_WriteString("KBTEST: start\n");
+    int pass = 1;
 
+    /* 1: type a command -> shell runs it -> output reaches serial.  Proves
+     *    inject -> decode -> ring -> shell -> exec -> serial end to end. */
     keyboard_inject_text("verbose on\n");   /* mirror shell output to serial */
     ksleep(80);
     keyboard_inject_text("echo KBINJECT_OK\n");
     ksleep(150);
 
+    /* 2: makmux + Alt-Tab / Alt-Shift-Tab VT cycling.  Asserts directly on
+     *    in-kernel state (vtty_active) -- no serial-scrape needed. */
+    keyboard_inject_text("makmux\n");
+    ksleep(400);                /* let makmux fork mak.sh1-4 + take focus */
+    if (vtty_count() > 1) {
+        int a0 = vtty_active();
+        keyboard_inject_key(KC_TAB, 0, 0, 1);   /* Alt+Tab       -> forward  */
+        ksleep(40);
+        int a1 = vtty_active();
+        keyboard_inject_key(KC_TAB, 1, 0, 1);   /* Alt+Shift+Tab -> backward */
+        ksleep(40);
+        int a2 = vtty_active();
+        if (a1 != a0 && a2 == a0) {
+            Serial_WriteString("KBTEST: alt-tab PASS\n");
+        } else {
+            Serial_WriteString("KBTEST: alt-tab FAIL\n");
+            pass = 0;
+        }
+    } else {
+        Serial_WriteString("KBTEST: alt-tab FAIL (makmux spawned no VTs)\n");
+        pass = 0;
+    }
+
+    Serial_WriteString(pass ? "KBTEST: ALL PASS\n" : "KBTEST: FAIL\n");
     Serial_WriteString("KBTEST: done\n");
     for (;;)
         task_yield();

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -112,6 +112,7 @@
 #include <kernel/timer.h>
 #include <kernel/vesa_tty.h>
 #include <kernel/serial.h>
+#include <kernel/ktest.h>
 
 /* ===========================================================================
  * Memory-ordering primitives
@@ -1137,6 +1138,72 @@ static void decoder_feed(uint8_t sc)
         return;
     }
     }
+}
+
+/* ===========================================================================
+ * Synthetic key injection -- deterministic in-guest test harness.
+ *
+ * Builds on keyboard_test_feed() (locked decoder_feed at the same entry the
+ * IRQ uses).  Crucially we do NOT call keyboard_test_begin(), so kb_focused
+ * is intact and the keys route to the focused task's ring -- i.e. they drive
+ * the *live* shell, full decode path and all (modifiers, Alt+Fn / Ctrl+Tab
+ * dispatch).  This replaces HMP `sendkey` for automation: keys land in the
+ * ring atomically with no QEMU PS/2 timing, so there are no typing races and
+ * it runs at full speed headless.
+ * ======================================================================== */
+void keyboard_inject_key(uint8_t kc, int shift, int ctrl, int alt)
+{
+    uint8_t k = kc & 0x7F;
+    if (ctrl)  keyboard_test_feed(KC_LCTRL);
+    if (alt)   keyboard_test_feed(KC_LALT);
+    if (shift) keyboard_test_feed(KC_LSHIFT);
+    keyboard_test_feed(k);                          /* make  */
+    keyboard_test_feed((uint8_t)(k | 0x80));        /* break */
+    if (shift) keyboard_test_feed((uint8_t)(KC_LSHIFT | 0x80));
+    if (alt)   keyboard_test_feed((uint8_t)(KC_LALT  | 0x80));
+    if (ctrl)  keyboard_test_feed((uint8_t)(KC_LCTRL | 0x80));
+}
+
+/* Printable char -> (keycode, needs-shift) by reversing the ASCII tables. */
+static int char_to_kc(char c, uint8_t *kc, int *shift)
+{
+    for (unsigned i = 0; i < sizeof(kc_ascii_lower); i++)
+        if (kc_ascii_lower[i] == (unsigned char)c) { *kc=(uint8_t)i; *shift=0; return 1; }
+    for (unsigned i = 0; i < sizeof(kc_ascii_upper); i++)
+        if (kc_ascii_upper[i] == (unsigned char)c) { *kc=(uint8_t)i; *shift=1; return 1; }
+    return 0;
+}
+
+void keyboard_inject_text(const char *s)
+{
+    for (; *s; s++) {
+        uint8_t kc; int shift;
+        if (char_to_kc(*s, &kc, &shift))
+            keyboard_inject_key(kc, shift, 0, 0);
+    }
+}
+
+/* keyboard_test_driver -- in-guest scripted keyboard scenarios, spawned on a
+ * normal boot when `kbtest` is on the cmdline.  Drives the live shell by
+ * injecting keys and emits KBTEST markers to serial; the host asserts on the
+ * shell output between markers (deterministic, no HMP).  This is the seed of
+ * the harness that replaces the flaky sendkey UI scenarios. */
+void keyboard_test_driver(void)
+{
+    while (!ktest_bg_done)
+        task_yield();
+    ksleep(80);                 /* let sh.elf reach its first prompt */
+
+    Serial_WriteString("KBTEST: start\n");
+
+    keyboard_inject_text("verbose on\n");   /* mirror shell output to serial */
+    ksleep(80);
+    keyboard_inject_text("echo KBINJECT_OK\n");
+    ksleep(150);
+
+    Serial_WriteString("KBTEST: done\n");
+    for (;;)
+        task_yield();
 }
 
 /*

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1233,6 +1233,22 @@ void keyboard_test_driver(void)
             Serial_WriteString("KBTEST: app-tab FAIL\n");
             pass = 0;
         }
+
+        /* 4: close every tab -> makmux exits -> focus + screen return to
+         *    mak.sh0 (the root console).  Asserts vtty_count() drops to 0. */
+        keyboard_inject_text("q");          /* quit maktop (q/Esc/F10) */
+        ksleep(150);
+        for (int e = 0; e < 5; e++) {       /* exit the four VT shells */
+            keyboard_inject_text("exit\n");
+            ksleep(120);
+        }
+        ksleep(150);
+        if (vtty_count() == 0) {
+            Serial_WriteString("KBTEST: exit-restore PASS\n");
+        } else {
+            Serial_WriteString("KBTEST: exit-restore FAIL\n");
+            pass = 0;
+        }
     } else {
         Serial_WriteString("KBTEST: alt-tab FAIL (makmux spawned no VTs)\n");
         pass = 0;

--- a/src/kernel/arch/i386/fs/ext2.c
+++ b/src/kernel/arch/i386/fs/ext2.c
@@ -701,6 +701,17 @@ void ext2_unmount(void)
 
 int ext2_mounted(void) { return s_mounted; }
 
+/* Filesystem usage in KiB (total + free), from the superblock block counts. */
+int ext2_statfs(uint32_t *total_kb, uint32_t *free_kb)
+{
+    if (!s_mounted) return -1;
+    uint32_t kb_per_blk = s_block_size / 1024u;
+    if (!kb_per_blk) kb_per_blk = 1u;
+    if (total_kb) *total_kb = s_sb.s_blocks_count      * kb_per_blk;
+    if (free_kb)  *free_kb  = s_sb.s_free_blocks_count * kb_per_blk;
+    return 0;
+}
+
 /* ---- read API ----------------------------------------------------------- */
 
 int ext2_file_exists(const char *path)

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -205,14 +205,17 @@ static void render_meminfo(pf_writer_t *w)
     size_t heap_u     = heap_used();
     size_t heap_f     = heap_free();
 
-    /* The kernel heap is identity-mapped on top of PMM frames that the
-     * allocator never reserved, so heap usage is invisible to the PMM
-     * bitmap.  Fold heap_used into MemUsed (and out of MemFree) so
-     * /proc/meminfo reflects the real working set — otherwise MemUsed
-     * sits near zero on a freshly booted 32 MiB system. */
+    /* The kernel image (everything from 0 up to _kernel_end: BIOS low memory
+     * + the loaded kernel) and the heap live outside the PMM-managed frame
+     * pool, so neither shows up in used_frames.  Count both as used (and add
+     * the kernel image into the total) so MemUsed reflects the real working
+     * set instead of sitting near zero on a freshly booted 32 MiB system --
+     * this is what maktop and the statusbar mem widget display. */
+    extern uint32_t _kernel_end;
+    uint32_t kernel_kb    = (uint32_t)&_kernel_end / 1024u;
     uint32_t heap_used_kb = (uint32_t)(heap_u / 1024u);
-    uint32_t total_kb = total_frames * 4u;
-    uint32_t used_kb  = used_frames  * 4u + heap_used_kb;
+    uint32_t total_kb = total_frames * 4u + kernel_kb;
+    uint32_t used_kb  = used_frames  * 4u + heap_used_kb + kernel_kb;
     uint32_t free_kb  = (total_kb > used_kb) ? (total_kb - used_kb) : 0u;
 
     pf_puts(w, "MemTotal:        "); pf_putu(w, total_kb); pf_puts(w, " kB\n");

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -898,6 +898,20 @@ int vfs_rootfs_is_disk(void)
     return 0;
 }
 
+/* Rootfs usage in KiB (total + free).  Accurate for ext2; FAT32 free needs a
+ * FAT scan (not done) and ISO9660 has no free space, so both return -1. */
+int vfs_statfs(uint32_t *total_kb, uint32_t *free_kb)
+{
+    for (int i = 0; i < s_nmounts; i++) {
+        if (s_mounts[i].mountpoint[0] == '/' && s_mounts[i].mountpoint[1] == '\0') {
+            if (s_mounts[i].backend == VFS_BACKEND_EXT2)
+                return ext2_statfs(total_kb, free_kb);
+            return -1;
+        }
+    }
+    return -1;
+}
+
 const char *vfs_hd_fsname(const char *name)
 {
     int mi = name ? mount_find_slot(name) : -1;

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -26,6 +26,7 @@
  */
 
 #include <kernel/installer.h>
+#include <kernel/task.h>
 #include <kernel/auth.h>
 #include <kernel/acpi.h>
 #include <kernel/timer.h>
@@ -112,8 +113,13 @@ static int s_nents;
 /* Installed target info, set during do_install so the account-creation
  * wizard can remount the data partition without re-discovering it. */
 static uint8_t  s_inst_drive;
+static uint32_t s_inst_boot_lba;
 static uint32_t s_inst_data_lba;
 static int      s_inst_fs;
+
+/* Optional component trees, chosen in the wizard (default: install both). */
+static int      s_inst_docs = 1;   /* copy /docs to the target rootfs */
+static int      s_inst_src  = 1;   /* copy /src  to the target rootfs */
 
 /* ------------------------------------------------------------------------- */
 /* Geometry                                                                  */
@@ -383,6 +389,7 @@ static void exec_screen(const char *title)
 {
     s_log_n = 0;
     if (g_gui) {
+        vesa_tty_clear();
         tui_frame(title, "Installing - please wait...");
         s_box_top   = 2;
         s_box_bot   = (g_rows > 4) ? g_rows - 3 : g_rows - 1;
@@ -779,29 +786,8 @@ static int do_install(uint8_t drive, uint32_t disk_sectors, int fs)
         return -2;
     }
 
-    tui_log("Mounting boot partition...");
-    if (fat32_mounted()) fat32_unmount();
-    if ((rc = fat32_mount(drive, boot_lba)) != 0) {
-        tui_log_rc("  ERROR: boot mount failed.", rc); return -3;
-    }
-    g_root_fs = ROOTFS_FAT32;
-
-    tui_log("Creating boot directory tree...");
-    if ((rc = fat32_mkdir("/boot"))   != 0) tui_log_rc("  WARNING: mkdir /boot failed.", rc);
-    if ((rc = fat32_mkdir("/limine")) != 0) tui_log_rc("  WARNING: mkdir /limine failed.", rc);
-
-    tui_log("Copying kernel...");
-    copy_one("/boot/makar.kernel", "/boot/makar.kernel");
-
-    tui_log("Copying limine-bios.sys...");
-    copy_one(LIMINE_SYS_ISO_PATH, "/limine/limine-bios.sys");
-
-    tui_log("Writing limine.conf...");
-    if ((rc = rfs_write("/limine/limine.conf", limine_conf,
-                        (uint32_t)(sizeof(limine_conf) - 1))) != 0)
-        tui_log_rc("  WARNING: failed to write limine.conf.", rc);
-
-    fat32_unmount();
+    /* Boot files are copied after the remaining wizard inputs have been
+     * collected.  This phase only prepares the filesystem. */
 
     /* ---- Partition 2: data (apps / docs / src) ---- */
 
@@ -828,24 +814,13 @@ static int do_install(uint8_t drive, uint32_t disk_sectors, int fs)
     g_root_fs = fs;
     /* Record for the post-install account-creation step. */
     s_inst_drive    = drive;
+    s_inst_boot_lba = boot_lba;
     s_inst_data_lba = data_lba;
     s_inst_fs       = fs;
 
-    copy_tree("/apps");
-    copy_tree("/docs");
-    copy_tree("/src");
-    copy_tree("/usr");
-
-    /* /bin is the scratch + output directory the in-OS kernel rebuild
-     * (rebuild-kernel.sh) writes to.  tmpfs has no subdirectories, so
-     * the rebuild can't use /tmp; it needs a real writable dir on the
-     * rootfs.  Create it empty here so the first `mkdir /bin/ktcc` from
-     * the script doesn't try to create a directory inside a missing
-     * parent.  No source tree to copy -- /bin lives only on the target. */
-    if (rfs_mkdir("/bin") != 0)
-        tui_log("  WARNING: mkdir /bin on rootfs failed (rebuild-kernel will need it).");
-
-    /* Flush data partition before touching the bootloader. */
+    /* Data partition contents are copied after the remaining wizard inputs
+     * have been collected, so the installer does not spend time mirroring
+     * large trees before hostname/account prompts. */
     if (fs == ROOTFS_EXT2) ext2_unmount(); else fat32_unmount();
 
     /* ---- limine MBR install ---- */
@@ -916,7 +891,23 @@ static int build_drive_list(void)
 /* installer_run                                                             */
 /* ------------------------------------------------------------------------- */
 
+static void installer_run_inner(void);
+
+/* Public entry: run the wizard with the calling task renamed "installer" so
+ * the userspace status bar's `command` widget reflects what's on screen.  The
+ * name is restored on every exit path (the success path reboots, so its
+ * restore is moot).  name is just a const char* pointer, so swapping it to a
+ * string literal and back is safe. */
 void installer_run(void)
+{
+    task_t     *me    = task_current();
+    const char *saved = me ? me->name : (const char *)0;
+    if (me) me->name = "installer";
+    installer_run_inner();
+    if (me) me->name = saved;
+}
+
+static void installer_run_inner(void)
 {
     tui_geometry();
     Serial_WriteString("INSTALL>welcome\n");
@@ -1017,30 +1008,29 @@ void installer_run(void)
         return;
     }
 
-    s_filebuf = (uint8_t *)kmalloc(INST_MAX_FILE_SIZE);
-    if (!s_filebuf) {
-        t_writestring("Error: out of memory for transfer buffer.\n");
-        return;
-    }
-
-    int rc = do_install((uint8_t)drive, hdd->size, fs);
-    kfree(s_filebuf);
-    s_filebuf = NULL;
-
-    /* Serial-visible result marker (the GUI "done" screen below is painted
-     * directly to the framebuffer and does not mirror to COM1). */
-    t_writestring(rc == 0 ? "INSTALL: complete ok\n" : "INSTALL: failed\n");
-
-    if (rc != 0) {
+    /* ---- Optional components: docs + source trees (default: install both) ---- */
+    Serial_WriteString("INSTALL>components\n");
+    {
+        unsigned char a1 = 0, a2 = 0;
         if (g_gui) {
-            tui_frame("Installer", "Press a key to return to the shell");
-            tui_center(6, "Installation FAILED.", C_WARN, C_BG);
-            tui_center(8, "See the messages above; nothing was finalised.", C_DIM, C_BG);
-            getkey();
+            tui_frame("Components", "Choose which optional trees to install.");
+            uint32_t mid  = g_rows / 2;
+            uint32_t lcol = (g_cols / 2) > 20 ? (g_cols / 2) - 20 : 2;
+            tui_at(lcol, mid - 1, "Install documentation (/docs)? [Y/n]", C_FG, C_BG);
+            a1 = getkey();
+            tui_at(lcol, mid + 1, "Install source code (/src)? [Y/n]", C_FG, C_BG);
+            a2 = getkey();
         } else {
-            t_writestring("\n=== Installation FAILED ===\n");
+            char buf[8];
+            t_writestring("Install documentation (/docs)? [Y/n] ");
+            readline(buf, sizeof(buf)); a1 = (unsigned char)buf[0];
+            t_writestring("Install source code (/src)? [Y/n] ");
+            readline(buf, sizeof(buf)); a2 = (unsigned char)buf[0];
         }
-        return;
+        s_inst_docs = (a1 == 'n' || a1 == 'N') ? 0 : 1;
+        s_inst_src  = (a2 == 'n' || a2 == 'N') ? 0 : 1;
+        Serial_WriteString(s_inst_docs ? "[install] docs: yes\n" : "[install] docs: no\n");
+        Serial_WriteString(s_inst_src  ? "[install] src: yes\n"  : "[install] src: no\n");
     }
 
     /* ------------------------------------------------------------------ */
@@ -1325,9 +1315,69 @@ void installer_run(void)
     }
 
     /* ------------------------------------------------------------------ */
-    /* Single disk write: hostname + shadow + home dirs                   */
-    /* One mount/unmount — no double-remount of the live rootfs.          */
+    /* Disk preparation: no partitioning/formatting/copying starts until */
+    /* all installer input has been collected.                           */
     /* ------------------------------------------------------------------ */
+
+    s_filebuf = (uint8_t *)kmalloc(INST_MAX_FILE_SIZE);
+    if (!s_filebuf) {
+        t_writestring("Error: out of memory for transfer buffer.\n");
+        return;
+    }
+
+    int rc = do_install((uint8_t)drive, hdd->size, fs);
+
+    if (rc != 0) {
+        t_writestring("INSTALL: failed\n");
+        kfree(s_filebuf);
+        s_filebuf = NULL;
+        if (g_gui) {
+            tui_frame("Installer", "Press a key to return to the shell");
+            tui_center(6, "Installation FAILED.", C_WARN, C_BG);
+            tui_center(8, "See the messages above; nothing was finalised.", C_DIM, C_BG);
+            getkey();
+        } else {
+            t_writestring("\n=== Installation FAILED ===\n");
+        }
+        return;
+    }
+    Serial_WriteString("INSTALL: disk prepared ok\n");
+
+    /* ------------------------------------------------------------------ */
+    /* Final disk writes: boot files, account config, and optional trees. */
+    /* All file copying happens here, after the remaining wizard inputs. */
+    /* ------------------------------------------------------------------ */
+    {
+        tui_log("Mounting boot partition...");
+        if (fat32_mounted()) fat32_unmount();
+        int bm = fat32_mount(s_inst_drive, s_inst_boot_lba);
+        if (bm == 0) {
+            g_root_fs = ROOTFS_FAT32;
+
+            tui_log("Creating boot directory tree...");
+            int brc;
+            if ((brc = fat32_mkdir("/boot")) != 0)
+                tui_log_rc("  WARNING: mkdir /boot failed.", brc);
+            if ((brc = fat32_mkdir("/limine")) != 0)
+                tui_log_rc("  WARNING: mkdir /limine failed.", brc);
+
+            tui_log("Copying kernel...");
+            copy_one("/boot/makar.kernel", "/boot/makar.kernel");
+
+            tui_log("Copying limine-bios.sys...");
+            copy_one(LIMINE_SYS_ISO_PATH, "/limine/limine-bios.sys");
+
+            tui_log("Writing limine.conf...");
+            if ((brc = rfs_write("/limine/limine.conf", limine_conf,
+                                  (uint32_t)(sizeof(limine_conf) - 1))) != 0)
+                tui_log_rc("  WARNING: failed to write limine.conf.", brc);
+
+            fat32_unmount();
+        } else {
+            tui_log_rc("  WARNING: boot mount failed during final copy.", bm);
+        }
+    }
+
     {
         int mnt = (s_inst_fs == ROOTFS_EXT2)
             ? ext2_mount(s_inst_drive, s_inst_data_lba)
@@ -1455,8 +1505,8 @@ void installer_run(void)
                 Serial_WriteString(vix_path);
                 Serial_WriteString("\n");
 
-                /* Write ~/.sbrc -- statusbar.elf layout (hostname left,
-                 * date+time right).  Sections: left/center/right + widgets. */
+                /* Write ~/.sbrc -- statusbar.elf layout (foreground command
+                 * left, resources right).  Sections: left/center/right + widgets. */
                 char sb_path[88];
                 p = 0;
                 for (size_t j = 0; hdir[j] && p < sizeof(sb_path) - 7; j++)
@@ -1468,7 +1518,7 @@ void installer_run(void)
                     "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
                     "# widgets: hostname user date time datetime uptime\n"
                     "#          cpu mem rootfs command tabs\n"
-                    "left hostname\n"
+                    "left command\n"
                     "center tabs\n"
                     "right cpu mem rootfs time\n";
                 size_t sb_len = 0;
@@ -1479,17 +1529,34 @@ void installer_run(void)
                 Serial_WriteString("\n");
             }
 
+            copy_tree("/apps");
+            if (s_inst_docs) copy_tree("/docs");
+            if (s_inst_src)  copy_tree("/src");
+            copy_tree("/usr");
+
+            /* /bin is the scratch + output directory the in-OS kernel rebuild
+             * (rebuild-kernel.sh) writes to.  tmpfs has no subdirectories, so
+             * the rebuild can't use /tmp; it needs a real writable dir on the
+             * rootfs.  Create it empty here so the first `mkdir /bin/ktcc` from
+             * the script doesn't try to create a directory inside a missing
+             * parent.  No source tree to copy -- /bin lives only on the target. */
+            if (rfs_mkdir("/bin") != 0)
+                tui_log("  WARNING: mkdir /bin on rootfs failed (rebuild-kernel will need it).");
+
             if (s_inst_fs == ROOTFS_EXT2) ext2_unmount();
             else fat32_unmount();
         } else {
             Serial_WriteString("[install] WARNING: could not mount data fs for post-install writes\n");
         }
     }
+    kfree(s_filebuf);
+    s_filebuf = NULL;
 
     /* ------------------------------------------------------------------ */
     /* Done                                                                 */
     /* ------------------------------------------------------------------ */
 
+    t_writestring("INSTALL: complete ok\n");
     Serial_WriteString("[install] complete — rebooting\n");
     if (g_gui) {
         tui_frame("Installer", "Rebooting...");
@@ -1498,10 +1565,8 @@ void installer_run(void)
     } else {
         t_writestring("\n=== Installation complete! Rebooting... ===\n");
     }
-    /* Yield ~1500 times so the scheduler runs and the user can read the
-     * message.  task_yield() works even if the timer tick is stuck, because
-     * keyboard_getchar() uses the same mechanism and we know it runs. */
-    for (int i = 0; i < 1500; i++)
+    uint32_t reboot_at = timer_get_ticks() + 300u; /* 3 seconds at 100 Hz */
+    while (timer_get_ticks() < reboot_at)
         task_yield();
     acpi_reboot();
 }

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -1466,8 +1466,9 @@ void installer_run(void)
                 sb_path[p]='\0';
                 static const char sbrc[] =
                     "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
-                    "# widgets: hostname user date time datetime uptime\n"
+                    "# widgets: hostname user date time datetime uptime tabs\n"
                     "left hostname\n"
+                    "center tabs\n"
                     "right date time\n";
                 size_t sb_len = 0;
                 while (sbrc[sb_len]) sb_len++;

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -1466,10 +1466,11 @@ void installer_run(void)
                 sb_path[p]='\0';
                 static const char sbrc[] =
                     "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
-                    "# widgets: hostname user date time datetime uptime tabs\n"
+                    "# widgets: hostname user date time datetime uptime\n"
+                    "#          cpu mem rootfs command tabs\n"
                     "left hostname\n"
                     "center tabs\n"
-                    "right date time\n";
+                    "right cpu mem rootfs time\n";
                 size_t sb_len = 0;
                 while (sbrc[sb_len]) sb_len++;
                 rfs_write(sb_path, sbrc, (uint32_t)sb_len);

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -1111,6 +1111,8 @@ void installer_run(void)
         size_t shadow_len;
     } w_accts[2];
     int w_naccts = 0;
+    char w_autologin[64];   /* username to auto-log-in, or "" for none */
+    w_autologin[0] = '\0';
 
     static const struct { const char *user; const char *prompt; int required; }
     acct_steps[] = {
@@ -1280,6 +1282,49 @@ void installer_run(void)
     }
 
     /* ------------------------------------------------------------------ */
+    /* Auto-login toggle — offer to skip the password prompt on boot.     */
+    /* ------------------------------------------------------------------ */
+    {
+        /* Prefer the first non-root account; fall back to root. */
+        const char *cand = (const char *)0;
+        for (int i = 0; i < w_naccts; i++) {
+            const char *u = w_accts[i].username;
+            int is_root = (u[0]=='r'&&u[1]=='o'&&u[2]=='o'&&u[3]=='t'&&u[4]=='\0');
+            if (!is_root) { cand = u; break; }
+        }
+        if (!cand && w_naccts > 0) cand = w_accts[0].username;
+
+        if (cand) {
+            char q[96]; size_t qp = 0;
+            const char *pre = "Enable auto-login for '";
+            for (const char *s = pre;  *s && qp < sizeof(q)-1; s++) q[qp++] = *s;
+            for (const char *s = cand; *s && qp < sizeof(q)-1; s++) q[qp++] = *s;
+            const char *suf = "'? [y/N]";
+            for (const char *s = suf;  *s && qp < sizeof(q)-1; s++) q[qp++] = *s;
+            q[qp] = '\0';
+
+            unsigned char ans = 0;
+            if (g_gui) {
+                tui_frame("Auto-login",
+                          "Skip the password prompt and sign in automatically on boot?");
+                uint32_t mid  = g_rows / 2;
+                uint32_t lcol = (g_cols / 2) > 20 ? (g_cols / 2) - 20 : 2;
+                tui_at(lcol, mid - 1, q, C_FG, C_BG);
+                ans = getkey();
+            } else {
+                t_writestring(q); t_writestring(" ");
+                char buf[8]; readline(buf, sizeof(buf));
+                ans = (unsigned char)buf[0];
+            }
+            if (ans == 'y' || ans == 'Y') {
+                size_t i = 0;
+                while (cand[i] && i < sizeof(w_autologin)-1) { w_autologin[i] = cand[i]; i++; }
+                w_autologin[i] = '\0';
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
     /* Single disk write: hostname + shadow + home dirs                   */
     /* One mount/unmount — no double-remount of the live rootfs.          */
     /* ------------------------------------------------------------------ */
@@ -1305,6 +1350,21 @@ void installer_run(void)
                 Serial_WriteString("\n");
             }
 
+            /* /etc/autologin — written only if the operator opted in. */
+            if (w_autologin[0]) {
+                char albuf[66];
+                size_t al = 0;
+                while (w_autologin[al] && al < sizeof(albuf) - 2) {
+                    albuf[al] = w_autologin[al]; al++;
+                }
+                albuf[al++] = '\n';
+                albuf[al]   = '\0';
+                rfs_write("/etc/autologin", albuf, (uint32_t)al);
+                Serial_WriteString("[install] autologin: ");
+                Serial_WriteString(w_autologin);
+                Serial_WriteString("\n");
+            }
+
             /* /etc/shadow — concatenate all entries */
             if (w_naccts > 0) {
                 static char shadow_buf[512];
@@ -1322,7 +1382,7 @@ void installer_run(void)
                 rfs_write("/etc/shadow", shadow_buf, (uint32_t)spos);
             }
 
-            /* Home directories + default .makrc */
+            /* Home directories + default .makshrc */
             rfs_mkdir("/root");
             rfs_mkdir("/home");
             for (int i = 0; i < w_naccts; i++) {
@@ -1350,28 +1410,70 @@ void installer_run(void)
                 Serial_WriteString(hdir);
                 Serial_WriteString("\n");
 
-                /* Write ~/.makrc with defaults */
+                /* Write ~/.makshrc with defaults */
                 char rc_path[88];
                 p = 0;
-                for (size_t j = 0; hdir[j] && p < sizeof(rc_path)-8; j++)
+                for (size_t j = 0; hdir[j] && p < sizeof(rc_path)-10; j++)
                     rc_path[p++] = hdir[j];
                 rc_path[p++]='/'; rc_path[p++]='.'; rc_path[p++]='m';
-                rc_path[p++]='a'; rc_path[p++]='k'; rc_path[p++]='r';
-                rc_path[p++]='c'; rc_path[p]='\0';
+                rc_path[p++]='a'; rc_path[p++]='k'; rc_path[p++]='s';
+                rc_path[p++]='h'; rc_path[p++]='r'; rc_path[p++]='c';
+                rc_path[p]='\0';
 
-                /* Default .makrc content */
+                /* Default .makshrc content */
                 static const char makrc_root[] =
-                    "# ~/.makrc -- sourced by sh.elf on login\n"
+                    "# ~/.makshrc -- sourced by sh.elf on login\n"
                     "PATH=/apps:/bin\n";
                 static const char makrc_user[] =
-                    "# ~/.makrc -- sourced by sh.elf on login\n"
+                    "# ~/.makshrc -- sourced by sh.elf on login\n"
                     "PATH=/apps:/bin\n";
                 const char *rc_content = is_root ? makrc_root : makrc_user;
                 size_t rc_len = 0;
                 while (rc_content[rc_len]) rc_len++;
                 rfs_write(rc_path, rc_content, (uint32_t)rc_len);
-                Serial_WriteString("[install] makrc: ");
+                Serial_WriteString("[install] makshrc: ");
                 Serial_WriteString(rc_path);
+                Serial_WriteString("\n");
+
+                /* Write ~/.vixrc enabling line numbers by default.  vix
+                 * itself ships with line numbers OFF; this rc opts each
+                 * installed account into them (Ctrl-N toggles at runtime). */
+                char vix_path[88];
+                p = 0;
+                for (size_t j = 0; hdir[j] && p < sizeof(vix_path) - 8; j++)
+                    vix_path[p++] = hdir[j];
+                vix_path[p++]='/'; vix_path[p++]='.'; vix_path[p++]='v';
+                vix_path[p++]='i'; vix_path[p++]='x'; vix_path[p++]='r';
+                vix_path[p++]='c'; vix_path[p]='\0';
+                static const char vixrc[] =
+                    "\" ~/.vixrc -- read by vix on startup\n"
+                    "set linenumbers\n";
+                size_t vix_len = 0;
+                while (vixrc[vix_len]) vix_len++;
+                rfs_write(vix_path, vixrc, (uint32_t)vix_len);
+                Serial_WriteString("[install] vixrc: ");
+                Serial_WriteString(vix_path);
+                Serial_WriteString("\n");
+
+                /* Write ~/.sbrc -- statusbar.elf layout (hostname left,
+                 * date+time right).  Sections: left/center/right + widgets. */
+                char sb_path[88];
+                p = 0;
+                for (size_t j = 0; hdir[j] && p < sizeof(sb_path) - 7; j++)
+                    sb_path[p++] = hdir[j];
+                sb_path[p++]='/'; sb_path[p++]='.'; sb_path[p++]='s';
+                sb_path[p++]='b'; sb_path[p++]='r'; sb_path[p++]='c';
+                sb_path[p]='\0';
+                static const char sbrc[] =
+                    "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
+                    "# widgets: hostname user date time datetime uptime\n"
+                    "left hostname\n"
+                    "right date time\n";
+                size_t sb_len = 0;
+                while (sbrc[sb_len]) sb_len++;
+                rfs_write(sb_path, sbrc, (uint32_t)sb_len);
+                Serial_WriteString("[install] sbrc: ");
+                Serial_WriteString(sb_path);
                 Serial_WriteString("\n");
             }
 

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -350,8 +350,12 @@ static void test_usr(void)
     /* The sentinel probe must work via the /usr rewrite. */
     KTEST_ASSERT(vfs_file_exists("/usr/lib/crt0.o") == 1);
 
-    /* libc.a must be reachable via /usr/lib. */
+    /* Runtime libraries and TCC startup objects must be reachable via /usr/lib. */
     KTEST_ASSERT(vfs_file_exists("/usr/lib/libc.a") == 1);
+    KTEST_ASSERT(vfs_file_exists("/usr/lib/crt1.o") == 1);
+    KTEST_ASSERT(vfs_file_exists("/usr/lib/crti.o") == 1);
+    KTEST_ASSERT(vfs_file_exists("/usr/lib/crtn.o") == 1);
+    KTEST_ASSERT(vfs_file_exists("/usr/lib/tcc/libtcc1.a") == 1);
 
     /* Headers must be reachable via /usr/include. */
     KTEST_ASSERT(vfs_file_exists("/usr/include/stdio.h") == 1);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -203,12 +203,15 @@ static void test_partition(void)
 /* ---------------------------------------------------------------------------
  * Suite: devfs
  *
- * Exercises the /dev synthetic filesystem against the boot CD-ROM, which
- * is always present on an ISO boot (the medium we booted from).  Verifies
- * node lookup, the read-only flag, a real ATAPI sector read through the
- * byte-addressed devfs_pread path, and negative lookups.  Disk-dependent
- * assertions (hda/partitions) are intentionally omitted so the suite is
- * stable on CD-only boots.
+ * Exercises the /dev synthetic filesystem.  Boot-mode aware: the medium we
+ * actually booted from dictates which device gets the read/readonly probes,
+ * so the suite passes identically on ISO and HDD boots.
+ *   - Negative lookups + "root is not a node" run unconditionally.
+ *   - The CD-ROM node carries media only on ISO/live boots; an HDD boot
+ *     still exposes an (empty) ATAPI drive, so the media-dependent asserts
+ *     run only when devfs_node_size(cdrom) > 0.
+ *   - The primary ATA disk (hda) is probed when present (HDD boots, or live
+ *     boots with an installed disk attached).
  * ------------------------------------------------------------------------- */
 
 static void test_devfs(void)
@@ -221,13 +224,15 @@ static void test_devfs(void)
     /* The mount root itself is not a node. */
     KTEST_ASSERT(devfs_lookup("/") < 0);
 
-    /* The CD-ROM we booted from is always registered. */
+    /* CD-ROM node: registered whenever an ATAPI drive exists, but only
+     * carries media on the ISO/live boot path.  An HDD-only boot still
+     * exposes an empty ATAPI drive (devfs_node_size == 0), so gate the
+     * media-dependent checks on real media being present -- the suite must
+     * pass on both ISO and HDD boots. */
     int cd = devfs_lookup("/cdrom");
-    KTEST_ASSERT(cd >= 0);
-    if (cd >= 0) {
+    if (cd >= 0 && devfs_node_size(cd) > 0) {
         KTEST_ASSERT(devfs_file_exists("/cdrom") == 1);
         KTEST_ASSERT(devfs_node_readonly(cd) == 1);
-        KTEST_ASSERT(devfs_node_size(cd) > 0);
 
         /* A byte-addressed read of the first sector must succeed and fill
          * the request (offset 0, a full 2048-byte ATAPI sector). */
@@ -237,6 +242,16 @@ static void test_devfs(void)
 
         /* Writes to a read-only node are rejected. */
         KTEST_ASSERT(devfs_pwrite(cd, sec, sizeof(sec), 0) < 0);
+    }
+
+    /* Primary ATA disk: present on HDD boots (the medium we booted from)
+     * and on live boots with an installed disk attached.  Verify a
+     * byte-addressed 512-byte sector read through devfs_pread when present. */
+    int hd = devfs_lookup("/hda");
+    if (hd >= 0 && devfs_node_size(hd) > 0) {
+        static uint8_t blk[512];
+        long n = devfs_pread(hd, blk, sizeof(blk), 0);
+        KTEST_ASSERT(n == (long)sizeof(blk));
     }
 
     ktest_summary();

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1826,8 +1826,13 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
     case SYS_VT_STATE: {
-        uint32_t active = (uint32_t)(vtty_active() & 0xFFFF);
         uint32_t mask = vtty_live_mask() & 0xFFFFu;
+        /* High 16 bits = focused tty.  With makmux running that's the active
+         * VT slot (0-3); with no VT children the root console (mak.sh0) is
+         * focused, so report VTTY_ROOT_SLOT -- lets the userspace statusbar's
+         * `command` widget find the root shell's foreground task. */
+        uint32_t active = mask ? (uint32_t)(vtty_active() & 0xFFFF)
+                               : (uint32_t)VTTY_ROOT_SLOT;
         regs->eax = (active << 16) | mask;
         break;
     }

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <kernel/ktest.h>
 #include <kernel/admin.h>
+#include <kernel/auth.h>
 
 /* USER_STACK_TOP / USER_STACK_PAGES - matches elf.c; defined locally to
  * avoid pulling that header into syscall.c just for these constants.
@@ -191,15 +192,30 @@ void syscall_dispatch(registers_t *regs)
                                 if (me->tty != VTTY_ROOT_SLOT && pvt) {
                                     /* Normal VT: child wrote into this buffer,
                                      * clear it so the parent's next prompt
-                                     * lands on a blank slate. */
-                                    vt_set_color(pvt,
-                                                 me->disp_fg_saved ? me->disp_fg_saved : pvt->fg,
-                                                 me->disp_bg_saved ? me->disp_bg_saved : pvt->bg);
+                                     * lands on a blank slate.  Restore the VT's
+                                     * scheme straight from the fork snapshot --
+                                     * not `saved ? saved : pvt`, because a real
+                                     * scheme colour can be 0x000000 (black fg on
+                                     * the black-on-white VT) and the falsy-zero
+                                     * fallback would keep vix's clobbered colour. */
+                                    vt_set_color(pvt, me->disp_fg_saved, me->disp_bg_saved);
                                     vt_clear(pvt);
+                                } else if (pvt) {
+                                    /* Root slot (mak.sh0): the fullscreen child
+                                     * ran as TASK_TTY_NONE and drew straight to
+                                     * the framebuffer without ever touching
+                                     * mak.sh0's backing buffer.  Wipe those raw
+                                     * pixels and repaint the console buffer so
+                                     * the hand-back is identical to the other
+                                     * VTs -- vix/maktop/etc. don't leave a frozen
+                                     * frame behind.  makmux also lands here, and
+                                     * its buffer is intact (it only drew status
+                                     * rows + child VTs), so this still restores
+                                     * the pre-makmux screen, just on a clean FB. */
+                                    vesa_tty_setcolor(me->disp_fg_saved, me->disp_bg_saved);
+                                    vesa_tty_clear();
+                                    vesa_tty_paint_buf(pvt);
                                 }
-                                /* Root slot: buffer retains mak.sh0's prior
-                                 * output — repaint as-is to restore the
-                                 * screen the user had before makmux ran. */
                             }
                             vtty_request_repaint(me->tty);
                         } else if (vesa_tty_is_ready()) {
@@ -1368,13 +1384,11 @@ void syscall_dispatch(registers_t *regs)
      * Returns EAX = (cols << 16) | rows.
      * ------------------------------------------------------------------ */
     case SYS_TERM_SIZE: {
-        /* Report the *drawable* area, not the full framebuffer.  The
-         * bottom VESA_TTY_STATUS_ROWS row is reserved for the makmux
-         * status bar -- but only when makmux has registered VT children
-         * (vtty_count() > 0).  Without makmux, fullscreen apps get the
-         * whole screen; with makmux they get (rows-1) so they don't stomp
-         * the bar.  Resolution-aware because vesa_tty_get_rows() and the
-         * constant scale with the chosen mode. */
+        /* Report the *drawable* area (vesa_tty_usable_rows), which excludes
+         * the bottom status row whenever the status bar is enabled (reserved)
+         * -- so shells/apps stay above it and statusbar.elf draws at row =
+         * usable_rows.  When the bar is toggled off (Alt+F5) the row is freed
+         * and apps get the full height.  Resolution-aware. */
         uint32_t cols, rows;
         if (vesa_tty_is_ready()) {
             cols = vesa_tty_get_cols();
@@ -1842,6 +1856,31 @@ void syscall_dispatch(registers_t *regs)
         }
         uint32_t copy = (slen + 1 > size) ? (size - 1) : slen;
         for (uint32_t i = 0; i < copy; i++) buf[i] = src[i];
+        buf[copy] = '\0';
+        regs->eax = (uint32_t)copy;
+        break;
+    }
+
+    case SYS_STATUSBAR: {
+        /* Mechanism for userspace statusbar.elf: reserve/free the bottom row.
+         * The renderer (which widgets, layout, .sbrc) lives in userspace. */
+        int cmd = (int)regs->ebx;
+        if (cmd == 0)      vesa_tty_set_status_visible(0);
+        else if (cmd == 1) vesa_tty_set_status_visible(1);
+        regs->eax = (uint32_t)vesa_tty_status_enabled();
+        break;
+    }
+
+    case SYS_WHOAMI: {
+        char *buf = (char *)regs->ebx;
+        uint32_t size = regs->ecx;
+        if (!buf || size == 0) { regs->eax = (uint32_t)-1; break; }
+        const char *u = auth_current_user();
+        if (!u) u = "user";
+        uint32_t slen = 0;
+        while (u[slen]) slen++;
+        uint32_t copy = (slen + 1 > size) ? (size - 1) : slen;
+        for (uint32_t i = 0; i < copy; i++) buf[i] = u[i];
         buf[copy] = '\0';
         regs->eax = (uint32_t)copy;
         break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1894,6 +1894,13 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    case SYS_STATFS: {
+        uint32_t *total = (uint32_t *)(uintptr_t)regs->ebx;
+        uint32_t *freeb = (uint32_t *)(uintptr_t)regs->ecx;
+        regs->eax = (uint32_t)vfs_statfs(total, freeb);
+        break;
+    }
+
     case SYS_VT_GETNAME: {
         int   slot = (int)regs->ebx;
         char *buf  = (char *)regs->ecx;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1871,6 +1871,29 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    case SYS_VT_OPEN_APP: {
+        const char *path = (const char *)(uintptr_t)regs->ebx;
+        regs->eax = (uint32_t)vtty_open_app(path);
+        break;
+    }
+
+    case SYS_VT_TAKE_APP: {
+        char *buf = (char *)regs->ebx;
+        int   cap = (int)regs->ecx;
+        if (!buf || cap <= 0) { regs->eax = 0; break; }
+        regs->eax = (uint32_t)vtty_take_app_request(buf, cap);
+        break;
+    }
+
+    case SYS_VT_SETNAME: {
+        const char *name = (const char *)(uintptr_t)regs->ebx;
+        task_t *me = task_current();
+        if (me && me->tty >= 0)
+            vtty_set_name(me->tty, name);
+        regs->eax = 0;
+        break;
+    }
+
     case SYS_WHOAMI: {
         char *buf = (char *)regs->ebx;
         uint32_t size = regs->ecx;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1894,6 +1894,19 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    case SYS_VT_GETNAME: {
+        int   slot = (int)regs->ebx;
+        char *buf  = (char *)regs->ecx;
+        int   cap  = (int)regs->edx;
+        if (!buf || cap <= 0) { regs->eax = (uint32_t)-1; break; }
+        const char *nm = vtty_get_name(slot);
+        int i = 0;
+        for (; nm[i] && i < cap - 1; i++) buf[i] = nm[i];
+        buf[i] = '\0';
+        regs->eax = (uint32_t)i;
+        break;
+    }
+
     case SYS_WHOAMI: {
         char *buf = (char *)regs->ebx;
         uint32_t size = regs->ecx;

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -143,14 +143,28 @@ static task_t *vtty_owner(int n)
 
 int vtty_register(void)
 {
+    task_t *me = task_current();
     int slot = -1;
+
+    /* Claim the lowest free slot ATOMICALLY.  makmux forks all four VT
+     * children before yielding, and syscalls run with interrupts enabled
+     * (sti in isr_asm.S), so the PIT can preempt this task between the
+     * vtty_owner() "is it free?" check and the me->tty assignment that marks
+     * it taken.  Without the IF guard, two children both read the same slot
+     * as free and both claim it -- producing two shells on slot 0 (the
+     * "duplicate mak.sh1" bug).  cli/sti makes find-then-claim indivisible. */
+    uint32_t flags;
+    asm volatile("pushfl; popl %0; cli" : "=r"(flags) :: "memory");
     for (int i = 0; i < VTTY_MAX - 1; i++) {   /* -1: skip root slot */
         if (!vtty_owner(i)) { slot = i; break; }
     }
+    if (slot >= 0) {
+        if (me) me->tty = slot;
+        if (slot >= vtty_nslots) vtty_nslots = slot + 1;
+    }
+    asm volatile("pushl %0; popfl" :: "r"(flags) : "memory", "cc");
+
     if (slot < 0) return -1;
-    if (slot >= vtty_nslots) vtty_nslots = slot + 1;
-    task_t *me = task_current();
-    if (me) me->tty = slot;
     if (slot == 0)
         keyboard_set_focus(me);
     vt_buf_t *vt = vtty_buf(slot);

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -200,9 +200,13 @@ int vtty_close_pid(int pid)
     if (vtty_nslots == 0) {
         vtty_current = 0;
         keyboard_set_focus(task_current());
-        /* No VT children left: the status bar stays enabled (statusbar_task
-         * just stops drawing tabs since vtty_count() == 0).  The bar is no
-         * longer tied to makmux's lifetime. */
+        /* No VT children left: the status bar stays enabled (it just stops
+         * drawing tabs since vtty_count() == 0).  Restore mak.sh0's screen --
+         * the VT children/app-tabs drew over the framebuffer, and makmux
+         * itself no longer paints (so its wait4 reaper can't), so repaint the
+         * root console's backing buffer when the last VT closes.  mak.sh0 owns
+         * VTTY_ROOT_SLOT, so its next keyboard_getchar drains this repaint. */
+        vtty_request_repaint(VTTY_ROOT_SLOT);
     } else if (vtty_current == slot || vtty_current >= vtty_nslots) {
         int next = -1;
         for (int i = slot; i < vtty_nslots; i++) {

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -24,6 +24,7 @@
 #include <kernel/vesa_tty.h>
 #include <kernel/heap.h>
 #include <kernel/atomic.h>
+#include <string.h>
 
 static int      vtty_nslots  = 0;
 static int      vtty_current = 0;
@@ -31,6 +32,18 @@ static vt_buf_t vtty_bufs[VTTY_MAX];
 static bool     vtty_bufs_ready = false;
 static volatile int vtty_open_requests = 0;
 static volatile int vtty_clock_toggle_requests = 0;
+
+/* Per-slot tab name (app-tabs: "maktop"/"vix"/...; empty = default "VTn"). */
+#define VTTY_NAME_MAX 16
+static char vtty_names[VTTY_MAX][VTTY_NAME_MAX];
+
+/* App-tab launch queue: shell -> kernel (vtty_open_app) -> makmux (drains and
+ * forks a VT child that execs the app).  Small ring of request paths. */
+#define VTTY_APP_PATH 128
+#define VTTY_APP_Q    4
+static char vtty_app_q[VTTY_APP_Q][VTTY_APP_PATH];
+static volatile int vtty_app_head = 0;
+static volatile int vtty_app_tail = 0;
 
 /* Pending repaint target.  vtty_switch runs in the keyboard IRQ; doing a
  * full framebuffer repaint there would block subsequent keyboard IRQs
@@ -176,6 +189,7 @@ int vtty_close_pid(int pid)
             t->tty = TASK_TTY_NONE;
     }
     __atomic_store_n(&vtty_foreground[slot], (task_t *)0, __ATOMIC_RELEASE);
+    vtty_names[slot][0] = '\0';            /* drop the app-tab name */
 
     vt_buf_t *vt = vtty_buf(slot);
     if (vt) vt_clear(vt);
@@ -232,6 +246,83 @@ int vtty_take_clock_toggle_request(void)
 {
     int n = __atomic_exchange_n(&vtty_clock_toggle_requests, 0, __ATOMIC_ACQ_REL);
     return n;
+}
+
+/* ---- VT tab names + app-tab launch routing ----------------------------- */
+
+void vtty_set_name(int slot, const char *name)
+{
+    if (slot < 0 || slot >= VTTY_MAX) return;
+    int i = 0;
+    for (; name && name[i] && i < VTTY_NAME_MAX - 1; i++)
+        vtty_names[slot][i] = name[i];
+    vtty_names[slot][i] = '\0';
+}
+
+const char *vtty_get_name(int slot)
+{
+    if (slot < 0 || slot >= VTTY_MAX) return "";
+    return vtty_names[slot];
+}
+
+/* Slot of a *live* tab whose name matches, or -1. */
+int vtty_find_name(const char *name)
+{
+    if (!name || !*name) return -1;
+    for (int i = 0; i < VTTY_MAX; i++) {
+        if (i == VTTY_ROOT_SLOT) continue;
+        if (vtty_owner(i) && strcmp(vtty_names[i], name) == 0)
+            return i;
+    }
+    return -1;
+}
+
+/* Derive a tab name from an ELF path: basename without ".elf". */
+static void app_name_from_path(const char *path, char *out, int cap)
+{
+    const char *base = path;
+    for (const char *p = path; *p; p++)
+        if (*p == '/') base = p + 1;
+    int n = 0;
+    while (base[n] && n < cap - 1) { out[n] = base[n]; n++; }
+    out[n] = '\0';
+    if (n >= 4 && out[n-4] == '.' && out[n-3] == 'e' &&
+        out[n-2] == 'l' && out[n-1] == 'f')
+        out[n-4] = '\0';
+}
+
+/* Shell entry point (SYS_VT_OPEN_APP): open `path` in a named app-tab.  If a
+ * live tab with that name already exists, just switch to it; otherwise queue
+ * the path for makmux to fork + exec into a fresh slot.  Returns 1 if it was
+ * switched/queued, 0 if the queue was full. */
+int vtty_open_app(const char *path)
+{
+    if (!path || !*path) return 0;
+    char name[VTTY_NAME_MAX];
+    app_name_from_path(path, name, sizeof(name));
+
+    int slot = vtty_find_name(name);
+    if (slot >= 0) { vtty_switch(slot); return 1; }
+
+    int next = (vtty_app_head + 1) % VTTY_APP_Q;
+    if (next == vtty_app_tail) return 0;            /* queue full */
+    int i = 0;
+    for (; path[i] && i < VTTY_APP_PATH - 1; i++) vtty_app_q[vtty_app_head][i] = path[i];
+    vtty_app_q[vtty_app_head][i] = '\0';
+    __atomic_store_n(&vtty_app_head, next, __ATOMIC_RELEASE);
+    return 1;
+}
+
+/* makmux drains one queued app path; returns 1 if one was written to out. */
+int vtty_take_app_request(char *out, int cap)
+{
+    int tail = __atomic_load_n(&vtty_app_tail, __ATOMIC_ACQUIRE);
+    if (tail == __atomic_load_n(&vtty_app_head, __ATOMIC_ACQUIRE)) return 0;
+    int i = 0;
+    for (; vtty_app_q[tail][i] && i < cap - 1; i++) out[i] = vtty_app_q[tail][i];
+    out[i] = '\0';
+    __atomic_store_n(&vtty_app_tail, (tail + 1) % VTTY_APP_Q, __ATOMIC_RELEASE);
+    return 1;
 }
 
 int vtty_active(void)

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -186,10 +186,9 @@ int vtty_close_pid(int pid)
     if (vtty_nslots == 0) {
         vtty_current = 0;
         keyboard_set_focus(task_current());
-        /* Erase the stale makmux status bar row now that no VT children
-         * remain; the root slot's vtty_request_repaint (from SYS_WAIT4
-         * when mak.sh0 reaps makmux) will repaint the text area above it. */
-        vesa_tty_set_status_visible(0);
+        /* No VT children left: the status bar stays enabled (statusbar_task
+         * just stops drawing tabs since vtty_count() == 0).  The bar is no
+         * longer tied to makmux's lifetime. */
     } else if (vtty_current == slot || vtty_current >= vtty_nslots) {
         int next = -1;
         for (int i = slot; i < vtty_nslots; i++) {

--- a/src/kernel/arch/i386/shell/shell.c
+++ b/src/kernel/arch/i386/shell/shell.c
@@ -905,9 +905,13 @@ static void shell_print_prompt(void)
                                            : (uint32_t)t_column;
     if (cur_col != 0) t_putchar('\n');
 
-    t_writestring(SHELL_USERNAME "@" SHELL_HOSTNAME ":");
+    const char *user = auth_current_user();
+    if (!user || !*user) user = SHELL_USERNAME;
+    t_writestring(user);
+    t_writestring("@" SHELL_HOSTNAME ":");
     t_writestring(vfs_getcwd());
-    t_writestring("# ");
+    /* root -> '#', any other user -> '$' (standard sh convention). */
+    t_writestring(strcmp(user, "root") == 0 ? "# " : "$ ");
 }
 
 /* ---------------------------------------------------------------------------
@@ -1013,10 +1017,9 @@ int shell_enter_slot(int with_loading_screen)
             task_yield();
         while (keyboard_poll()) {}
 
-        /* Loading is over.  Keep the kernel VT status bar hidden on the
-         * default shell: the tabbed VT UI belongs to the userspace makmux
-         * app, not to normal boot. */
-        vesa_tty_set_status_visible(0);
+        /* Loading is over.  Enable the kernel status bar (statusbar_task
+         * owns the bottom row from here on); Alt+F5 toggles it off. */
+        vesa_tty_set_status_visible(1);
 
         /* Switch into this VT's per-VT palette and clear so the banner
          * prints on the VT's bg colour (the loading screen left the FB
@@ -1175,7 +1178,9 @@ void shell_enter_root_tty(void)
         task_yield();
     while (keyboard_poll()) {}
 
-    vesa_tty_set_status_visible(0);
+    /* Boot splash done: enable the kernel status bar (statusbar_task owns
+     * the bottom row from here; Alt+F5 toggles it). */
+    vesa_tty_set_status_visible(1);
     terminal_set_colorscheme(SHELL_COLOR_VGA);
     if (vesa_tty_is_ready()) {
         vesa_tty_setcolor(SHELL_FG_RGB, SHELL_BG_RGB);
@@ -1207,8 +1212,13 @@ void shell_login_loop(void)
          *   3. /etc/shadow exists (password has been configured)
          * Any live ISO boot — even one where the kernel elected an HDD as
          * rootfs — skips authentication entirely. */
-        if (!g_live_boot && vfs_rootfs_is_disk() && vfs_file_exists("/etc/shadow"))
-            login_screen();
+        if (!g_live_boot && vfs_rootfs_is_disk() && vfs_file_exists("/etc/shadow")) {
+            /* Try auto-login first (cmdline autologin=<user>, else
+             * /etc/autologin).  Falls through to the password prompt when
+             * not configured or the named user is invalid. */
+            if (!auth_try_autologin(g_autologin_user[0] ? g_autologin_user : (const char *)0))
+                login_screen();
+        }
 
         /* --- Session start: clear to the shell's own palette and print
          *     the build-info banner, matching the pre-login-flow UX. --- */
@@ -1227,6 +1237,27 @@ void shell_login_loop(void)
             t_writestring("!\n\n");
         } else {
             t_writestring("Welcome, user@makar! (live session)\n\n");
+        }
+
+        /* --- Ensure the login user's home directory exists ---
+         * The login shell cd's into HOME on startup; create it here on a
+         * writable rootfs so that lands somewhere real.  root -> /root,
+         * everyone else -> /home/<user>.  No-op on a read-only (live ISO)
+         * rootfs, where the shell stays at '/' instead. */
+        if (vfs_rootfs_is_disk()) {
+            const char *u = auth_current_user();
+            if (u && strcmp(u, "root") == 0) {
+                if (!vfs_file_exists("/root")) vfs_mkdir("/root");
+            } else if (u && *u) {
+                if (!vfs_file_exists("/home")) vfs_mkdir("/home");
+                char home_path[VFS_PATH_MAX];
+                size_t hi = 0;
+                const char *hp = "/home/";
+                while (*hp && hi < sizeof(home_path) - 1) home_path[hi++] = *hp++;
+                while (*u && hi < sizeof(home_path) - 1) home_path[hi++] = *u++;
+                home_path[hi] = '\0';
+                if (!vfs_file_exists(home_path)) vfs_mkdir(home_path);
+            }
         }
 
         /* --- Spawn sh.elf --login --user=<name> --- */

--- a/src/kernel/arch/i386/shell/shell_cmd_display.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_display.c
@@ -263,6 +263,25 @@ int admin_setmode(const char *mode)
         uint32_t w = vesa_modes[i].w;
         uint32_t h = vesa_modes[i].h;
 
+        /* Refuse modes the adapter can't scan out (insufficient VRAM or
+         * beyond the advertised maxima).  Bailing here -- before touching
+         * the hardware or geometry -- keeps us in the working mode instead
+         * of half-switching into a framebuffer that overruns VRAM and
+         * faults.  The boot path already mapped the largest *supported*
+         * mode, so any mode that passes this gate is guaranteed mapped in
+         * every task PD. */
+        if (!bochs_vbe_mode_supported(w, h, 32)) {
+            uint32_t mw = 0, mh = 0, mb = 0;
+            bochs_vbe_caps(&mw, &mh, &mb);
+            t_writestring("Error: ");
+            t_dec(w); t_writestring("x"); t_dec(h);
+            t_writestring(" exceeds this adapter (max ");
+            t_dec(mw); t_writestring("x"); t_dec(mh);
+            t_writestring(", VRAM "); t_dec(bochs_vbe_vram_bytes() / 1024u);
+            t_writestring(" KiB)\n");
+            return -2;
+        }
+
         vesa_tty_set_scale(w >= 1280 ? 2 : 1);
         bochs_vbe_set_mode(w, h, 32);
         vesa_update_geometry(w, h, 32);

--- a/src/kernel/include/kernel/auth.h
+++ b/src/kernel/include/kernel/auth.h
@@ -15,6 +15,9 @@ void microhash_hex16(const uint8_t *data, size_t len, char out[17]);
 int shadow_verify      (const char *username, const char *password);
 int shadow_set_password(const char *username, const char *password);
 
+/* Returns 1 if `username` has an entry in /etc/shadow, else 0. */
+int shadow_user_exists (const char *username);
+
 /* login.c: full-screen login prompt; returns when user is authenticated. */
 void login_screen(void);
 
@@ -24,5 +27,13 @@ const char *auth_current_user(void);
 
 /* Re-enter the login prompt (call from `logout` shell command). */
 void auth_logout(void);
+
+/* Attempt auto-login, skipping the password prompt.  The user is taken from
+ * `cmdline_user` (the `autologin=<user>` kernel arg) when non-NULL/non-empty,
+ * otherwise from the first token of /etc/autologin.  Returns 1 and records the
+ * session user (auth_current_user) when the resolved user exists in
+ * /etc/shadow; returns 0 (so the caller shows login_screen) when no autologin
+ * is configured or the named user is invalid. */
+int auth_try_autologin(const char *cmdline_user);
 
 #endif /* _KERNEL_AUTH_H */

--- a/src/kernel/include/kernel/bochs_vbe.h
+++ b/src/kernel/include/kernel/bochs_vbe.h
@@ -10,6 +10,21 @@
 /* Returns true if a Bochs-compatible VBE adapter is detected. */
 bool bochs_vbe_available(void);
 
+/* Total video memory in bytes, read from the Bochs DISPI VIDEO_MEMORY_64K
+ * register.  Returns 0 if the adapter doesn't report it. */
+uint32_t bochs_vbe_vram_bytes(void);
+
+/* Maximum mode the adapter advertises via the DISPI GETCAPS protocol.
+ * Any of the out-params may come back 0 if the adapter doesn't report a
+ * given cap. */
+void bochs_vbe_caps(uint32_t *max_w, uint32_t *max_h, uint32_t *max_bpp);
+
+/* True if width×height×bpp is within both the advertised dimension caps
+ * and the available VRAM.  Returns false when no VBE adapter is present.
+ * Used to pick the boot resolution and to gate `setmode` so we never
+ * program a mode the adapter can't scan out (black screen / FB overrun). */
+bool bochs_vbe_mode_supported(uint32_t width, uint32_t height, uint32_t bpp);
+
 /* Switch the linear framebuffer to width×height at bpp bits per pixel.
  * LFB_ENABLED is set so the framebuffer address stays constant.
  * Call vesa_update_geometry() + vesa_tty_init() after this. */

--- a/src/kernel/include/kernel/ext2.h
+++ b/src/kernel/include/kernel/ext2.h
@@ -54,6 +54,10 @@ void ext2_unmount(void);
 /* Returns 1 if an ext2 volume is currently mounted, 0 otherwise. */
 int ext2_mounted(void);
 
+/* Filesystem usage in KiB (total + free) of the mounted ext2 volume.
+ * Returns 0 on success, -1 if not mounted. */
+int ext2_statfs(uint32_t *total_kb, uint32_t *free_kb);
+
 /* -------------------------------------------------------------------------
  * Directory operations
  * ---------------------------------------------------------------------- */

--- a/src/kernel/include/kernel/keyboard.h
+++ b/src/kernel/include/kernel/keyboard.h
@@ -125,4 +125,13 @@ uint32_t keyboard_test_mod_state(void);
 uint8_t  keyboard_test_leds(void);
 uint32_t keyboard_test_led_sends(void);
 
+/* Synthetic key injection for the in-guest keyboard test harness (drives the
+ * live shell, not the isolated test ring).  keyboard_inject_key presses one
+ * key with optional modifiers; keyboard_inject_text types a string.
+ * keyboard_test_driver runs the scripted scenarios (spawned when `kbtest` is
+ * on the cmdline). */
+void keyboard_inject_key(uint8_t kc, int shift, int ctrl, int alt);
+void keyboard_inject_text(const char *s);
+void keyboard_test_driver(void);
+
 #endif /* _KERNEL_KEYBOARD_H */

--- a/src/kernel/include/kernel/shell.h
+++ b/src/kernel/include/kernel/shell.h
@@ -7,6 +7,10 @@
  * shell_login_loop reads this to skip authentication on live ISO sessions. */
 extern int g_live_boot;
 
+/* `autologin=<user>` from the kernel cmdline (empty = unset).  Passed to
+ * auth_try_autologin by shell_login_loop; overrides /etc/autologin. */
+extern char g_autologin_user[64];
+
 /*
  * Minimal kernel REPL over VGA + PS/2 keyboard.
  *

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -117,6 +117,14 @@
                                  * /etc/hostname (or fallback "makar"), copy up
                                  * to size-1 bytes, NUL-terminate.  Returns
                                  * strlen on success, -1 if buf invalid. */
+#define SYS_WHOAMI         240  /* int whoami(char *buf, size_t size) - copy the
+                                 * current session's username (auth_current_user,
+                                 * "user" on live boots) up to size-1 bytes,
+                                 * NUL-terminate.  Returns strlen, -1 if invalid. */
+#define SYS_STATUSBAR      241  /* int statusbar(int cmd) - reserve/free the bottom
+                                 * status row (mechanism for userspace statusbar.elf).
+                                 * cmd: 1=enable (reserve), 0=disable (free), <0=query.
+                                 * Returns the resulting enabled state (0/1). */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -132,6 +132,9 @@
                                  * drains one queued app path.  Returns 1/0. */
 #define SYS_VT_SETNAME     244  /* int vt_setname(const char *name) - name the
                                  * calling task's VT tab (shown in the status bar). */
+#define SYS_VT_GETNAME     245  /* int vt_getname(int slot, char *buf, int cap) -
+                                 * copy slot's tab name (empty for unnamed VT
+                                 * shells).  Returns strlen.  Used by statusbar. */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -125,6 +125,13 @@
                                  * status row (mechanism for userspace statusbar.elf).
                                  * cmd: 1=enable (reserve), 0=disable (free), <0=query.
                                  * Returns the resulting enabled state (0/1). */
+#define SYS_VT_OPEN_APP    242  /* int vt_open_app(const char *path) - open an app
+                                 * in a named tab: switch to it if it exists, else
+                                 * queue for makmux to spawn.  Returns 1/0. */
+#define SYS_VT_TAKE_APP    243  /* int vt_take_app(char *buf, int cap) - makmux
+                                 * drains one queued app path.  Returns 1/0. */
+#define SYS_VT_SETNAME     244  /* int vt_setname(const char *name) - name the
+                                 * calling task's VT tab (shown in the status bar). */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -135,6 +135,8 @@
 #define SYS_VT_GETNAME     245  /* int vt_getname(int slot, char *buf, int cap) -
                                  * copy slot's tab name (empty for unnamed VT
                                  * shells).  Returns strlen.  Used by statusbar. */
+#define SYS_STATFS         246  /* int statfs(uint32_t *total_kb, uint32_t *free_kb)
+                                 * rootfs usage in KiB (ext2 only).  Returns 0/-1. */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/kernel/include/kernel/vesa_tty.h
+++ b/src/kernel/include/kernel/vesa_tty.h
@@ -150,6 +150,10 @@ void vesa_tty_paint_status_mask(int active, unsigned int live_mask);
  * background.  Used by shell_run's loading screen and mak.sh0. */
 void vesa_tty_set_status_visible(int v);
 
+/* Returns the current status-bar enabled state (1 = reserved + drawn at the
+ * bottom row, 0 = freed for apps/shells to use the full screen). */
+int vesa_tty_status_enabled(void);
+
 /* Legacy no-op; Alt+F5 is queued for makmux via vtty. */
 void vesa_tty_toggle_clock(void);
 

--- a/src/kernel/include/kernel/vfs.h
+++ b/src/kernel/include/kernel/vfs.h
@@ -117,6 +117,7 @@ const char *vfs_hd_fsname(const char *name);
 /* 1 when the rootfs at "/" is ext2 or FAT32 (installed system); 0 on live
  * ISO9660 boots or when no rootfs has been elected. */
 int         vfs_rootfs_is_disk(void);
+int         vfs_statfs(uint32_t *total_kb, uint32_t *free_kb);
 void        vfs_print_mounts(void);
 
 /* Empty-mountpoint management (Linux-style: a mountpoint is a directory under

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -45,7 +45,8 @@ int vtty_close_pid(int pid);
 void vtty_request_open(void);
 int  vtty_take_open_request(void);
 
-/* Global Alt+F5 request queue consumed by makmux in userspace. */
+/* Global Alt+F5 request queue.  Consumed by userspace statusbar.elf (via
+ * SYS_VT_CLOCK_REQUEST) to toggle the bottom status bar on/off. */
 void vtty_request_clock_toggle(void);
 int  vtty_take_clock_toggle_request(void);
 

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -12,13 +12,16 @@
 #include <kernel/task.h>
 #include <kernel/vt.h>
 
-/* Slots 0..VTTY_MAX-2 are the user-visible VT slots (makmux VT1-4).
+/* Slots 0..VTTY_MAX-2 are the user-visible VT slots: 0-3 are makmux's VT
+ * shells (mak.sh1-4, reached via Alt+F1-F4) and 4-7 are dynamic named
+ * app-tabs (maktop/vix/clock/..., reached via Alt-Tab cycling).
  * Slot VTTY_ROOT_SLOT is the hidden "console" slot for mak.sh0: it has a
  * full backing buffer (so its content is preserved across makmux sessions)
- * but it is excluded from Ctrl+Tab cycling, Alt+Fn switching, and the
- * makmux status bar — exactly like Linux's tty0/console. */
-#define VTTY_MAX      5
-#define VTTY_ROOT_SLOT 4
+ * but it is excluded from Alt-Tab cycling, Alt+Fn switching, and the
+ * status bar — exactly like Linux's tty0/console. */
+#define VTTY_MAX        9
+#define VTTY_SHELL_MAX  4   /* slots 0..3 = the VT shells (Alt+F1-F4) */
+#define VTTY_ROOT_SLOT  8   /* hidden root console = the last slot */
 
 /* Call once before spawning shell tasks.  Allocates per-slot backing
  * grids sized from the active display geometry (VESA cell dims if the

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -69,6 +69,18 @@ int vtty_count(void);
 /* Returns a bitmask of currently live TTY slots.  Bit 0 is VT1. */
 unsigned int vtty_live_mask(void);
 
+/* ---- VT tab names + app-tab launch routing --------------------------------
+ * Each slot can carry a short tab name (app-tabs: "maktop"/"vix"/...).
+ * vtty_open_app (SYS_VT_OPEN_APP): if a live tab already has the app's name,
+ * switch to it; else queue the path for makmux to fork+exec into a new slot.
+ * makmux drains the queue with vtty_take_app_request and names the slot via
+ * vtty_set_name (SYS_VT_SETNAME). */
+void         vtty_set_name(int slot, const char *name);
+const char  *vtty_get_name(int slot);
+int          vtty_find_name(const char *name);
+int          vtty_open_app(const char *path);
+int          vtty_take_app_request(char *out, int cap);
+
 /* ------------------------------------------------------------------ */
 /* Per-TTY backing-grid access                                          */
 /* ------------------------------------------------------------------ */

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -33,6 +33,10 @@
  * Suppresses login regardless of rootfs type. */
 int g_live_boot = 0;
 
+/* `autologin=<user>` from the kernel cmdline.  Overrides /etc/autologin;
+ * empty = not set.  Read by shell_login_loop -> auth_try_autologin. */
+char g_autologin_user[64] = {0};
+
 /*
  * Column at which "[ OK ]" starts, counting from 0.
  * "[ OK ]" is 6 characters wide, so it occupies columns 74–79 on an
@@ -115,6 +119,28 @@ void user_shell_slot_entry(void)
 	shell_login_loop();
 }
 
+/*
+ * statusbar_entry – become /apps/statusbar.elf, the userspace renderer for
+ * the kernel's reserved bottom status row (hostname + clock now; ~/.sbrc
+ * widgets later).  Runs as a detached background task with no VT slot; its
+ * status-row cells reach the framebuffer regardless of which VT is focused.
+ * Waits for the boot ktests so the prompt + enabled row are up first.
+ */
+extern void statusbar_entry(void);
+void statusbar_entry(void)
+{
+	while (!ktest_bg_done)
+		task_yield();
+	const char *path = (g_live_boot && vfs_file_exists("/mnt/cdrom/apps/statusbar.elf"))
+	                   ? "/mnt/cdrom/apps/statusbar.elf"
+	                   : "/apps/statusbar.elf";
+	const char *argv[2] = { "statusbar", NULL };
+	elf_exec(path, 1, argv);
+	/* exec failed (missing/broken ELF): idle harmlessly, no status bar. */
+	for (;;)
+		task_yield();
+}
+
 void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 {
 	terminal_initialize();
@@ -154,14 +180,97 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 
 	t_writestring("Initializing display mode");
 	kprint_ok();
-	if (bochs_vbe_available()) {
-		vesa_tty_set_scale(2);
-		bochs_vbe_set_mode(1280, 720, 32);
-		vesa_update_geometry(1280, 720, 32);
-		vesa_tty_init();
-	} else {
-		vesa_tty_disable();
-		terminal_set_rows(50);
+	{
+		/* vmode=<720p|1080p|480p|WxH> from the boot cmdline.  GRUB and Limine
+		 * both feed the multiboot2 CMDLINE tag; the full cmdline parse runs
+		 * later, so peek for vmode= now since the display comes up first.
+		 * Absent/unsupported -> default 720p. */
+		char vmode[16]; vmode[0] = '\0';
+		if (magic == MULTIBOOT2_BOOTLOADER_MAGIC) {
+			uint8_t *tp = (uint8_t *)mbi + sizeof(multiboot2_info_t);
+			uint8_t *te = (uint8_t *)mbi + mbi->total_size;
+			while (tp < te) {
+				multiboot2_tag_t *tag = (multiboot2_tag_t *)tp;
+				if (tag->type == MULTIBOOT2_TAG_TYPE_END) break;
+				if (tag->type == MULTIBOOT2_TAG_TYPE_CMDLINE) {
+					const char *vp = strstr(
+						((multiboot2_tag_cmdline_t *)tag)->string, "vmode=");
+					if (vp) {
+						vp += 6;
+						size_t k = 0;
+						while (*vp && *vp != ' ' && *vp != '\t' &&
+						       k + 1 < sizeof(vmode))
+							vmode[k++] = *vp++;
+						vmode[k] = '\0';
+					}
+					break;
+				}
+				tp += (tag->size + 7u) & ~7u;
+			}
+		}
+
+		if (bochs_vbe_available()) {
+			/* Highest mode the adapter can scan out: this is the framebuffer
+			 * span we pre-map below, before any task PD is snapshotted, so a
+			 * later setmode up to this size never reaches an unmapped FB region
+			 * (the 1080p page-fault-at-0xFD400000 bug). */
+			static const struct { uint32_t w, h; } prefs[] = {
+				{ 1920, 1080 }, { 1280, 720 }, { 640, 480 },
+			};
+			uint32_t max_w = 0, max_h = 0;
+			for (uint32_t i = 0; i < sizeof(prefs)/sizeof(prefs[0]); i++) {
+				if (bochs_vbe_mode_supported(prefs[i].w, prefs[i].h, 32)) {
+					max_w = prefs[i].w; max_h = prefs[i].h; break;
+				}
+			}
+			if (max_w == 0) { max_w = 1280; max_h = 720; }
+
+			/* Active boot mode: vmode= if given and supported; else default
+			 * 720p; else the max the adapter supports. */
+			uint32_t bw = 0, bh = 0;
+			if (vmode[0]) {
+				uint32_t rw = 0, rh = 0;
+				if (!strcmp(vmode,"1080p") || !strcmp(vmode,"1920x1080")) { rw=1920; rh=1080; }
+				else if (!strcmp(vmode,"720p") || !strcmp(vmode,"1280x720")) { rw=1280; rh=720; }
+				else if (!strcmp(vmode,"480p") || !strcmp(vmode,"640x480")) { rw=640; rh=480; }
+				if (rw && bochs_vbe_mode_supported(rw, rh, 32)) { bw = rw; bh = rh; }
+			}
+			if (bw == 0) {
+				if (bochs_vbe_mode_supported(1280, 720, 32)) { bw = 1280; bh = 720; }
+				else { bw = max_w; bh = max_h; }
+			}
+
+			/* Pre-map the max-supported FB span into the kernel PD (pre-tasking). */
+			{
+				const vesa_fb_t *fbp = vesa_get_fb();
+				if (fbp)
+					paging_map_region((uint32_t)(uintptr_t)fbp->addr,
+					                  max_w * max_h * 4u);
+			}
+
+			{
+				uint32_t cw = 0, ch = 0, cb = 0;
+				bochs_vbe_caps(&cw, &ch, &cb);
+				Serial_WriteString("display: VBE caps max=");
+				Serial_WriteDec(cw); Serial_WriteString("x");
+				Serial_WriteDec(ch); Serial_WriteString("x"); Serial_WriteDec(cb);
+				Serial_WriteString(" vram="); Serial_WriteDec(bochs_vbe_vram_bytes());
+				Serial_WriteString(" premap="); Serial_WriteDec(max_w);
+				Serial_WriteString("x"); Serial_WriteDec(max_h);
+				Serial_WriteString(" -> mode ");
+				Serial_WriteDec(bw); Serial_WriteString("x"); Serial_WriteDec(bh);
+				if (vmode[0]) { Serial_WriteString(" (vmode="); Serial_WriteString(vmode); Serial_WriteString(")"); }
+				Serial_WriteString("\n");
+			}
+
+			vesa_tty_set_scale(bw >= 1280 ? 2 : 1);
+			bochs_vbe_set_mode(bw, bh, 32);
+			vesa_update_geometry(bw, bh, 32);
+			vesa_tty_init();
+		} else {
+			vesa_tty_disable();
+			terminal_set_rows(50);
+		}
 	}
 
 	t_writestring("Starting timer (100 Hz)");
@@ -254,6 +363,18 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 						    sp[3] == 'c' && sp[4] == 'u' && sp[5] == 'e')
 							shell_rescue = 1;
 					}
+					/* autologin=<user> - skip the password prompt and sign in as
+					 * <user> (must exist in /etc/shadow); overrides /etc/autologin. */
+					const char *ap = strstr(cmd->string, "autologin=");
+					if (ap) {
+						ap += 10;
+						size_t j = 0;
+						while (*ap && *ap != ' ' && *ap != '\t' &&
+						       j + 1 < sizeof(g_autologin_user)) {
+							g_autologin_user[j++] = *ap++;
+						}
+						g_autologin_user[j] = '\0';
+					}
 					/* test=<comma-list> -- which test-mode scripts to run. */
 					const char *tp = strstr(cmd->string, "test=");
 					if (tp) {
@@ -325,6 +446,9 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 			task_create("rescu.sh", shell_run);
 		} else {
 			task_create("mak.sh0", user_shell_slot_entry);
+			/* Userspace status-bar renderer (skipped on the rescue path,
+			 * which wants a single bare in-kernel shell). */
+			task_create("statusbar", statusbar_entry);
 		}
 		task_create("ktest",  ktest_bg_task);
 	}

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -300,6 +300,9 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 	int test_mode = 0;
 	int live_boot = 0;          /* `live` on cmdline → live CD session,
 	                             * skip login regardless of rootfs type. */
+	int kbtest = 0;             /* `kbtest` → spawn the in-guest keyboard
+	                             * injection test driver against the live
+	                             * shell (deterministic, replaces HMP). */
 	int console_serial = 0;     /* "console=ttyS0" - keep g_serial_verbose
 	                             * on after boot so the shell mirrors to
 	                             * COM1.  Linux-style: dmesg + tty over
@@ -340,6 +343,8 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 						test_mode = 1;
 					if (strstr(cmd->string, "live"))
 						live_boot = 1;
+					if (strstr(cmd->string, "kbtest"))
+						kbtest = 1;
 					if (strstr(cmd->string, "console=ttyS0"))
 						console_serial = 1;
 					const char *rp = strstr(cmd->string, "root=");
@@ -449,6 +454,9 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 			/* Userspace status-bar renderer (skipped on the rescue path,
 			 * which wants a single bare in-kernel shell). */
 			task_create("statusbar", statusbar_entry);
+			/* In-guest keyboard injection test driver (cmdline `kbtest`). */
+			if (kbtest)
+				task_create("kbtest", keyboard_test_driver);
 		}
 		task_create("ktest",  ktest_bg_task);
 	}

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -16,7 +16,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf kbtester.elf makbox.elf makmux.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf ktest_uspace.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf ktest_uspace.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -77,6 +77,9 @@ makbox.elf: crt0.o makbox.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 makmux.elf: crt0.o makmux.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+statusbar.elf: crt0.o statusbar.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 kbtester.elf: crt0.o kbtester.o

--- a/src/userspace/ktest_uspace.c
+++ b/src/userspace/ktest_uspace.c
@@ -72,6 +72,10 @@ static void suite_usr(void)
 
     ASSERT(file_exists("/usr/lib/crt0.o"),      "/usr/lib/crt0.o exists");
     ASSERT(file_exists("/usr/lib/libc.a"),       "/usr/lib/libc.a exists");
+    ASSERT(file_exists("/usr/lib/crt1.o"),       "/usr/lib/crt1.o exists");
+    ASSERT(file_exists("/usr/lib/crti.o"),       "/usr/lib/crti.o exists");
+    ASSERT(file_exists("/usr/lib/crtn.o"),       "/usr/lib/crtn.o exists");
+    ASSERT(file_exists("/usr/lib/tcc/libtcc1.a"), "/usr/lib/tcc/libtcc1.a exists");
     ASSERT(file_exists("/usr/include/stdio.h"),  "/usr/include/stdio.h exists");
     ASSERT(file_exists("/usr/include/string.h"), "/usr/include/string.h exists");
     ASSERT(file_exists("/apps/hello.elf"),       "/apps/hello.elf exists");

--- a/src/userspace/makmux.c
+++ b/src/userspace/makmux.c
@@ -50,7 +50,20 @@ static void child_shell(void)
         sys_exit(1);
     }
 
-    char *argv[] = { "sh.elf", "--makmux", 0 };
+    /* Pass the session user so the VT shell's prompt matches mak.sh0
+     * (user@ with '$', not the default root@ with '#'). */
+    static char user_arg[48];
+    char uname[40];
+    int have_user = (sys_whoami(uname, sizeof(uname)) > 0 && uname[0]);
+    if (have_user) {
+        const char *pfx = "--user=";
+        int o = 0;
+        for (int i = 0; pfx[i]; i++) user_arg[o++] = pfx[i];
+        for (int i = 0; uname[i] && o < (int)sizeof(user_arg) - 1; i++) user_arg[o++] = uname[i];
+        user_arg[o] = '\0';
+    }
+
+    char *argv[] = { "sh.elf", "--makmux", have_user ? user_arg : 0, 0 };
     sys_execve("/apps/sh.elf", argv, (char *const *)0);
     put_s("makmux: exec /apps/sh.elf failed on VT ");
     put_dec(slot);

--- a/src/userspace/makmux.c
+++ b/src/userspace/makmux.c
@@ -69,6 +69,51 @@ static int spawn_child(int idx, int focus)
     return 0;
 }
 
+/* App-tabs: dynamic named tabs (maktop/vix/clock/...) opened in slots beyond
+ * the 4 VT shells.  The kernel queues a launch (vtty_open_app, after a
+ * switch-if-exists check); makmux drains it here and forks a child that takes
+ * a fresh VT slot, names it after the app, and execs it. */
+#define APP_MAX 4
+static int s_app_pids[APP_MAX];
+
+static void child_app(const char *path)
+{
+    int slot = sys_vt_enter(1);          /* focus the new app-tab */
+    if (slot < 0) { put_s("makmux: no VT slot for app-tab\n"); sys_exit(1); }
+
+    /* Tab name = basename(path) without ".elf". */
+    char name[16]; int n = 0;
+    const char *base = path;
+    for (const char *p = path; *p; p++) if (*p == '/') base = p + 1;
+    while (base[n] && n < 15) { name[n] = base[n]; n++; }
+    name[n] = '\0';
+    if (n >= 4 && name[n-4]=='.' && name[n-3]=='e' && name[n-2]=='l' && name[n-1]=='f')
+        name[n-4] = '\0';
+    sys_vt_setname(name);
+
+    char *argv[] = { (char *)path, 0 };
+    sys_execve(path, argv, (char *const *)0);
+    sys_exit(127);
+}
+
+static int spawn_app(const char *path)
+{
+    int idx = -1;
+    for (int i = 0; i < APP_MAX; i++) if (s_app_pids[i] <= 0) { idx = i; break; }
+    if (idx < 0) return -1;
+    int pid = sys_fork();
+    if (pid < 0) return -1;
+    if (pid == 0) child_app(path);
+    s_app_pids[idx] = pid;
+    return 0;
+}
+
+static void note_app_exit(int pid)
+{
+    for (int i = 0; i < APP_MAX; i++)
+        if (s_app_pids[i] == pid) { s_app_pids[i] = 0; return; }
+}
+
 static int live_children(void)
 {
     int n = 0;
@@ -138,13 +183,14 @@ int main(int argc, char **argv)
         int status = 0;
         int pid = sys_wait4(-1, &status, WNOHANG);
         if (pid > 0) {
-            put_s("makmux: child shell exited pid=");
+            put_s("makmux: child exited pid=");
             put_dec(pid);
             put_s(" status=");
             put_dec(status);
             put_s("\n");
-            sys_vt_close(pid);
+            sys_vt_close(pid);          /* frees the slot (shell or app-tab) */
             note_child_exit(pid);
+            note_app_exit(pid);
             if (live_children() == 0)
                 return 0;
         }
@@ -155,6 +201,12 @@ int main(int argc, char **argv)
             if (idx >= 0)
                 spawn_child(idx, 1);
         }
+
+        /* Drain queued app-tab launches (vix/maktop/clock/... opened from a
+         * shell while makmux is running). */
+        char app_path[128];
+        while (sys_vt_take_app(app_path, sizeof(app_path)) > 0)
+            spawn_app(app_path);
 
         sys_yield();
     }

--- a/src/userspace/makmux.c
+++ b/src/userspace/makmux.c
@@ -11,16 +11,9 @@
 #include "syscall.h"
 
 #define CHILD_COUNT 4
-#define STATUS_LABEL_COL 1
-#define STATUS_LABEL_W   18
-#define STATUS_BAR_CLR   ((VGA_BROWN << 4) | VGA_WHITE)
-#define STATUS_ACTIVE_CLR ((VGA_YELLOW << 4) | VGA_BLACK)
 
 static int s_child_pids[CHILD_COUNT];
 static int s_child_focus = 0;
-static int s_clock_mode = 0;
-static unsigned int s_last_state = 0xFFFFFFFFu;
-static unsigned int s_last_tick = 0xFFFFFFFFu;
 
 static void put_s(const char *s)
 {
@@ -98,108 +91,6 @@ static int slen(const char *s)
     return n;
 }
 
-static void put_cell(tty_cell_t *cells, unsigned int *n,
-                     unsigned int col, unsigned int row, char ch,
-                     unsigned char clr)
-{
-    cells[*n].col = (unsigned char)col;
-    cells[*n].row = (unsigned char)row;
-    cells[*n].ch = (unsigned char)ch;
-    cells[*n].clr = clr;
-    (*n)++;
-}
-
-static void put_cells_str(tty_cell_t *cells, unsigned int *n,
-                          unsigned int col, unsigned int row,
-                          const char *s, unsigned char clr)
-{
-    while (*s) {
-        put_cell(cells, n, col++, row, *s++, clr);
-    }
-}
-
-static int read_rtc(char *buf, unsigned int cap)
-{
-    int fd = sys_open("/proc/rtc", O_RDONLY);
-    if (fd < 0) return -1;
-    long n = sys_read(fd, buf, cap - 1);
-    sys_close(fd);
-    if (n < 0) return -1;
-    buf[n] = '\0';
-    return (int)n;
-}
-
-static void status_label(char *out)
-{
-    if (!s_clock_mode) {
-        out[0] = 'M'; out[1] = 'a'; out[2] = 'k'; out[3] = 'a';
-        out[4] = 'r'; out[5] = '\0';
-        return;
-    }
-
-    char rtc[32];
-    if (read_rtc(rtc, sizeof(rtc)) < 19) {
-        out[0] = '-'; out[1] = '-'; out[2] = ':'; out[3] = '-';
-        out[4] = '-'; out[5] = ':'; out[6] = '-'; out[7] = '-';
-        out[8] = ' '; out[9] = '-'; out[10] = '-'; out[11] = '/';
-        out[12] = '-'; out[13] = '-'; out[14] = '/'; out[15] = '-';
-        out[16] = '-'; out[17] = '\0';
-        return;
-    }
-
-    /* /proc/rtc is "YYYY-MM-DD HH:MM:SS"; status wants HH:MM:SS DD/MM/YY. */
-    out[0] = rtc[11]; out[1] = rtc[12]; out[2] = ':';
-    out[3] = rtc[14]; out[4] = rtc[15]; out[5] = ':';
-    out[6] = rtc[17]; out[7] = rtc[18]; out[8] = ' ';
-    out[9] = rtc[8]; out[10] = rtc[9]; out[11] = '/';
-    out[12] = rtc[5]; out[13] = rtc[6]; out[14] = '/';
-    out[15] = rtc[2]; out[16] = rtc[3]; out[17] = '\0';
-}
-
-static void draw_status(unsigned int state)
-{
-    unsigned int size = (unsigned int)sys_term_size();
-    unsigned int cols = (size >> 16) & 0xFFFFu;
-    unsigned int row = size & 0xFFFFu;
-    if (cols == 0 || row == 0) return;
-
-    unsigned int active = (state >> 16) & 0xFFFFu;
-    unsigned int mask = state & 0xFFFFu;
-    unsigned int count = 0;
-    for (int i = 0; i < CHILD_COUNT; i++)
-        if (mask & (1u << i)) count++;
-
-    tty_cell_t cells[512];
-    unsigned int n = 0;
-    if (cols > sizeof(cells) / sizeof(cells[0]))
-        cols = sizeof(cells) / sizeof(cells[0]);
-
-    for (unsigned int c = 0; c < cols; c++)
-        put_cell(cells, &n, c, row, ' ', STATUS_BAR_CLR);
-
-    char label[20];
-    status_label(label);
-    put_cells_str(cells, &n, STATUS_LABEL_COL, row, label, STATUS_BAR_CLR);
-
-    unsigned int label_end = STATUS_LABEL_COL + STATUS_LABEL_W;
-    unsigned int block = count * 6u;
-    unsigned int col = (cols > block) ? (cols - block) / 2u : label_end;
-    if (col < label_end) col = label_end;
-    for (int i = 0; i < CHILD_COUNT && col + 5 < cols; i++) {
-        if (!(mask & (1u << i))) continue;
-        char tab[6] = { ' ', 'V', 'T', (char)('1' + i), ' ', '\0' };
-        put_cells_str(cells, &n, col, row, tab,
-                      (i == (int)active) ? STATUS_ACTIVE_CLR : STATUS_BAR_CLR);
-        col += 6;
-    }
-
-    const char *hint = "Alt+F1-F4";
-    unsigned int hlen = (unsigned int)slen(hint);
-    if (cols > hlen + 2)
-        put_cells_str(cells, &n, cols - hlen - 1, row, hint, STATUS_BAR_CLR);
-
-    sys_putch_at(cells, n);
-}
 
 static void note_child_exit(int pid)
 {
@@ -238,8 +129,11 @@ int main(int argc, char **argv)
 
     put_s("makmux: use Alt+F1..Alt+F4 for mak.sh1..mak.sh4\n");
     if (!ok) put_s("makmux: one or more child shells failed to start\n");
-    draw_status(sys_vt_state());
 
+    /* makmux now only manages the VT children.  The bottom status bar
+     * (hostname + VT tabs + clock) is drawn by the kernel statusbar task,
+     * which reads the live VT state -- so Alt+F5 (bar toggle) and the clock
+     * are handled there, not here. */
     for (;;) {
         int status = 0;
         int pid = sys_wait4(-1, &status, WNOHANG);
@@ -251,7 +145,6 @@ int main(int argc, char **argv)
             put_s("\n");
             sys_vt_close(pid);
             note_child_exit(pid);
-            s_last_state = 0xFFFFFFFFu;
             if (live_children() == 0)
                 return 0;
         }
@@ -259,23 +152,10 @@ int main(int argc, char **argv)
         int opens = sys_vt_open_request();
         while (opens-- > 0 && live_children() < CHILD_COUNT) {
             int idx = first_free_child_slot();
-            if (idx >= 0 && spawn_child(idx, 1) == 0)
-                s_last_state = 0xFFFFFFFFu;
+            if (idx >= 0)
+                spawn_child(idx, 1);
         }
 
-        int toggles = sys_vt_clock_request();
-        if (toggles > 0) {
-            if (toggles & 1) s_clock_mode = !s_clock_mode;
-            s_last_state = 0xFFFFFFFFu;
-        }
-
-        unsigned int state = sys_vt_state();
-        unsigned int tick = (unsigned int)sys_uptime();
-        if (state != s_last_state || (s_clock_mode && tick / 100u != s_last_tick / 100u)) {
-            draw_status(state);
-            s_last_state = state;
-            s_last_tick = tick;
-        }
         sys_yield();
     }
 }

--- a/src/userspace/sh.c
+++ b/src/userspace/sh.c
@@ -1732,14 +1732,15 @@ static void build_prompt(char *out, unsigned int outsz)
 {
     char cwd[VFS_PATH_MAX];
     if (sys_getcwd(cwd, sizeof(cwd)) < 0) { cwd[0] = '/'; cwd[1] = '\0'; }
-    /* root@host:cwd# */
+    /* user@host:cwd$  (root gets '#', unprivileged users get '$' -- the
+     * usual sh convention so you can tell at a glance whether you're root). */
     unsigned int o = 0;
     for (unsigned int i = 0; g_username[i] && o + 1 < outsz; i++) out[o++] = g_username[i];
     if (o + 1 < outsz) out[o++] = '@';
     for (unsigned int i = 0; g_hostname[i] && o + 1 < outsz; i++) out[o++] = g_hostname[i];
     if (o + 1 < outsz) out[o++] = ':';
     for (unsigned int i = 0; cwd[i] && o + 1 < outsz; i++) out[o++] = cwd[i];
-    if (o + 1 < outsz) out[o++] = '#';
+    if (o + 1 < outsz) out[o++] = s_eq(g_username, "root") ? '#' : '$';
     if (o + 1 < outsz) out[o++] = ' ';
     out[o] = '\0';
 }
@@ -1775,19 +1776,32 @@ int main(int argc, char **argv, char **envp)
             s_copy(home_val + 6, g_username, sizeof(home_val) - 6);
         }
         var_set("HOME", home_val);
+
+        /* A login shell starts in the user's home directory (the cwd we
+         * inherit from the kernel login loop is '/').  Stat first so we
+         * never hand SYS_CHDIR a path that doesn't exist -- the kernel's
+         * vfs_cd prints "cd: directory not found" on a miss, which would
+         * spew on a live session whose read-only rootfs has no
+         * /home/<user>.  If HOME isn't a directory we just stay at '/'. */
+        if (g_login) {
+            struct stat hst;
+            if (sys_stat(home_val, &hst) == 0 && S_ISDIR(hst.st_mode))
+                (void)sys_chdir(home_val);
+        }
     }
 
-    /* Source ~/.makrc on login shells (best-effort; missing file is fine). */
+    /* Source ~/.makshrc on login shells (best-effort; missing file is fine). */
     if (g_login) {
         const char *home = var_get("HOME");
         if (home && *home) {
             static char rc_path[VFS_PATH_MAX];
             unsigned int hl = s_len(home);
             unsigned int i;
-            for (i = 0; i < hl && i < sizeof(rc_path)-8; i++) rc_path[i] = home[i];
+            for (i = 0; i < hl && i < sizeof(rc_path)-10; i++) rc_path[i] = home[i];
             rc_path[i++]='/'; rc_path[i++]='.'; rc_path[i++]='m';
-            rc_path[i++]='a'; rc_path[i++]='k'; rc_path[i++]='r';
-            rc_path[i++]='c'; rc_path[i] = '\0';
+            rc_path[i++]='a'; rc_path[i++]='k'; rc_path[i++]='s';
+            rc_path[i++]='h'; rc_path[i++]='r'; rc_path[i++]='c';
+            rc_path[i] = '\0';
             int rcfd = sys_open(rc_path, O_RDONLY);
             if (rcfd >= 0) {
                 static char rcbuf[4096];

--- a/src/userspace/sh.c
+++ b/src/userspace/sh.c
@@ -994,10 +994,53 @@ static int shell_path_dir(int p, char *out, unsigned int outsz)
     }
     return 0;
 }
+/* Fullscreen apps that, while makmux is running, open in their own named tab
+ * instead of taking over the current VT (matches the kernel shell's notion of
+ * "fullscreen" commands). */
+static int is_tab_app(const char *name)
+{
+    static const char *apps[] = { "vix", "maktop", "clock", "cfdisk",
+                                  "basic", "kbtester", 0 };
+    for (int i = 0; apps[i]; i++)
+        if (s_eq(name, apps[i])) return 1;
+    return 0;
+}
+
+/* Resolve a bare command name to a full path via PATH (with .elf fallback). */
+static int resolve_app_path(const char *name, char *out, unsigned int sz)
+{
+    char dir[VFS_PATH_MAX];
+    for (int p = 0; shell_path_dir(p, dir, sizeof(dir)); p++) {
+        unsigned int dl = s_len(dir), nl = s_len(name);
+        if (dl + nl + 5 >= sz) continue;
+        unsigned int i;
+        for (i = 0; i < dl; i++) out[i] = dir[i];
+        for (unsigned int j = 0; j < nl; j++) out[dl + j] = name[j];
+        out[dl + nl] = '\0';
+        if (path_exists(out)) return 1;
+        out[dl+nl]='.'; out[dl+nl+1]='e'; out[dl+nl+2]='l';
+        out[dl+nl+3]='f'; out[dl+nl+4]='\0';
+        if (path_exists(out)) return 1;
+    }
+    return 0;
+}
+
 static int run_external(int argc, char **argv)
 {
     (void)argc;
     int status = 0;
+
+    /* App-tab routing: while makmux is running (any VT child registered),
+     * a fullscreen app opens in its own named tab (switch-if-exists handled
+     * kernel-side) rather than replacing the current VT's shell view. */
+    if (is_tab_app(argv[0]) && (sys_vt_state() & 0xFFFFu)) {
+        char appp[VFS_PATH_MAX];
+        if (resolve_app_path(argv[0], appp, sizeof(appp))) {
+            sys_vt_open_app(appp);
+            return 0;
+        }
+    }
+
     if (looks_like_path(argv[0])) {
         if (try_exec_path(argv[0], argv, &status)) return status;
         put_s("Unknown command '"); put_s(argv[0]); put_s("' - try 'lsman'.\n");

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -1,0 +1,235 @@
+/*
+ * statusbar.c -- /apps/statusbar.elf
+ *
+ * Userspace renderer for the kernel's reserved bottom status row.  The kernel
+ * provides only the mechanism: SYS_STATUSBAR reserves/frees the row and
+ * SYS_PUTCH_AT paints status-row cells regardless of which VT is focused.
+ * Everything about *what* the bar shows lives here (Linux/tmux model).
+ *
+ * Layout + widgets are configured by ~/.sbrc (re-read live so edits + the
+ * post-login user change are picked up).  Each non-comment line is:
+ *
+ *     <section> <widget> [<widget> ...]        section = left | center | right
+ *
+ * Widgets: hostname user date time datetime uptime  (command/mem/rootfs are
+ * reserved names for later phases -- they render empty for now).  Default
+ * when ~/.sbrc is absent:  left hostname  /  right time.
+ *
+ * Alt+F5 toggles the whole bar (reserve <-> free the row).
+ *
+ * Freestanding (only syscall.h) so in-OS TCC can rebuild it.
+ */
+
+#include "syscall.h"
+
+#define SB_CLR      ((VGA_BROWN << 4) | VGA_WHITE)   /* white on brown */
+#define SB_MAXCELLS 256
+#define SEC_MAX     128      /* rendered chars per section */
+#define RC_MAX      512      /* ~/.sbrc bytes */
+
+/* ---- tiny string helpers ------------------------------------------------ */
+static unsigned int s_len(const char *s){ unsigned int n=0; while(s[n])n++; return n; }
+static int s_eq(const char *a,const char *b){ while(*a&&*b){ if(*a!=*b)return 0; a++; b++; } return *a==*b; }
+static void s_cat(char *d,unsigned int *o,unsigned int cap,const char *s)
+{ while(*s && *o+1<cap) d[(*o)++]=*s++; d[*o]='\0'; }
+
+/* ---- cell batching ------------------------------------------------------ */
+static void put_cell(tty_cell_t *c,unsigned int *n,unsigned int col,unsigned int row,char ch,unsigned char clr)
+{ if(*n>=SB_MAXCELLS)return; c[*n].col=(unsigned char)col; c[*n].row=(unsigned char)row;
+  c[*n].ch=(unsigned char)ch; c[*n].clr=clr; (*n)++; }
+static void put_str(tty_cell_t *c,unsigned int *n,unsigned int col,unsigned int row,const char *s,unsigned char clr)
+{ while(*s) put_cell(c,n,col++,row,*s++,clr); }
+
+/* ---- data sources ------------------------------------------------------- */
+
+/* /proc/rtc -> "YYYY-MM-DD HH:MM:SS" (>=19 chars), into buf. */
+static int read_rtc(char *buf,unsigned int cap)
+{
+    int fd=sys_open("/proc/rtc",O_RDONLY);
+    if(fd<0)return -1;
+    long r=sys_read(fd,buf,cap-1); sys_close(fd);
+    if(r<0)return -1;
+    buf[r]='\0';
+    return (int)r;
+}
+
+static char g_host[48];
+static char g_user[48];
+
+/* Append the named widget's current value to out[]. */
+static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
+{
+    if(s_eq(name,"hostname")){ s_cat(out,o,cap,g_host); return; }
+    if(s_eq(name,"user")){ s_cat(out,o,cap,g_user); return; }
+
+    if(s_eq(name,"date")||s_eq(name,"time")||s_eq(name,"datetime")){
+        char rtc[40];
+        if(read_rtc(rtc,sizeof(rtc))<19) return;
+        char tmp[24]; unsigned int t=0;
+        if(s_eq(name,"date")){
+            /* YYYY-MM-DD */
+            for(int i=0;i<10;i++) tmp[t++]=rtc[i];
+        } else if(s_eq(name,"time")){
+            tmp[t++]=rtc[11];tmp[t++]=rtc[12];tmp[t++]=':';
+            tmp[t++]=rtc[14];tmp[t++]=rtc[15];tmp[t++]=':';
+            tmp[t++]=rtc[17];tmp[t++]=rtc[18];
+        } else { /* datetime */
+            for(int i=0;i<19;i++) tmp[t++]=rtc[i];
+        }
+        tmp[t]='\0';
+        s_cat(out,o,cap,tmp);
+        return;
+    }
+
+    if(s_eq(name,"uptime")){
+        unsigned int secs=sys_uptime()/100u;
+        unsigned int h=secs/3600u, m=(secs/60u)%60u, sc=secs%60u;
+        char tmp[16]; unsigned int t=0;
+        const char *up="up "; while(*up) tmp[t++]=*up++;
+        tmp[t++]=(char)('0'+h/10);tmp[t++]=(char)('0'+h%10);tmp[t++]=':';
+        tmp[t++]=(char)('0'+m/10);tmp[t++]=(char)('0'+m%10);tmp[t++]=':';
+        tmp[t++]=(char)('0'+sc/10);tmp[t++]=(char)('0'+sc%10);tmp[t]='\0';
+        s_cat(out,o,cap,tmp);
+        return;
+    }
+
+    /* command / mem / rootfs: reserved for a later phase -> render empty. */
+}
+
+/* ---- ~/.sbrc -> three section widget-lists ------------------------------ */
+static char g_left[SEC_MAX];      /* space-separated widget names */
+static char g_center[SEC_MAX];
+static char g_right[SEC_MAX];
+
+static void set_default_layout(void)
+{
+    g_left[0]='h';g_left[1]='o';g_left[2]='s';g_left[3]='t';g_left[4]='n';
+    g_left[5]='a';g_left[6]='m';g_left[7]='e';g_left[8]='\0';
+    g_center[0]='\0';
+    g_right[0]='t';g_right[1]='i';g_right[2]='m';g_right[3]='e';g_right[4]='\0';
+}
+
+/* Build "/home/<user>/.sbrc" (root -> /root/.sbrc) into path. */
+static void sbrc_path(char *path,unsigned int cap)
+{
+    unsigned int o=0;
+    if(s_eq(g_user,"root")){ s_cat(path,&o,cap,"/root"); }
+    else { s_cat(path,&o,cap,"/home/"); s_cat(path,&o,cap,g_user); }
+    s_cat(path,&o,cap,"/.sbrc");
+}
+
+static void load_sbrc(void)
+{
+    set_default_layout();
+
+    char path[80]; sbrc_path(path,sizeof(path));
+    int fd=sys_open(path,O_RDONLY);
+    if(fd<0) return;                 /* no config -> keep defaults */
+    char buf[RC_MAX]; long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
+    if(r<=0) return;
+    buf[r]='\0';
+
+    int saw_any=0;
+    long i=0;
+    while(i<r){
+        char line[SEC_MAX+16]; int li=0;
+        while(i<r && buf[i]!='\n'){ if(li<(int)sizeof(line)-1) line[li++]=buf[i]; i++; }
+        line[li]='\0'; if(i<r) i++;
+
+        const char *p=line; while(*p==' '||*p=='\t') p++;
+        if(*p=='\0'||*p=='#') continue;
+
+        /* first token = section */
+        char sec[12]; int s=0;
+        while(*p && *p!=' ' && *p!='\t' && s<(int)sizeof(sec)-1) sec[s++]=*p++;
+        sec[s]='\0';
+        char *dst=0;
+        if(s_eq(sec,"left")) dst=g_left;
+        else if(s_eq(sec,"center")) dst=g_center;
+        else if(s_eq(sec,"right")) dst=g_right;
+        else continue;
+
+        /* rest of line (the widget list) trimmed */
+        while(*p==' '||*p=='\t') p++;
+        if(!saw_any){ g_left[0]=g_center[0]=g_right[0]='\0'; saw_any=1; }
+        unsigned int o=0; dst[0]='\0';
+        s_cat(dst,&o,SEC_MAX,p);
+    }
+}
+
+/* Render a section's widget list into out[] (widgets joined by "  "). */
+static void build_section(const char *list,char *out)
+{
+    unsigned int o=0; out[0]='\0';
+    const char *p=list;
+    while(*p){
+        while(*p==' '||*p=='\t') p++;
+        if(!*p) break;
+        char name[24]; int n=0;
+        while(*p && *p!=' ' && *p!='\t' && n<(int)sizeof(name)-1) name[n++]=*p++;
+        name[n]='\0';
+        unsigned int before=o;
+        if(o) s_cat(out,&o,SEC_MAX,"  ");
+        unsigned int after_sep=o;
+        widget(name,out,&o,SEC_MAX);
+        if(o==after_sep) o=before, out[o]='\0';   /* widget empty -> drop sep */
+    }
+}
+
+static void draw(void)
+{
+    unsigned int size=(unsigned int)sys_term_size();
+    unsigned int cols=(size>>16)&0xFFFFu;
+    unsigned int row =size&0xFFFFu;        /* status row = drawable rows */
+    if(cols<12)return;
+    if(cols>SB_MAXCELLS) cols=SB_MAXCELLS;
+
+    char left[SEC_MAX],center[SEC_MAX],right[SEC_MAX];
+    build_section(g_left,left);
+    build_section(g_center,center);
+    build_section(g_right,right);
+
+    tty_cell_t cells[SB_MAXCELLS]; unsigned int n=0;
+    for(unsigned int c=0;c<cols;c++) put_cell(cells,&n,c,row,' ',SB_CLR);
+
+    if(left[0])   put_str(cells,&n,1,row,left,SB_CLR);
+
+    unsigned int rl=s_len(right);
+    if(rl && cols>rl+1) put_str(cells,&n,cols-rl-1,row,right,SB_CLR);
+
+    unsigned int cl=s_len(center);
+    if(cl && cols>cl){ unsigned int cc=(cols-cl)/2u; put_str(cells,&n,cc,row,center,SB_CLR); }
+
+    sys_putch_at(cells,n);
+}
+
+int main(void)
+{
+    if(sys_gethostname(g_host,sizeof(g_host))<=0){
+        g_host[0]='m';g_host[1]='a';g_host[2]='k';g_host[3]='a';g_host[4]='r';g_host[5]='\0';
+    }
+    g_user[0]='\0';
+    set_default_layout();
+
+    unsigned int last=sys_uptime();
+    unsigned int rc_next=0;             /* force an immediate ~/.sbrc load */
+    for(;;){
+        if(sys_vt_clock_request()>0)
+            sys_statusbar_set(!sys_statusbar_enabled());
+
+        /* Re-read user + ~/.sbrc every ~3 s (picks up login + edits). */
+        unsigned int now=sys_uptime();
+        if(now>=rc_next){
+            if(sys_whoami(g_user,sizeof(g_user))<=0){ g_user[0]='u';g_user[1]='s';g_user[2]='e';g_user[3]='r';g_user[4]='\0'; }
+            load_sbrc();
+            rc_next=now+300u;           /* 3 s at 100 Hz */
+        }
+
+        if(sys_statusbar_enabled())
+            draw();
+
+        unsigned int next=last+20u;     /* ~0.2 s frame */
+        while(sys_uptime()<next) sys_yield();
+        last=sys_uptime();
+    }
+}

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -12,9 +12,9 @@
  *     <section> <widget> [<widget> ...]        section = left | center | right
  *
  * Widgets: hostname user date time datetime uptime cpu mem rootfs command tabs.
- * (`cpu` = busy %, `mem`/`rootfs` = used/total MiB, `command` = the active VT's
- *  foreground task, `tabs` = the makmux VT strip.  `rootfs` is ext2-only -- it
- *  renders empty on FAT32/ISO9660 rootfs.)
+ * (`cpu`/`mem` = busy/used % -- same source + calc as maktop; `rootfs` =
+ *  used/total MiB (ext2-only, empty on FAT32/ISO9660); `command` = the active
+ *  VT's foreground task; `tabs` = the makmux VT strip.)
  * Default ~/.sbrc:  left hostname / center tabs / right cpu mem rootfs time.
  *
  * Alt+F5 toggles the whole bar (reserve <-> free the row).
@@ -123,14 +123,15 @@ static void active_command(char *out,unsigned int cap)
     if(best[0]){ unsigned int o=0; s_cat(out,&o,cap,best); }
 }
 
-/* Cumulative ticks the idle task (pid 1) has run, from /proc/tasks. */
-static unsigned int proc_idle_ticks(void)
+/* Sum of TICKS across all tasks except the idle task (pid 1), from
+ * /proc/tasks -- maktop's CPU% basis. */
+static unsigned int proc_busy_ticks(void)
 {
     char buf[1024]; int fd=sys_open("/proc/tasks",O_RDONLY);
     if(fd<0) return 0;
     long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
     if(r<=0) return 0; buf[r]='\0';
-    long i=0; int line=0;
+    long i=0; int line=0; unsigned int sum=0;
     while(i<r){
         char tok[6][20]; int nt=0;
         while(i<r && buf[i]!='\n'){
@@ -142,12 +143,12 @@ static unsigned int proc_idle_ticks(void)
         }
         if(i<r) i++;
         if(line++==0) continue;
-        if(nt>=5 && tok[0][0]=='1' && tok[0][1]=='\0'){    /* pid 1 = idle */
-            unsigned int v=0; for(int k=0;tok[4][k];k++) v=v*10+(unsigned int)(tok[4][k]-'0');
-            return v;
-        }
+        if(nt<5) continue;
+        if(tok[0][0]=='1' && tok[0][1]=='\0') continue;     /* skip idle (pid 1) */
+        unsigned int v=0; for(int k=0;tok[4][k];k++) v=v*10+(unsigned int)(tok[4][k]-'0');
+        sum+=v;
     }
-    return 0;
+    return sum;
 }
 
 /* Append the named widget's current value to out[]. */
@@ -188,11 +189,12 @@ static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
     }
 
     if(s_eq(name,"mem")){
-        unsigned int used=meminfo_kb("MemUsed"), total=meminfo_kb("MemTotal");
+        /* maktop's calc: (MemTotal - MemFree) / MemTotal as a percentage. */
+        unsigned int total=meminfo_kb("MemTotal"), freekb=meminfo_kb("MemFree");
         if(total){
-            char a[12],b[12]; sb_uitoa(used/1024u,a); sb_uitoa(total/1024u,b);
-            s_cat(out,o,cap,"MEM "); s_cat(out,o,cap,a);
-            s_cat(out,o,cap,"/"); s_cat(out,o,cap,b); s_cat(out,o,cap,"M");
+            unsigned int pct=(total>freekb)?(total-freekb)*100u/total:0u;
+            char b[8]; sb_uitoa(pct,b);
+            s_cat(out,o,cap,"MEM "); s_cat(out,o,cap,b); s_cat(out,o,cap,"%");
         }
         return;
     }
@@ -204,14 +206,17 @@ static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
     }
 
     if(s_eq(name,"cpu")){
-        static unsigned int last_idle=0,last_up=0; static int have=0;
-        unsigned int idle=proc_idle_ticks(), up=sys_uptime(), busy=0;
+        /* maktop's calc: non-idle task ticks delta over real-time (uptime)
+         * delta, as a percentage. */
+        static unsigned int last_busy=0,last_up=0; static int have=0;
+        unsigned int busy=proc_busy_ticks(), up=sys_uptime(), pct=0;
         if(have && up>last_up){
-            unsigned int dt=up-last_up, di=(idle>=last_idle)?(idle-last_idle):0u;
-            busy=(dt>di)?(dt-di)*100u/dt:0u;
+            unsigned int dt=up-last_up;
+            unsigned int db=(busy>last_busy)?(busy-last_busy):0u;
+            pct=db*100u/dt; if(pct>100u) pct=100u;
         }
-        last_idle=idle; last_up=up; have=1;
-        char b[8]; sb_uitoa(busy,b);
+        last_busy=busy; last_up=up; have=1;
+        char b[8]; sb_uitoa(pct,b);
         s_cat(out,o,cap,"CPU "); s_cat(out,o,cap,b); s_cat(out,o,cap,"%");
         return;
     }

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -11,9 +11,10 @@
  *
  *     <section> <widget> [<widget> ...]        section = left | center | right
  *
- * Widgets: hostname user date time datetime uptime  (command/mem/rootfs are
- * reserved names for later phases -- they render empty for now).  Default
- * when ~/.sbrc is absent:  left hostname  /  right time.
+ * Widgets: hostname user date time datetime uptime mem command tabs.
+ * (`command` = the active VT's foreground task; `tabs` = the makmux VT strip;
+ *  `rootfs` is reserved -- needs a statvfs-style syscall the kernel lacks.)
+ * Default when ~/.sbrc is absent:  left hostname / center tabs / right time.
  *
  * Alt+F5 toggles the whole bar (reserve <-> free the row).
  *
@@ -57,6 +58,70 @@ static int read_rtc(char *buf,unsigned int cap)
 static char g_host[48];
 static char g_user[48];
 
+static void sb_uitoa(unsigned int v,char *buf)
+{
+    char t[12]; int i=0;
+    if(v==0){ buf[0]='0'; buf[1]='\0'; return; }
+    while(v){ t[i++]=(char)('0'+v%10); v/=10; }
+    int j=0; while(i>0) buf[j++]=t[--i]; buf[j]='\0';
+}
+
+/* Value (kB) of a "Label:   N kB" line in /proc/meminfo, or 0. */
+static unsigned int meminfo_kb(const char *label)
+{
+    char buf[512]; int fd=sys_open("/proc/meminfo",O_RDONLY);
+    if(fd<0) return 0;
+    long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
+    if(r<=0) return 0; buf[r]='\0';
+    unsigned int ll=0; while(label[ll]) ll++;
+    for(long i=0;i<r;){
+        long j=0; while(j<(long)ll && buf[i+j]==label[j]) j++;
+        if(j==(long)ll && buf[i+ll]==':'){
+            const char *p=buf+i+ll+1; while(*p==' ') p++;
+            unsigned int v=0; while(*p>='0'&&*p<='9'){ v=v*10+(unsigned int)(*p-'0'); p++; }
+            return v;
+        }
+        while(i<r && buf[i]!='\n') i++;
+        i++;
+    }
+    return 0;
+}
+
+/* Foreground command of the active VT: the live task with that tty and the
+ * highest pid (a running child outranks its shell).  Empty if none. */
+static void active_command(char *out,unsigned int cap)
+{
+    out[0]='\0';
+    unsigned int active=((unsigned int)sys_vt_state()>>16)&0xFFFFu;
+    char buf[1024]; int fd=sys_open("/proc/tasks",O_RDONLY);
+    if(fd<0) return;
+    long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
+    if(r<=0) return; buf[r]='\0';
+
+    long i=0; int line=0; int best_pid=-1; char best[20]; best[0]='\0';
+    while(i<r){
+        char tok[5][20]; int nt=0;
+        while(i<r && buf[i]!='\n'){
+            while(i<r && (buf[i]==' '||buf[i]=='\t')) i++;
+            if(i>=r||buf[i]=='\n') break;
+            int tl=0;
+            while(i<r&&buf[i]!=' '&&buf[i]!='\t'&&buf[i]!='\n'){
+                if(nt<5 && tl<19) tok[nt][tl++]=buf[i];
+                i++;
+            }
+            if(nt<5){ tok[nt][tl]='\0'; nt++; }
+        }
+        if(i<r) i++;
+        if(line++==0) continue;                 /* header row */
+        if(nt<4 || tok[3][0]=='-') continue;     /* no tty */
+        unsigned int tn=0; for(int k=0;tok[3][k];k++) tn=tn*10+(unsigned int)(tok[3][k]-'0');
+        if(tn!=active) continue;
+        int pid=0; for(int k=0;tok[0][k];k++) pid=pid*10+(tok[0][k]-'0');
+        if(pid>best_pid){ best_pid=pid; int b=0; while(tok[1][b]&&b<19){best[b]=tok[1][b];b++;} best[b]='\0'; }
+    }
+    if(best[0]){ unsigned int o=0; s_cat(out,&o,cap,best); }
+}
+
 /* Append the named widget's current value to out[]. */
 static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
 {
@@ -94,7 +159,24 @@ static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
         return;
     }
 
-    /* command / mem / rootfs: reserved for a later phase -> render empty. */
+    if(s_eq(name,"mem")){
+        unsigned int used=meminfo_kb("MemUsed"), total=meminfo_kb("MemTotal");
+        if(total){
+            char a[12],b[12]; sb_uitoa(used/1024u,a); sb_uitoa(total/1024u,b);
+            s_cat(out,o,cap,"MEM "); s_cat(out,o,cap,a);
+            s_cat(out,o,cap,"/"); s_cat(out,o,cap,b); s_cat(out,o,cap,"M");
+        }
+        return;
+    }
+
+    if(s_eq(name,"command")){
+        char cmd[20]; active_command(cmd,sizeof(cmd));
+        if(cmd[0]) s_cat(out,o,cap,cmd);
+        return;
+    }
+
+    /* rootfs: needs a fs-free-blocks (statvfs-style) syscall the kernel
+     * doesn't expose yet -> render empty for now. */
 }
 
 /* ---- ~/.sbrc -> three section widget-lists ------------------------------ */

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -15,7 +15,7 @@
  * (`cpu`/`mem` = busy/used % -- same source + calc as maktop; `rootfs` =
  *  used/total MiB (ext2-only, empty on FAT32/ISO9660); `command` = the active
  *  VT's foreground task; `tabs` = the makmux VT strip.)
- * Default ~/.sbrc:  left hostname / center tabs / right cpu mem rootfs time.
+ * Default ~/.sbrc:  left command / center tabs / right cpu mem rootfs time.
  *
  * Alt+F5 toggles the whole bar (reserve <-> free the row).
  *
@@ -240,7 +240,7 @@ static char g_right[SEC_MAX];
 static void set_default_layout(void)
 {
     unsigned int o;
-    o=0; s_cat(g_left,&o,SEC_MAX,"hostname");
+    o=0; s_cat(g_left,&o,SEC_MAX,"command");    /* active VT's foreground exe */
     o=0; s_cat(g_center,&o,SEC_MAX,"tabs");     /* makmux VT tabs */
     o=0; s_cat(g_right,&o,SEC_MAX,"cpu mem rootfs time");
 }
@@ -327,15 +327,18 @@ static int sb_has(const char *list,const char *tok)
     return 0;
 }
 
-/* Render the live VT tabs centred, active highlighted.  Shells (slots 0-3)
- * show "VTn"; named app-tabs show their name.  No-op if makmux isn't running
- * (mask == 0).  Returns 1 if it drew tabs. */
-static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,unsigned int cols)
+/* Render the live VT tabs centred within the [lo,hi) column window (the gap
+ * between the left and right sections, so the tabs never paint over the
+ * resource widgets).  Active highlighted; shells show "VTn", named app-tabs
+ * show their name.  Tabs that don't fit the window are clipped.  No-op if
+ * makmux isn't running (mask == 0).  Returns 1 if it drew tabs. */
+static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,
+                       unsigned int lo,unsigned int hi)
 {
     unsigned int state=(unsigned int)sys_vt_state();
     unsigned int active=(state>>16)&0xFFFFu;
     unsigned int mask=state&0xFFFFu;
-    if(!mask) return 0;
+    if(!mask || hi<=lo) return 0;
 
     char  lab[8][18];
     int   idx[8], cnt=0;
@@ -353,10 +356,11 @@ static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,unsign
     }
     if(!cnt) return 0;
 
-    unsigned int c=(cols>total)?(cols-total)/2u:0u;
+    unsigned int avail=hi-lo;
+    unsigned int c=(avail>total)?(lo+(avail-total)/2u):lo;
     for(int k=0;k<cnt;k++){
         unsigned char clr=(idx[k]==(int)active)?SB_TAB_ACT:SB_CLR;
-        for(unsigned int j=0; lab[k][j] && c<cols; j++)
+        for(unsigned int j=0; lab[k][j] && c<hi; j++)
             put_cell(cells,n,c++,row,lab[k][j],clr);
     }
     return 1;
@@ -377,19 +381,29 @@ static void draw(void)
     tty_cell_t cells[SB_MAXCELLS]; unsigned int n=0;
     for(unsigned int c=0;c<cols;c++) put_cell(cells,&n,c,row,' ',SB_CLR);
 
+    unsigned int ll=s_len(left);
     if(left[0])   put_str(cells,&n,1,row,left,SB_CLR);
 
     unsigned int rl=s_len(right);
     if(rl && cols>rl+1) put_str(cells,&n,cols-rl-1,row,right,SB_CLR);
 
+    /* Centre window = the gap between the left and right sections, so the
+     * tabs / centre widget never overpaint the resource readouts.  One cell
+     * of padding on each side. */
+    unsigned int lo=left[0] ? (1+ll+1) : 0;
+    unsigned int hi=(rl && cols>rl+1) ? (cols-rl-1) : cols;
+    if(hi>cols) hi=cols;
+    if(lo>hi)   lo=hi;
+
     /* Center: the live VT tabs when requested (the makmux strip), else a
      * normal widget string. */
     if(sb_has(g_center,"tabs")){
-        render_tabs(cells,&n,row,cols);
+        render_tabs(cells,&n,row,lo,hi);
     } else {
         char center[SEC_MAX]; build_section(g_center,center);
         unsigned int cl=s_len(center);
-        if(cl && cols>cl){ unsigned int cc=(cols-cl)/2u; put_str(cells,&n,cc,row,center,SB_CLR); }
+        unsigned int avail=hi-lo;
+        if(cl && avail>cl){ unsigned int cc=lo+(avail-cl)/2u; put_str(cells,&n,cc,row,center,SB_CLR); }
     }
 
     sys_putch_at(cells,n);

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -22,7 +22,8 @@
 
 #include "syscall.h"
 
-#define SB_CLR      ((VGA_BROWN << 4) | VGA_WHITE)   /* white on brown */
+#define SB_CLR      ((VGA_BROWN << 4) | VGA_WHITE)    /* white on brown */
+#define SB_TAB_ACT  ((VGA_YELLOW << 4) | VGA_BLACK)   /* active VT tab  */
 #define SB_MAXCELLS 256
 #define SEC_MAX     128      /* rendered chars per section */
 #define RC_MAX      512      /* ~/.sbrc bytes */
@@ -103,10 +104,10 @@ static char g_right[SEC_MAX];
 
 static void set_default_layout(void)
 {
-    g_left[0]='h';g_left[1]='o';g_left[2]='s';g_left[3]='t';g_left[4]='n';
-    g_left[5]='a';g_left[6]='m';g_left[7]='e';g_left[8]='\0';
-    g_center[0]='\0';
-    g_right[0]='t';g_right[1]='i';g_right[2]='m';g_right[3]='e';g_right[4]='\0';
+    unsigned int o;
+    o=0; s_cat(g_left,&o,SEC_MAX,"hostname");
+    o=0; s_cat(g_center,&o,SEC_MAX,"tabs");     /* makmux VT tabs */
+    o=0; s_cat(g_right,&o,SEC_MAX,"time");
 }
 
 /* Build "/home/<user>/.sbrc" (root -> /root/.sbrc) into path. */
@@ -176,6 +177,56 @@ static void build_section(const char *list,char *out)
     }
 }
 
+/* True if a section's widget list contains the token `tok`. */
+static int sb_has(const char *list,const char *tok)
+{
+    const char *p=list;
+    while(*p){
+        while(*p==' '||*p=='\t') p++;
+        if(!*p) break;
+        const char *q=tok; const char *s=p;
+        while(*s && *s!=' ' && *s!='\t' && *q && *s==*q){ s++; q++; }
+        if(*q=='\0' && (*s=='\0'||*s==' '||*s=='\t')) return 1;
+        while(*p && *p!=' ' && *p!='\t') p++;
+    }
+    return 0;
+}
+
+/* Render the live VT tabs centred, active highlighted.  Shells (slots 0-3)
+ * show "VTn"; named app-tabs show their name.  No-op if makmux isn't running
+ * (mask == 0).  Returns 1 if it drew tabs. */
+static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,unsigned int cols)
+{
+    unsigned int state=(unsigned int)sys_vt_state();
+    unsigned int active=(state>>16)&0xFFFFu;
+    unsigned int mask=state&0xFFFFu;
+    if(!mask) return 0;
+
+    char  lab[8][18];
+    int   idx[8], cnt=0;
+    unsigned int total=0;
+    for(int i=0;i<8;i++){
+        if(!(mask&(1u<<i))) continue;
+        char nm[16]; int ln=sys_vt_getname(i,nm,sizeof(nm));
+        char *l=lab[cnt]; unsigned int w=0;
+        l[w++]=' ';
+        if(ln>0){ for(int j=0;nm[j]&&w<16;j++) l[w++]=nm[j]; }
+        else    { l[w++]='V'; l[w++]='T'; l[w++]=(char)('1'+i); }
+        l[w++]=' '; l[w]='\0';
+        idx[cnt]=i; total+=w; cnt++;
+        if(cnt>=8) break;
+    }
+    if(!cnt) return 0;
+
+    unsigned int c=(cols>total)?(cols-total)/2u:0u;
+    for(int k=0;k<cnt;k++){
+        unsigned char clr=(idx[k]==(int)active)?SB_TAB_ACT:SB_CLR;
+        for(unsigned int j=0; lab[k][j] && c<cols; j++)
+            put_cell(cells,n,c++,row,lab[k][j],clr);
+    }
+    return 1;
+}
+
 static void draw(void)
 {
     unsigned int size=(unsigned int)sys_term_size();
@@ -184,9 +235,8 @@ static void draw(void)
     if(cols<12)return;
     if(cols>SB_MAXCELLS) cols=SB_MAXCELLS;
 
-    char left[SEC_MAX],center[SEC_MAX],right[SEC_MAX];
+    char left[SEC_MAX],right[SEC_MAX];
     build_section(g_left,left);
-    build_section(g_center,center);
     build_section(g_right,right);
 
     tty_cell_t cells[SB_MAXCELLS]; unsigned int n=0;
@@ -197,8 +247,15 @@ static void draw(void)
     unsigned int rl=s_len(right);
     if(rl && cols>rl+1) put_str(cells,&n,cols-rl-1,row,right,SB_CLR);
 
-    unsigned int cl=s_len(center);
-    if(cl && cols>cl){ unsigned int cc=(cols-cl)/2u; put_str(cells,&n,cc,row,center,SB_CLR); }
+    /* Center: the live VT tabs when requested (the makmux strip), else a
+     * normal widget string. */
+    if(sb_has(g_center,"tabs")){
+        render_tabs(cells,&n,row,cols);
+    } else {
+        char center[SEC_MAX]; build_section(g_center,center);
+        unsigned int cl=s_len(center);
+        if(cl && cols>cl){ unsigned int cc=(cols-cl)/2u; put_str(cells,&n,cc,row,center,SB_CLR); }
+    }
 
     sys_putch_at(cells,n);
 }

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -11,10 +11,11 @@
  *
  *     <section> <widget> [<widget> ...]        section = left | center | right
  *
- * Widgets: hostname user date time datetime uptime mem command tabs.
- * (`command` = the active VT's foreground task; `tabs` = the makmux VT strip;
- *  `rootfs` is reserved -- needs a statvfs-style syscall the kernel lacks.)
- * Default when ~/.sbrc is absent:  left hostname / center tabs / right time.
+ * Widgets: hostname user date time datetime uptime cpu mem rootfs command tabs.
+ * (`cpu` = busy %, `mem`/`rootfs` = used/total MiB, `command` = the active VT's
+ *  foreground task, `tabs` = the makmux VT strip.  `rootfs` is ext2-only -- it
+ *  renders empty on FAT32/ISO9660 rootfs.)
+ * Default ~/.sbrc:  left hostname / center tabs / right cpu mem rootfs time.
  *
  * Alt+F5 toggles the whole bar (reserve <-> free the row).
  *
@@ -122,6 +123,33 @@ static void active_command(char *out,unsigned int cap)
     if(best[0]){ unsigned int o=0; s_cat(out,&o,cap,best); }
 }
 
+/* Cumulative ticks the idle task (pid 1) has run, from /proc/tasks. */
+static unsigned int proc_idle_ticks(void)
+{
+    char buf[1024]; int fd=sys_open("/proc/tasks",O_RDONLY);
+    if(fd<0) return 0;
+    long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
+    if(r<=0) return 0; buf[r]='\0';
+    long i=0; int line=0;
+    while(i<r){
+        char tok[6][20]; int nt=0;
+        while(i<r && buf[i]!='\n'){
+            while(i<r&&(buf[i]==' '||buf[i]=='\t')) i++;
+            if(i>=r||buf[i]=='\n') break;
+            int tl=0;
+            while(i<r&&buf[i]!=' '&&buf[i]!='\t'&&buf[i]!='\n'){ if(nt<6&&tl<19) tok[nt][tl++]=buf[i]; i++; }
+            if(nt<6){ tok[nt][tl]='\0'; nt++; }
+        }
+        if(i<r) i++;
+        if(line++==0) continue;
+        if(nt>=5 && tok[0][0]=='1' && tok[0][1]=='\0'){    /* pid 1 = idle */
+            unsigned int v=0; for(int k=0;tok[4][k];k++) v=v*10+(unsigned int)(tok[4][k]-'0');
+            return v;
+        }
+    }
+    return 0;
+}
+
 /* Append the named widget's current value to out[]. */
 static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
 {
@@ -175,8 +203,28 @@ static void widget(const char *name,char *out,unsigned int *o,unsigned int cap)
         return;
     }
 
-    /* rootfs: needs a fs-free-blocks (statvfs-style) syscall the kernel
-     * doesn't expose yet -> render empty for now. */
+    if(s_eq(name,"cpu")){
+        static unsigned int last_idle=0,last_up=0; static int have=0;
+        unsigned int idle=proc_idle_ticks(), up=sys_uptime(), busy=0;
+        if(have && up>last_up){
+            unsigned int dt=up-last_up, di=(idle>=last_idle)?(idle-last_idle):0u;
+            busy=(dt>di)?(dt-di)*100u/dt:0u;
+        }
+        last_idle=idle; last_up=up; have=1;
+        char b[8]; sb_uitoa(busy,b);
+        s_cat(out,o,cap,"CPU "); s_cat(out,o,cap,b); s_cat(out,o,cap,"%");
+        return;
+    }
+
+    if(s_eq(name,"rootfs")){
+        unsigned int t=0,fr=0;
+        if(sys_statfs(&t,&fr)==0 && t){
+            char a[12],b[12]; sb_uitoa((t-fr)/1024u,a); sb_uitoa(t/1024u,b);
+            s_cat(out,o,cap,"ROOT "); s_cat(out,o,cap,a);
+            s_cat(out,o,cap,"/"); s_cat(out,o,cap,b); s_cat(out,o,cap,"M");
+        }
+        return;
+    }
 }
 
 /* ---- ~/.sbrc -> three section widget-lists ------------------------------ */
@@ -189,7 +237,7 @@ static void set_default_layout(void)
     unsigned int o;
     o=0; s_cat(g_left,&o,SEC_MAX,"hostname");
     o=0; s_cat(g_center,&o,SEC_MAX,"tabs");     /* makmux VT tabs */
-    o=0; s_cat(g_right,&o,SEC_MAX,"time");
+    o=0; s_cat(g_right,&o,SEC_MAX,"cpu mem rootfs time");
 }
 
 /* Build "/home/<user>/.sbrc" (root -> /root/.sbrc) into path. */

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -89,6 +89,8 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_SCHED_QUANTUM 228
 #define SYS_VERBOSE       229
 #define SYS_GETHOSTNAME   230
+#define SYS_WHOAMI        240
+#define SYS_STATUSBAR     241
 #define SYS_SHELL_READY   231
 #define SYS_CURSOR_POS    232
 #define SYS_VT_ENTER      233
@@ -705,6 +707,22 @@ static inline int sys_gethostname(char *buf, unsigned int size)
 {
     return (int)syscall2(SYS_GETHOSTNAME, (long)buf, (long)size);
 }
+
+/* Copy the current session's username ("user" on live boots) into buf,
+ * capped at size-1 bytes, NUL-terminated.  Returns strlen, -1 on bad args. */
+static inline int sys_whoami(char *buf, unsigned int size)
+{
+    return (int)syscall2(SYS_WHOAMI, (long)buf, (long)size);
+}
+
+/* Status-bar reservation (statusbar.elf uses this).  cmd: 1=enable/reserve the
+ * bottom row, 0=disable/free it, <0=query only.  Returns the enabled state. */
+static inline int sys_statusbar(int cmd)
+{
+    return (int)syscall1(SYS_STATUSBAR, (long)cmd);
+}
+static inline int sys_statusbar_enabled(void) { return sys_statusbar(-1); }
+static inline int sys_statusbar_set(int on)   { return sys_statusbar(on ? 1 : 0); }
 
 /* Emit `[shell:ready vt=N]` on COM1 when g_serial_verbose is set.
  * Called by /apps/sh.elf before each prompt so ui_test.sh's

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -94,6 +94,7 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_VT_OPEN_APP   242
 #define SYS_VT_TAKE_APP   243
 #define SYS_VT_SETNAME    244
+#define SYS_VT_GETNAME    245
 #define SYS_SHELL_READY   231
 #define SYS_CURSOR_POS    232
 #define SYS_VT_ENTER      233
@@ -741,6 +742,10 @@ static inline int sys_vt_take_app(char *buf, int cap)
 static inline int sys_vt_setname(const char *name)
 {
     return (int)syscall1(SYS_VT_SETNAME, (long)name);
+}
+static inline int sys_vt_getname(int slot, char *buf, int cap)
+{
+    return (int)syscall3(SYS_VT_GETNAME, (long)slot, (long)buf, (long)cap);
 }
 
 /* Emit `[shell:ready vt=N]` on COM1 when g_serial_verbose is set.

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -91,6 +91,9 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_GETHOSTNAME   230
 #define SYS_WHOAMI        240
 #define SYS_STATUSBAR     241
+#define SYS_VT_OPEN_APP   242
+#define SYS_VT_TAKE_APP   243
+#define SYS_VT_SETNAME    244
 #define SYS_SHELL_READY   231
 #define SYS_CURSOR_POS    232
 #define SYS_VT_ENTER      233
@@ -723,6 +726,22 @@ static inline int sys_statusbar(int cmd)
 }
 static inline int sys_statusbar_enabled(void) { return sys_statusbar(-1); }
 static inline int sys_statusbar_set(int on)   { return sys_statusbar(on ? 1 : 0); }
+
+/* App-tab routing.  sys_vt_open_app: open `path` in a named tab (switch if it
+ * exists, else queue for makmux).  sys_vt_take_app: makmux drains one queued
+ * path.  sys_vt_setname: name the calling task's VT tab. */
+static inline int sys_vt_open_app(const char *path)
+{
+    return (int)syscall1(SYS_VT_OPEN_APP, (long)path);
+}
+static inline int sys_vt_take_app(char *buf, int cap)
+{
+    return (int)syscall2(SYS_VT_TAKE_APP, (long)buf, (long)cap);
+}
+static inline int sys_vt_setname(const char *name)
+{
+    return (int)syscall1(SYS_VT_SETNAME, (long)name);
+}
 
 /* Emit `[shell:ready vt=N]` on COM1 when g_serial_verbose is set.
  * Called by /apps/sh.elf before each prompt so ui_test.sh's

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -95,6 +95,7 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_VT_TAKE_APP   243
 #define SYS_VT_SETNAME    244
 #define SYS_VT_GETNAME    245
+#define SYS_STATFS        246
 #define SYS_SHELL_READY   231
 #define SYS_CURSOR_POS    232
 #define SYS_VT_ENTER      233
@@ -746,6 +747,13 @@ static inline int sys_vt_setname(const char *name)
 static inline int sys_vt_getname(int slot, char *buf, int cap)
 {
     return (int)syscall3(SYS_VT_GETNAME, (long)slot, (long)buf, (long)cap);
+}
+
+/* Rootfs usage in KiB (total + free).  Returns 0 on success, -1 if the rootfs
+ * doesn't report usage (FAT32/ISO9660). */
+static inline int sys_statfs(unsigned int *total_kb, unsigned int *free_kb)
+{
+    return (int)syscall2(SYS_STATFS, (long)total_kb, (long)free_kb);
 }
 
 /* Emit `[shell:ready vt=N]` on COM1 when g_serial_verbose is set.

--- a/src/userspace/vix.c
+++ b/src/userspace/vix.c
@@ -36,12 +36,21 @@
 
 #define CTRL_S  '\x13'
 #define CTRL_Q  '\x11'
+#define CTRL_N  '\x0E'   /* toggle line numbers */
+
+#define VIX_USER_MAX    64
 
 /* Runtime geometry (set in main from the pane). */
 static int v_cols;        /* total pane width                       */
 static int v_text_cols;   /* usable content width = v_cols - gutter */
 static int v_text_rows;   /* visible content rows (status excluded) */
 static int v_status_row;  /* status-bar row                         */
+
+/* Line numbers: OFF by default.  Turned on at runtime with Ctrl-N or via a
+ * `set linenumbers` (alias `set number` / `set nu`) line in ~/.vixrc.  When
+ * off the gutter has zero width and text starts at column 0. */
+static int v_linenumbers; /* 0 = off (default), 1 = on               */
+static int v_gutter;      /* current gutter width (VIX_GUTTER_W or 0) */
 
 /* Editor buffer. */
 static char v_lines[VIX_MAX_LINES][VIX_LINE_CAP + 1];
@@ -116,6 +125,8 @@ static int line_vrows(int li)
  * continuation marker on later segments. */
 static void vix_draw_gutter(int screen_row, int line_one_based, int seg)
 {
+    if (v_gutter <= 0) return;   /* line numbers off: no gutter */
+
     char gut[VIX_GUTTER_W + 1];
     for (int i = 0; i < VIX_GUTTER_W; i++) gut[i] = ' ';
     gut[VIX_GUTTER_W] = '\0';
@@ -147,9 +158,9 @@ static void vix_draw_text(int screen_row, int line_idx, int seg_start)
     for (int c = 0; c < v_text_cols; c++) {
         int  idx = seg_start + c;
         char ch  = (s && idx < len) ? s[idx] : ' ';
-        vix_put(VIX_GUTTER_W + c, screen_row, ch, VIX_CLR_TEXT);
+        vix_put(v_gutter + c, screen_row, ch, VIX_CLR_TEXT);
     }
-    for (int c = VIX_GUTTER_W + v_text_cols; c < v_cols; c++)
+    for (int c = v_gutter + v_text_cols; c < v_cols; c++)
         vix_put(c, screen_row, ' ', VIX_CLR_TEXT);
 }
 
@@ -178,7 +189,7 @@ static void vix_draw_status(void)
         vix_append(bar, cap, &off, "/");
         vix_uitoa((unsigned int)v_nlines, tmp);
         vix_append(bar, cap, &off, tmp);
-        vix_append(bar, cap, &off, " | ^S:Save  ^Q:Quit");
+        vix_append(bar, cap, &off, " | ^S:Save  ^Q:Quit  ^N:Num");
     }
 
     while (off < v_cols && off < VIX_STATUS_BUF - 1) bar[off++] = ' ';
@@ -219,8 +230,8 @@ static void vix_redraw(void)
     /* Vim-style empty rows past EOF: blank gutter + '~'. */
     while (vrow < v_text_rows) {
         vix_draw_gutter(vrow, 0, 0);
-        vix_put(VIX_GUTTER_W, vrow, '~', VIX_CLR_GUTTER);
-        for (int c = VIX_GUTTER_W + 1; c < v_cols; c++)
+        vix_put(v_gutter, vrow, '~', VIX_CLR_GUTTER);
+        for (int c = v_gutter + 1; c < v_cols; c++)
             vix_put(c, vrow, ' ', VIX_CLR_TEXT);
         vrow++;
     }
@@ -230,7 +241,7 @@ static void vix_redraw(void)
 
     int cur_vrow  = vix_cursor_vrow();
     int cur_inseg = v_cur_col % (v_text_cols > 0 ? v_text_cols : 1);
-    sys_set_cursor((unsigned int)(VIX_GUTTER_W + cur_inseg),
+    sys_set_cursor((unsigned int)(v_gutter + cur_inseg),
                    (unsigned int)cur_vrow);
 }
 
@@ -357,6 +368,93 @@ static int vix_save(void)
     return err;
 }
 
+/* Recompute the gutter width and usable text width from v_linenumbers.
+ * Called at startup and whenever line numbers are toggled. */
+static void vix_recompute_geometry(void)
+{
+    v_gutter    = v_linenumbers ? VIX_GUTTER_W : 0;
+    v_text_cols = (v_cols > v_gutter + 1) ? (v_cols - v_gutter) : v_cols;
+    if (v_text_cols > VIX_LINE_CAP) v_text_cols = VIX_LINE_CAP;
+}
+
+static int vix_streq(const char *a, const char *b)
+{
+    while (*a && *b) { if (*a != *b) return 0; a++; b++; }
+    return *a == *b;
+}
+
+static int vix_starts(const char *s, const char *pfx)
+{
+    while (*pfx) { if (*s != *pfx) return 0; s++; pfx++; }
+    return 1;
+}
+
+/* Apply one `set ...` directive (from ~/.vixrc or a future command line).
+ * Recognises linenumbers / number / nu and their `no...` negations. */
+static void vix_apply_setting(const char *s)
+{
+    while (*s == ' ' || *s == '\t') s++;
+    if (!vix_starts(s, "set")) return;
+    s += 3;
+    while (*s == ' ' || *s == '\t') s++;
+
+    if (vix_streq(s, "linenumbers") || vix_streq(s, "number") || vix_streq(s, "nu"))
+        v_linenumbers = 1;
+    else if (vix_streq(s, "nolinenumbers") || vix_streq(s, "nonumber") || vix_streq(s, "nonu"))
+        v_linenumbers = 0;
+
+    vix_recompute_geometry();
+}
+
+/* Read ~/.vixrc and apply each `set` directive.  Home is derived from the
+ * current user (root -> /root, otherwise /home/<user>) via SYS_WHOAMI, since
+ * userspace has no environment to carry $HOME.  Best-effort: a missing file,
+ * unknown user, or unreadable rc just leaves the defaults in place. */
+static void vix_load_vixrc(void)
+{
+    char user[VIX_USER_MAX];
+    if (sys_whoami(user, sizeof(user)) <= 0) return;
+
+    char path[VFS_PATH_MAX];
+    int o = 0;
+    if (vix_streq(user, "root")) {
+        const char *h = "/root";
+        while (*h && o < VFS_PATH_MAX - 8) path[o++] = *h++;
+    } else {
+        const char *h = "/home/";
+        while (*h && o < VFS_PATH_MAX - 8) path[o++] = *h++;
+        for (int i = 0; user[i] && o < VFS_PATH_MAX - 8; i++) path[o++] = user[i];
+    }
+    const char *suf = "/.vixrc";
+    while (*suf && o < VFS_PATH_MAX - 1) path[o++] = *suf++;
+    path[o] = '\0';
+
+    int fd = sys_open(path, O_RDONLY);
+    if (fd < 0) return;
+    static char rc[2048];
+    long n = sys_read(fd, rc, sizeof(rc) - 1);
+    sys_close(fd);
+    if (n <= 0) return;
+    rc[n] = '\0';
+
+    long i = 0;
+    while (i < n) {
+        char line[128];
+        int  li = 0;
+        while (i < n && rc[i] != '\n') {
+            if (li < (int)sizeof(line) - 1) line[li++] = rc[i];
+            i++;
+        }
+        line[li] = '\0';
+        if (i < n) i++;                 /* skip newline */
+
+        const char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0' || *p == '#' || *p == '"') continue;   /* blank/comment */
+        vix_apply_setting(p);
+    }
+}
+
 int main(int argc, char **argv)
 {
     if (argc < 2) {
@@ -374,8 +472,11 @@ int main(int argc, char **argv)
     if (rows  > VIX_MAX_ROWS)  rows = VIX_MAX_ROWS;
     v_text_rows  = rows - 1;
     v_status_row = rows - 1;
-    v_text_cols  = (v_cols > VIX_GUTTER_W + 1) ? (v_cols - VIX_GUTTER_W) : v_cols;
-    if (v_text_cols > VIX_LINE_CAP) v_text_cols = VIX_LINE_CAP;
+
+    /* Line numbers default off; ~/.vixrc may flip them on with
+     * `set linenumbers`.  Load it before computing the gutter geometry. */
+    vix_load_vixrc();
+    vix_recompute_geometry();
 
     /* Store path. */
     const char *src = argv[1];
@@ -415,6 +516,12 @@ int main(int argc, char **argv)
         if (c == KEY_CTRL_S || c == CTRL_S) {
             if (v_path[0]) v_save_msg = (vix_save() == 0) ? 1 : -1;
             else           v_save_msg = -1;
+            continue;
+        }
+
+        if (c == CTRL_N) {   /* toggle line numbers (mirrors `set linenumbers`) */
+            v_linenumbers = !v_linenumbers;
+            vix_recompute_geometry();
             continue;
         }
 

--- a/tests/groups/cdrom_content.py
+++ b/tests/groups/cdrom_content.py
@@ -22,21 +22,57 @@ EXPECTED_FILES = [
 ]
 
 
+def _exists(path):
+    return int(gdb.parse_and_eval('vfs_file_exists("{}")'.format(path))) == 1
+
+
+def _cdrom_alias(path):
+    if path.startswith('/mnt/cdrom/'):
+        return None
+    return '/mnt/cdrom' + path
+
+
+def _check_exists(path):
+    """Check a CD-ROM path, tolerating transient GDB inferior-call misses.
+
+    This group runs after bg-ktest while QEMU is stopped under GDB.  The same
+    ISO sysroot is already verified by in-kernel ktest, but direct GDB calls
+    into vfs_file_exists() can occasionally observe a one-off ATAPI/ISO lookup
+    miss on shared CI runners.  Retry the exact path and then the explicit
+    /mnt/cdrom bind alias before declaring the image content absent.
+    """
+    aliases = [path]
+    alias = _cdrom_alias(path)
+    if alias:
+        aliases.append(alias)
+
+    last_exc = None
+    for _ in range(5):
+        for candidate in aliases:
+            try:
+                if _exists(candidate):
+                    return True, candidate, None
+            except gdb.error as exc:
+                last_exc = exc
+
+    return False, None, last_exc
+
+
 def run():
     for path in EXPECTED_FILES:
-        try:
-            result = int(gdb.parse_and_eval(
-                'vfs_file_exists("{}")'.format(path)))
-        except gdb.error as exc:
-            print('FAIL: could not check {}: {}'.format(path, exc),
-                  flush=True)
+        found, matched_path, exc = _check_exists(path)
+        if exc is not None:
+            print('FAIL: could not check {}: {}'.format(path, exc), flush=True)
             return False
 
-        if result != 1:
+        if not found:
             print('FAIL: {} not found on CD-ROM'.format(path), flush=True)
             return False
 
-        print('PASS: {} exists'.format(path), flush=True)
+        if matched_path == path:
+            print('PASS: {} exists'.format(path), flush=True)
+        else:
+            print('PASS: {} exists via {}'.format(path, matched_path), flush=True)
 
     print('GROUP PASS: ' + NAME, flush=True)
     return True

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -951,6 +951,25 @@ sendkey ret" \
     assert_serial_not_contains "Kernel panic" "SIGSEGV"
 }
 
+test_tcc_rebuild_statusbar() {
+    # Self-host: in-OS TCC rebuilds statusbar.c (freestanding, only syscall.h,
+    # no floats).  It's a long-running loop so we don't exec it -- just prove
+    # the compile produced an ELF (ls shows it; a compile error leaves no file).
+    reset_shell
+    CURRENT_NAME=tcc-rebuild-statusbar
+    local sb1=$(wc -c < "$SERIAL_LOG")
+    send_script "$(keys "tcc /src/userspace/statusbar.c -o /tmp/statusbar.elf")
+sendkey ret"
+    wait_for_serial '\[shell:ready vt=0\]' "$sb1" 90 || \
+        echo "  - stage1: tcc compile of statusbar.c never returned to prompt"
+    it_until "tcc-rebuild-statusbar" \
+"$(keys "ls /tmp/statusbar.elf")
+sendkey ret" \
+        "statusbar.elf" 15
+    assert_serial_contains "statusbar.elf"
+    assert_serial_not_contains "Kernel panic" "SIGSEGV" "error:"
+}
+
 test_tcc_hello() {
     # Phase-3-of-TCC-port slice: cross-built tcc.elf compiles a known C
     # source on a running Makar guest and the freshly-emitted ELF is


### PR DESCRIPTION
Builds on the auth-login base (#184) with a large batch of display, shell, statusbar, and VT/window-manager work, plus a deterministic keyboard test harness that replaces the flaky HMP `sendkey` path.

## Display & boot
- **VBE capability detection** (`bochs_vbe`): probe adapter caps (GETCAPS max dims + VRAM), cached.
- **`vmode=` boot cmdline arg** (works via GRUB *and* Limine — both feed the multiboot2 CMDLINE tag): `720p`/`1080p`/`480p`/`WxH`. Defaults to **720p**.
- **1080p fix**: boot pre-maps the *max-supported* framebuffer span into the kernel PD before task PDs are snapshotted, so a later `setmode` can't reach an unmapped FB region (was a ring-0 page-fault panic at `0xFD400000`). `setmode` now rejects modes the adapter can't scan out.
- **Panic-loop guard** (`debug.c`): re-entrancy guard + a fault-proof VGA-text "please reboot" notice, so a fault while rendering the panic screen can't recurse forever.

## Auth / login / home
- **Auto-login**: `/etc/autologin` file **and** `autologin=<user>` cmdline; verified against `/etc/shadow`, falls back to the password prompt on an invalid entry. Installer offers a toggle.
- Prompt shows **`$` for non-root / `#` for root** (sh.elf + kernel shell).
- Login shells **`cd` into `$HOME`** (stat-guarded so a missing home doesn't spew `cd` errors); kernel creates the user's home on a writable rootfs.
- `~/.makrc` → **`~/.makshrc`**.

## vix
- Line numbers **off by default**; **Ctrl-N** toggles; `~/.vixrc` (`set linenumbers` / `number` / `nu`). Palette correctly reverts on exit (incl. the mak.sh0 root slot).

## Status bar (decoupled, Linux/tmux model)
- Kernel keeps **mechanism only** (reserve/free the bottom row + `SYS_STATUSBAR`); the renderer moved to a freestanding **`statusbar.elf`**. Alt+F5 toggles it.
- Configurable via **`~/.sbrc`** (`left`/`center`/`right` sections). Widgets: `hostname user date time datetime uptime cpu mem rootfs command tabs`.
- `cpu`/`mem` use **maktop's exact source + calc** (`/proc/tasks` non-idle ticks; `(MemTotal-MemFree)/MemTotal`); `/proc/meminfo` now counts the kernel image so usage isn't ~0 at idle. `rootfs` via new `SYS_STATFS` → `ext2_statfs` (ext2-only).

## VT / makmux window manager
- **Slot model grown** to 8 tabs (4 VT shells + 4 app-tabs) + hidden root console.
- **Alt-Tab / Alt-Shift-Tab** cycle VTs.
- **Named app-tabs**: launching `vix`/`maktop`/`clock`/… while makmux runs opens it in its own named tab (shown in the status bar, active highlighted); switch-if-exists; runs in the current VT if makmux isn't running.
- makmux's VT shells use the session user (`user@:$`), and the **screen is restored to mak.sh0 when the last tab closes**.

## Test harness
- **Deterministic in-guest keyboard injection** (`./run.sh kbtest`): feeds scancodes through the real decoder to drive the *live* shell — full decode path, no QEMU PS/2 timing, CI-able. Scenarios: command exec, Alt-Tab cycling, app-tab launch, exit-restore. Replaces flaky HMP `sendkey`.
- `tcc-rebuild-statusbar` self-host scenario.

## Verification
`ktest` 661/0 throughout; `./run.sh kbtest` all scenarios PASS; 0 faults; verified on a real install (autologin, ext2 rootfs, statusbar widgets) + live boot.
