### PR TITLE
Add PCI, buddy PMM, IPC, and virtio networking groundwork

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -329,6 +329,8 @@ _run_ktest() {
             -display none \
             -no-reboot \
             -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+            -netdev user,id=n0 \
+            -device virtio-net-pci,netdev=n0,disable-modern=on,disable-legacy=off,vectors=0 \
             $_accel \
             2>/dev/null </dev/null | tee "$REPO_ROOT/ktest.log" || true
     else
@@ -340,6 +342,8 @@ _run_ktest() {
                  -display none \
                  -no-reboot \
                  -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+                 -netdev user,id=n0 \
+                 -device virtio-net-pci,netdev=n0,disable-modern=on,disable-legacy=off,vectors=0 \
                  $QEMU_ACCEL \
                  2>/dev/null </dev/null | tee /work/ktest.log || true'
     fi
@@ -765,6 +769,8 @@ ktest)
         -serial "file:$REPO_ROOT/ktest.log" \
         ${QEMU_DISPLAY:+-display "$QEMU_DISPLAY"} \
         -no-reboot \
+        -netdev user,id=n0 \
+        -device virtio-net-pci,netdev=n0,disable-modern=on,disable-legacy=off,vectors=0 \
         -device isa-debug-exit,iobase=0xf4,iosize=0x04 || true
     _check_ktest
     ;;
@@ -786,6 +792,8 @@ ktest)
         -serial "file:$REPO_ROOT/ktest.log" \
         ${QEMU_DISPLAY:+-display "$QEMU_DISPLAY"} \
         -no-reboot \
+        -netdev user,id=n0 \
+        -device virtio-net-pci,netdev=n0,disable-modern=on,disable-legacy=off,vectors=0 \
         -device isa-debug-exit,iobase=0xf4,iosize=0x04 &
     QPID=$!
     ( sleep 60 && kill "$QPID" 2>/dev/null ) &

--- a/src/kernel/arch/i386/display/tty.c
+++ b/src/kernel/arch/i386/display/tty.c
@@ -61,6 +61,8 @@ void t_setcolor(uint8_t color)
 
 void t_putentryat(char c, uint8_t color, size_t x, size_t y)
 {
+	if (x >= VGA_WIDTH || y >= t_height)
+		return;
 	const size_t index = y * VGA_WIDTH + x;
 	t_buffer[index] = make_vgaentry(c, color);
 }
@@ -168,7 +170,7 @@ void t_dec(uint32_t num)
 int t_get_rows(void)
 {
 	if (vesa_tty_is_ready())
-		return (int)vesa_tty_get_rows();
+		return (int)vesa_tty_usable_rows();
 	return (int)t_height;
 }
 

--- a/src/kernel/arch/i386/display/vesa_tty.c
+++ b/src/kernel/arch/i386/display/vesa_tty.c
@@ -474,6 +474,34 @@ void vesa_tty_paint_string_at(uint32_t col, uint32_t row, const char *s,
  * vesa_tty.h. */
 static int s_status_visible = 1;
 
+static uint32_t status_usable_rows(void)
+{
+	if (s_status_visible && tty_rows > VESA_TTY_STATUS_ROWS)
+		return tty_rows - VESA_TTY_STATUS_ROWS;
+	return tty_rows;
+}
+
+static void sync_vt_usable_rows(void)
+{
+	uint32_t rows = status_usable_rows();
+	for (int i = 0; i < VTTY_MAX; i++) {
+		vt_buf_t *vt = vtty_buf(i);
+		if (vt)
+			vt_set_usable_rows(vt, rows);
+	}
+}
+
+static void clear_physical_status_rows(void)
+{
+	if (!tty_ready || tty_rows <= VESA_TTY_STATUS_ROWS)
+		return;
+	uint32_t first = tty_rows - VESA_TTY_STATUS_ROWS;
+	for (uint32_t r = first; r < tty_rows; r++) {
+		for (uint32_t c = 0; c < tty_cols; c++)
+			paint_cell(' ', default_pane.fg, default_pane.bg, c, r);
+	}
+}
+
 void vesa_tty_set_status_visible(int v)
 {
 	s_status_visible = v ? 1 : 0;
@@ -482,23 +510,19 @@ void vesa_tty_set_status_visible(int v)
 	 * pane-scroll fallback match the actual usable area.  With makmux
 	 * running (v=1) the bottom row is the status bar; without it (v=0)
 	 * mak.sh0 gets the full screen including that row. */
-	default_pane.rows = s_status_visible
-	    ? (tty_rows > VESA_TTY_STATUS_ROWS
-	           ? tty_rows - VESA_TTY_STATUS_ROWS : tty_rows)
-	    : tty_rows;
-	if (!v) {
-		uint32_t row = tty_rows - 1;
-		for (uint32_t c = 0; c < tty_cols; c++)
-			paint_cell(' ', compose_rgb(0x000000),
-			           compose_rgb(0x000000), c, row);
-	}
+	default_pane.rows = status_usable_rows();
+	sync_vt_usable_rows();
+	if (default_pane.cur_row >= default_pane.rows)
+		default_pane.cur_row = default_pane.rows - 1;
+	if (s_status_visible)
+		clear_physical_status_rows();
+	else
+		clear_physical_status_rows();
 }
 
 uint32_t vesa_tty_usable_rows(void)
 {
-    if (s_status_visible && tty_rows > VESA_TTY_STATUS_ROWS)
-        return tty_rows - VESA_TTY_STATUS_ROWS;
-    return tty_rows;
+    return status_usable_rows();
 }
 
 int vesa_tty_status_enabled(void)
@@ -540,7 +564,8 @@ void vesa_tty_paint_buf(const vt_buf_t *vt)
 	/* Hide the caret first - the strip stash holds pixels from the OLD VT;
 	 * those would smear back over the new VT's content on the next move. */
 	caret_drawn = false;
-	for (uint32_t r = 0; r < vt->rows && r < tty_rows; r++) {
+	uint32_t rows = vesa_tty_usable_rows();
+	for (uint32_t r = 0; r < vt->rows && r < rows; r++) {
 		for (uint32_t c = 0; c < vt->cols && c < tty_cols; c++) {
 			vt_cell_t cell = vt->cells[r * vt->cols + c];
 			paint_cell((char)cell.ch, cell.fg, cell.bg, c, r);
@@ -655,7 +680,7 @@ void vesa_tty_clear(void)
 	}
 
 	/* Focused-buffer (or no-task) clear: paint the framebuffer too. */
-	vesa_clear(default_pane.bg);
+	vesa_tty_pane_clear(&default_pane);
 	default_pane.cur_col = 0;
 	default_pane.cur_row = 0;
 	/* The full-framebuffer paint also wiped any caret strip we'd drawn

--- a/src/kernel/arch/i386/display/vt.c
+++ b/src/kernel/arch/i386/display/vt.c
@@ -3,7 +3,7 @@
  */
 
 #include <kernel/vt.h>
-#include <stdlib.h>
+#include <kernel/heap.h>
 #include <string.h>
 
 static void vt_fill_cell(vt_cell_t *c, uint8_t ch, uint32_t fg, uint32_t bg)
@@ -19,13 +19,14 @@ bool vt_init(vt_buf_t *vt, uint32_t cols, uint32_t rows,
 {
     vt->cols    = cols;
     vt->rows    = rows;
+    vt->usable_rows = rows;
     vt->cur_col = 0;
     vt->cur_row = 0;
     vt->fg      = default_fg;
     vt->bg      = default_bg;
 
     size_t n = (size_t)cols * (size_t)rows;
-    vt->cells = (vt_cell_t *)malloc(n * sizeof(vt_cell_t));
+    vt->cells = (vt_cell_t *)kmalloc(n * sizeof(vt_cell_t));
     if (!vt->cells) return false;
 
     for (size_t i = 0; i < n; i++)
@@ -39,11 +40,32 @@ void vt_set_color(vt_buf_t *vt, uint32_t fg, uint32_t bg)
     vt->bg = bg;
 }
 
+static uint32_t vt_limit_rows(const vt_buf_t *vt)
+{
+    if (!vt || vt->rows == 0) return 0;
+    if (vt->usable_rows == 0 || vt->usable_rows > vt->rows)
+        return vt->rows;
+    return vt->usable_rows;
+}
+
+void vt_set_usable_rows(vt_buf_t *vt, uint32_t rows)
+{
+    if (!vt || vt->rows == 0) return;
+    if (rows == 0 || rows > vt->rows)
+        rows = vt->rows;
+    vt->usable_rows = rows;
+    if (vt->cur_row >= rows)
+        vt->cur_row = rows - 1;
+    if (vt->cur_col >= vt->cols && vt->cols > 0)
+        vt->cur_col = vt->cols - 1;
+}
+
 void vt_set_cursor(vt_buf_t *vt, uint32_t col, uint32_t row)
 {
-    if (vt->cols == 0 || vt->rows == 0) return;
+    uint32_t rows = vt_limit_rows(vt);
+    if (vt->cols == 0 || rows == 0) return;
     if (col >= vt->cols) col = vt->cols - 1;
-    if (row >= vt->rows) row = vt->rows - 1;
+    if (row >= rows) row = rows - 1;
     vt->cur_col = col;
     vt->cur_row = row;
 }
@@ -53,20 +75,21 @@ void vt_clear(vt_buf_t *vt)
     vt->cur_col = 0;
     vt->cur_row = 0;
     if (!vt->cells) return;
-    size_t n = (size_t)vt->cols * (size_t)vt->rows;
+    size_t n = (size_t)vt->cols * (size_t)vt_limit_rows(vt);
     for (size_t i = 0; i < n; i++)
         vt_fill_cell(&vt->cells[i], ' ', vt->fg, vt->bg);
 }
 
 static void vt_scroll_up(vt_buf_t *vt)
 {
-    if (vt->rows <= 1) {
+    uint32_t rows = vt_limit_rows(vt);
+    if (rows <= 1) {
         vt_clear(vt);
         return;
     }
     size_t row_bytes = (size_t)vt->cols * sizeof(vt_cell_t);
-    memmove(vt->cells, vt->cells + vt->cols, (size_t)(vt->rows - 1) * row_bytes);
-    vt_cell_t *last = vt->cells + (size_t)(vt->rows - 1) * vt->cols;
+    memmove(vt->cells, vt->cells + vt->cols, (size_t)(rows - 1) * row_bytes);
+    vt_cell_t *last = vt->cells + (size_t)(rows - 1) * vt->cols;
     for (uint32_t c = 0; c < vt->cols; c++)
         vt_fill_cell(&last[c], ' ', vt->fg, vt->bg);
 }
@@ -82,29 +105,30 @@ void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row)
 vt_dirty_t vt_putchar(vt_buf_t *vt, char c)
 {
     vt_dirty_t d = { 0, 0, 0, 0 };
-    if (!vt->cells || vt->cols == 0 || vt->rows == 0) return d;
+    uint32_t rows = vt_limit_rows(vt);
+    if (!vt->cells || vt->cols == 0 || rows == 0) return d;
 
     /* Clamp transient out-of-range cursor (preemption between increment
      * and bounds check elsewhere). */
     if (vt->cur_col >= vt->cols) {
         vt->cur_col = 0;
-        if (++vt->cur_row >= vt->rows) {
+        if (++vt->cur_row >= rows) {
             vt_scroll_up(vt);
-            vt->cur_row = vt->rows - 1;
+            vt->cur_row = rows - 1;
             d.scrolled = 1;
         }
     }
-    if (vt->cur_row >= vt->rows) {
+    if (vt->cur_row >= rows) {
         vt_scroll_up(vt);
-        vt->cur_row = vt->rows - 1;
+        vt->cur_row = rows - 1;
         d.scrolled = 1;
     }
 
     if (c == '\n') {
         vt->cur_col = 0;
-        if (++vt->cur_row >= vt->rows) {
+        if (++vt->cur_row >= rows) {
             vt_scroll_up(vt);
-            vt->cur_row = vt->rows - 1;
+            vt->cur_row = rows - 1;
             d.scrolled = 1;
         }
         return d;
@@ -136,9 +160,9 @@ vt_dirty_t vt_putchar(vt_buf_t *vt, char c)
 
     if (++vt->cur_col >= vt->cols) {
         vt->cur_col = 0;
-        if (++vt->cur_row >= vt->rows) {
+        if (++vt->cur_row >= rows) {
             vt_scroll_up(vt);
-            vt->cur_row = vt->rows - 1;
+            vt->cur_row = rows - 1;
             d.scrolled = 1;
         }
     }

--- a/src/kernel/arch/i386/drivers/net/netdev.c
+++ b/src/kernel/arch/i386/drivers/net/netdev.c
@@ -1,0 +1,41 @@
+#include <kernel/netdev.h>
+
+static const netdev_ops_t *s_netdev;
+
+void netdev_register(const netdev_ops_t *ops)
+{
+    if (!ops || s_netdev)
+        return;
+    s_netdev = ops;
+}
+
+int netdev_present(void)
+{
+    return s_netdev && s_netdev->present && s_netdev->present();
+}
+
+const char *netdev_name(void)
+{
+    return s_netdev ? s_netdev->name : 0;
+}
+
+const uint8_t *netdev_mac(void)
+{
+    if (!netdev_present() || !s_netdev->mac)
+        return 0;
+    return s_netdev->mac();
+}
+
+int netdev_send(const void *frame, uint16_t len)
+{
+    if (!netdev_present() || !s_netdev->send)
+        return -1;
+    return s_netdev->send(frame, len);
+}
+
+int netdev_rx_poll(void *buf, uint16_t bufsz)
+{
+    if (!netdev_present() || !s_netdev->rx_poll)
+        return -1;
+    return s_netdev->rx_poll(buf, bufsz);
+}

--- a/src/kernel/arch/i386/drivers/net/virtio_net.c
+++ b/src/kernel/arch/i386/drivers/net/virtio_net.c
@@ -1,0 +1,426 @@
+#include <kernel/virtio_net.h>
+#include <kernel/pci.h>
+#include <kernel/pmm.h>
+#include <kernel/asm.h>
+#include <string.h>
+
+#define VIRTIO_PCI_VENDOR       0x1AF4u
+#define VIRTIO_PCI_NET_DEVICE   0x1000u
+
+#define VIRTIO_PCI_HOST_FEATURES  0x00u
+#define VIRTIO_PCI_GUEST_FEATURES 0x04u
+#define VIRTIO_PCI_QUEUE_PFN      0x08u
+#define VIRTIO_PCI_QUEUE_NUM      0x0Cu
+#define VIRTIO_PCI_QUEUE_SEL      0x0Eu
+#define VIRTIO_PCI_QUEUE_NOTIFY   0x10u
+#define VIRTIO_PCI_STATUS         0x12u
+#define VIRTIO_PCI_CONFIG         0x14u
+
+#define VIRTIO_STATUS_ACKNOWLEDGE 0x01u
+#define VIRTIO_STATUS_DRIVER      0x02u
+#define VIRTIO_STATUS_DRIVER_OK   0x04u
+#define VIRTIO_STATUS_FEATURES_OK 0x08u
+#define VIRTIO_STATUS_FAILED      0x80u
+
+#define VIRTIO_NET_F_MAC          (1u << 5)
+
+#define VIRTQ_DESC_F_NEXT         1u
+#define VIRTQ_DESC_F_WRITE        2u
+
+#define VIRTQ_AVAIL_F_NO_INTERRUPT 1u
+
+#define VIRTIO_NET_Q_RX           0u
+#define VIRTIO_NET_Q_TX           1u
+
+#define VIRTIO_NET_MAX_QSZ        256u
+#define VIRTIO_NET_RX_BUF_SIZE    2048u
+#define VIRTIO_NET_TX_BUF_SIZE    2048u
+#define VIRTIO_NET_DMA_MIN_PHYS  0x00100000u
+
+typedef struct __attribute__((packed)) {
+    uint32_t addr_lo;
+    uint32_t addr_hi;
+    uint32_t len;
+    uint16_t flags;
+    uint16_t next;
+} virtq_desc_t;
+
+typedef struct __attribute__((packed)) {
+    uint16_t flags;
+    uint16_t idx;
+    uint16_t ring[VIRTIO_NET_MAX_QSZ];
+} virtq_avail_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t id;
+    uint32_t len;
+} virtq_used_elem_t;
+
+typedef struct __attribute__((packed)) {
+    uint16_t flags;
+    uint16_t idx;
+    virtq_used_elem_t ring[VIRTIO_NET_MAX_QSZ];
+} virtq_used_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  flags;
+    uint8_t  gso_type;
+    uint16_t hdr_len;
+    uint16_t gso_size;
+    uint16_t csum_start;
+    uint16_t csum_offset;
+} virtio_net_hdr_t;
+
+typedef struct {
+    uint16_t qsel;
+    uint16_t size;
+    uint32_t phys;
+    uint32_t bytes;
+    virtq_desc_t  *desc;
+    virtq_avail_t *avail;
+    virtq_used_t  *used;
+    uint16_t last_used;
+} virtio_queue_t;
+
+typedef struct {
+    int up;
+    uint16_t io;
+    uint8_t mac[6];
+    virtio_queue_t rxq;
+    virtio_queue_t txq;
+    uint16_t rx_slots;
+    uint32_t rx_buf_phys;
+    uint8_t *rx_bufs;
+    uint32_t tx_buf_phys;
+    uint8_t *tx_buf;
+} virtio_net_dev_t;
+
+static virtio_net_dev_t s_vnet;
+
+static inline void vq_barrier(void)
+{
+    asm volatile("" ::: "memory");
+}
+
+static inline uint32_t align_up(uint32_t v, uint32_t a)
+{
+    return (v + a - 1u) & ~(a - 1u);
+}
+
+static uint8_t vp_inb(uint16_t off)   { return inb((uint16_t)(s_vnet.io + off)); }
+static uint16_t vp_inw(uint16_t off)  { return inw((uint16_t)(s_vnet.io + off)); }
+static uint32_t vp_inl(uint16_t off)  { return inl((uint16_t)(s_vnet.io + off)); }
+static void vp_outb(uint16_t off, uint8_t v)   { outb((uint16_t)(s_vnet.io + off), v); }
+static void vp_outw(uint16_t off, uint16_t v)  { outw((uint16_t)(s_vnet.io + off), v); }
+static void vp_outl(uint16_t off, uint32_t v)  { outl((uint16_t)(s_vnet.io + off), v); }
+
+static void add_status(uint8_t bits)
+{
+    vp_outb(VIRTIO_PCI_STATUS, (uint8_t)(vp_inb(VIRTIO_PCI_STATUS) | bits));
+}
+
+/* Mask the device's legacy INTx line at the 8259 PIC.  This driver polls the
+ * virtqueues, so it registers no IRQ handler; legacy virtio's level-triggered
+ * INTx would otherwise stay asserted (we never read the ISR to clear it) and
+ * storm the CPU into a livelock.  The boot PIC init unmasks every line, so we
+ * must explicitly mask ours to stay panic-proof. */
+static void mask_device_irq(uint8_t irq)
+{
+    if (irq == 0 || irq >= 16)
+        return;                       /* 0 = no/invalid line; 2 = cascade */
+    uint16_t port = (irq < 8) ? 0x21u : 0xA1u;
+    uint8_t  bit  = (irq < 8) ? irq : (uint8_t)(irq - 8);
+    outb(port, (uint8_t)(inb(port) | (1u << bit)));
+}
+
+static unsigned order_for_bytes(uint32_t bytes)
+{
+    uint32_t pages = (bytes + PMM_FRAME_SIZE - 1u) / PMM_FRAME_SIZE;
+    unsigned order = 0;
+    uint32_t have = 1;
+    while (have < pages && order + 1 < PMM_MAX_ORDER) {
+        have <<= 1;
+        order++;
+    }
+    return have >= pages ? order : PMM_MAX_ORDER;
+}
+
+static uint32_t dma_alloc_pages(unsigned order)
+{
+    uint32_t skipped[16];
+    uint32_t skipped_count = 0;
+    uint32_t phys = PMM_ALLOC_ERROR;
+
+    for (uint32_t tries = 0; tries < 64; tries++) {
+        phys = pmm_alloc_pages(order);
+        if (phys == PMM_ALLOC_ERROR)
+            break;
+        if (phys >= VIRTIO_NET_DMA_MIN_PHYS)
+            break;
+        if (skipped_count < (uint32_t)(sizeof(skipped) / sizeof(skipped[0]))) {
+            skipped[skipped_count++] = phys;
+        } else {
+            pmm_free_pages(phys, order);
+            phys = PMM_ALLOC_ERROR;
+            break;
+        }
+        phys = PMM_ALLOC_ERROR;
+    }
+
+    for (uint32_t i = 0; i < skipped_count; i++)
+        pmm_free_pages(skipped[i], order);
+
+    return phys;
+}
+
+static int queue_alloc(virtio_queue_t *q, uint16_t qsel)
+{
+    vp_outw(VIRTIO_PCI_QUEUE_SEL, qsel);
+    uint16_t size = vp_inw(VIRTIO_PCI_QUEUE_NUM);
+    if (size == 0 || size > VIRTIO_NET_MAX_QSZ)
+        return -1;
+
+    uint32_t desc_bytes = sizeof(virtq_desc_t) * size;
+    uint32_t avail_bytes = 4u + 2u * size;
+    uint32_t used_bytes = 4u + sizeof(virtq_used_elem_t) * size;
+    uint32_t used_off = align_up(desc_bytes + avail_bytes, PMM_FRAME_SIZE);
+    uint32_t total = used_off + used_bytes;
+    unsigned order = order_for_bytes(total);
+    if (order >= PMM_MAX_ORDER)
+        return -1;
+
+    uint32_t phys = dma_alloc_pages(order);
+    if (phys == PMM_ALLOC_ERROR)
+        return -1;
+
+    memset((void *)(uintptr_t)phys, 0, (1u << order) * PMM_FRAME_SIZE);
+
+    q->qsel = qsel;
+    q->size = size;
+    q->phys = phys;
+    q->bytes = (1u << order) * PMM_FRAME_SIZE;
+    q->desc = (virtq_desc_t *)(uintptr_t)phys;
+    q->avail = (virtq_avail_t *)(uintptr_t)(phys + desc_bytes);
+    q->used = (virtq_used_t *)(uintptr_t)(phys + used_off);
+    q->last_used = 0;
+
+    /* Polled: ask the device not to raise used-ring interrupts. */
+    q->avail->flags = VIRTQ_AVAIL_F_NO_INTERRUPT;
+
+    vp_outw(VIRTIO_PCI_QUEUE_SEL, qsel);
+    vp_outl(VIRTIO_PCI_QUEUE_PFN, phys >> 12);
+
+    return 0;
+}
+
+static int alloc_buffers(void)
+{
+    s_vnet.rx_slots = (uint16_t)(s_vnet.rxq.size / 2);
+    if (s_vnet.rx_slots == 0 || s_vnet.txq.size < 2)
+        return -1;
+
+    uint32_t rx_bytes = s_vnet.rx_slots * VIRTIO_NET_RX_BUF_SIZE;
+    unsigned rx_order = order_for_bytes(rx_bytes);
+    if (rx_order >= PMM_MAX_ORDER)
+        return -1;
+    s_vnet.rx_buf_phys = dma_alloc_pages(rx_order);
+    if (s_vnet.rx_buf_phys == PMM_ALLOC_ERROR)
+        return -1;
+    s_vnet.rx_bufs = (uint8_t *)(uintptr_t)s_vnet.rx_buf_phys;
+    memset(s_vnet.rx_bufs, 0, (1u << rx_order) * PMM_FRAME_SIZE);
+
+    unsigned tx_order = order_for_bytes(VIRTIO_NET_TX_BUF_SIZE);
+    if (tx_order >= PMM_MAX_ORDER)
+        return -1;
+    s_vnet.tx_buf_phys = dma_alloc_pages(tx_order);
+    if (s_vnet.tx_buf_phys == PMM_ALLOC_ERROR)
+        return -1;
+    s_vnet.tx_buf = (uint8_t *)(uintptr_t)s_vnet.tx_buf_phys;
+    memset(s_vnet.tx_buf, 0, (1u << tx_order) * PMM_FRAME_SIZE);
+    return 0;
+}
+
+static void rx_refill_all(void)
+{
+    virtio_queue_t *q = &s_vnet.rxq;
+    for (uint16_t i = 0; i < s_vnet.rx_slots; i++) {
+        uint32_t phys = s_vnet.rx_buf_phys + (uint32_t)i * VIRTIO_NET_RX_BUF_SIZE;
+        uint16_t head = (uint16_t)(i * 2);
+        uint16_t body = (uint16_t)(head + 1);
+
+        q->desc[head].addr_lo = phys;
+        q->desc[head].addr_hi = 0;
+        q->desc[head].len = sizeof(virtio_net_hdr_t);
+        q->desc[head].flags = VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT;
+        q->desc[head].next = body;
+
+        q->desc[body].addr_lo = phys + sizeof(virtio_net_hdr_t);
+        q->desc[body].addr_hi = 0;
+        q->desc[body].len = VIRTIO_NET_RX_BUF_SIZE - sizeof(virtio_net_hdr_t);
+        q->desc[body].flags = VIRTQ_DESC_F_WRITE;
+        q->desc[body].next = 0;
+
+        q->avail->ring[i] = head;
+    }
+    q->avail->idx = s_vnet.rx_slots;
+    vq_barrier();
+    vp_outw(VIRTIO_PCI_QUEUE_NOTIFY, q->qsel);
+}
+
+static int virtio_net_probe(pci_device_t *dev)
+{
+    uint32_t io = pci_bar_io(dev, 0);
+    if (io == 0)
+        return -1;
+
+    memset(&s_vnet, 0, sizeof(s_vnet));
+    s_vnet.io = (uint16_t)io;
+
+    pci_enable_bus_master(dev);
+    /* Polled driver: mask our INTx line so the device can't livelock the CPU. */
+    mask_device_irq(dev->irq_line);
+
+    vp_outb(VIRTIO_PCI_STATUS, 0);
+    add_status(VIRTIO_STATUS_ACKNOWLEDGE);
+    add_status(VIRTIO_STATUS_DRIVER);
+
+    uint32_t host_features = vp_inl(VIRTIO_PCI_HOST_FEATURES);
+    uint32_t guest_features = host_features & VIRTIO_NET_F_MAC;
+    vp_outl(VIRTIO_PCI_GUEST_FEATURES, guest_features);
+    add_status(VIRTIO_STATUS_FEATURES_OK);
+    if ((vp_inb(VIRTIO_PCI_STATUS) & VIRTIO_STATUS_FEATURES_OK) == 0) {
+        add_status(VIRTIO_STATUS_FAILED);
+        return -1;
+    }
+
+    if ((guest_features & VIRTIO_NET_F_MAC) == 0) {
+        add_status(VIRTIO_STATUS_FAILED);
+        return -1;
+    }
+    for (uint16_t i = 0; i < 6; i++)
+        s_vnet.mac[i] = vp_inb((uint16_t)(VIRTIO_PCI_CONFIG + i));
+
+    if (queue_alloc(&s_vnet.rxq, VIRTIO_NET_Q_RX) != 0 ||
+        queue_alloc(&s_vnet.txq, VIRTIO_NET_Q_TX) != 0 ||
+        alloc_buffers() != 0) {
+        add_status(VIRTIO_STATUS_FAILED);
+        return -1;
+    }
+
+    add_status(VIRTIO_STATUS_DRIVER_OK);
+    s_vnet.up = 1;
+    /* Post RX buffers only after DRIVER_OK so the notify is valid per spec. */
+    rx_refill_all();
+
+    return 0;
+}
+
+static const pci_driver_t virtio_net_driver = {
+    .name = "virtio-net",
+    .vendor = VIRTIO_PCI_VENDOR,
+    .device = VIRTIO_PCI_NET_DEVICE,
+    .class_code = 0,
+    .subclass = 0,
+    .match_class = 0,
+    .probe = virtio_net_probe,
+};
+
+void virtio_net_register(void)
+{
+    pci_register_driver(&virtio_net_driver);
+}
+
+int virtio_net_present(void)
+{
+    return s_vnet.up;
+}
+
+const uint8_t *virtio_net_mac(void)
+{
+    return s_vnet.up ? s_vnet.mac : 0;
+}
+
+int virtio_net_send(const void *frame, uint16_t len)
+{
+    if (!s_vnet.up || !frame || len == 0)
+        return -1;
+    if ((uint32_t)len + sizeof(virtio_net_hdr_t) > VIRTIO_NET_TX_BUF_SIZE)
+        return -1;
+
+    virtio_queue_t *q = &s_vnet.txq;
+
+    /* virtio_net_hdr (zeroed: no checksum offload, no GSO) + frame, as a
+     * legacy-safe two-descriptor chain: header desc -> frame desc. */
+    memset(s_vnet.tx_buf, 0, sizeof(virtio_net_hdr_t));
+    memcpy(s_vnet.tx_buf + sizeof(virtio_net_hdr_t), frame, len);
+
+    q->desc[0].addr_lo = s_vnet.tx_buf_phys;
+    q->desc[0].addr_hi = 0;
+    q->desc[0].len     = sizeof(virtio_net_hdr_t);
+    q->desc[0].flags   = VIRTQ_DESC_F_NEXT;
+    q->desc[0].next    = 1;
+
+    q->desc[1].addr_lo = s_vnet.tx_buf_phys + sizeof(virtio_net_hdr_t);
+    q->desc[1].addr_hi = 0;
+    q->desc[1].len     = len;
+    q->desc[1].flags   = 0;
+    q->desc[1].next    = 0;
+
+    uint16_t avail = q->avail->idx;
+    q->avail->ring[avail % q->size] = 0;
+    vq_barrier();                       /* publish the ring slot before idx */
+    q->avail->idx = (uint16_t)(avail + 1);
+    vq_barrier();
+    vp_outw(VIRTIO_PCI_QUEUE_NOTIFY, q->qsel);
+
+    /* Fire-and-forget.  Under QEMU/TCG the device drains the TX queue on its
+     * own thread once the guest yields the CPU; busy-waiting on the used ring
+     * here would starve that backend and never complete.  One outstanding TX
+     * buffer suffices for today's single-frame callers; a TX descriptor ring
+     * with lazy reclaim lands alongside lwIP. */
+    return 0;
+}
+
+int virtio_net_rx_poll(void *buf, uint16_t bufsz)
+{
+    if (!s_vnet.up || !buf)
+        return -1;
+
+    virtio_queue_t *q = &s_vnet.rxq;
+    volatile virtq_used_t *used = (volatile virtq_used_t *)q->used;
+    if (q->last_used == used->idx)
+        return 0;
+
+    volatile virtq_used_elem_t *e = &used->ring[q->last_used % q->size];
+    uint16_t id = (uint16_t)e->id;
+    uint32_t len = e->len;
+    q->last_used++;
+
+    if (id >= q->size || (id & 1u) || len <= sizeof(virtio_net_hdr_t)) {
+        if (id < q->size && !(id & 1u)) {
+            uint16_t avail = q->avail->idx;
+            q->avail->ring[avail % q->size] = id;
+            q->avail->idx = (uint16_t)(avail + 1);
+            vq_barrier();
+            vp_outw(VIRTIO_PCI_QUEUE_NOTIFY, q->qsel);
+        }
+        return -1;
+    }
+
+    uint16_t slot = (uint16_t)(id / 2);
+    if (slot >= s_vnet.rx_slots)
+        return -1;
+
+    uint8_t *pkt = s_vnet.rx_bufs + (uint32_t)slot * VIRTIO_NET_RX_BUF_SIZE;
+    uint32_t frame_len = len - sizeof(virtio_net_hdr_t);
+    uint32_t copy_len = frame_len < bufsz ? frame_len : bufsz;
+    memcpy(buf, pkt + sizeof(virtio_net_hdr_t), copy_len);
+
+    uint16_t avail = q->avail->idx;
+    q->avail->ring[avail % q->size] = id;
+    q->avail->idx = (uint16_t)(avail + 1);
+    vq_barrier();
+    vp_outw(VIRTIO_PCI_QUEUE_NOTIFY, q->qsel);
+
+    return (int)frame_len;
+}

--- a/src/kernel/arch/i386/drivers/net/virtio_net.c
+++ b/src/kernel/arch/i386/drivers/net/virtio_net.c
@@ -1,4 +1,5 @@
 #include <kernel/virtio_net.h>
+#include <kernel/netdev.h>
 #include <kernel/pci.h>
 #include <kernel/pmm.h>
 #include <kernel/asm.h>
@@ -96,6 +97,14 @@ typedef struct {
 } virtio_net_dev_t;
 
 static virtio_net_dev_t s_vnet;
+
+static const netdev_ops_t virtio_net_ops = {
+    .name = "virtio-net",
+    .present = virtio_net_present,
+    .mac = virtio_net_mac,
+    .send = virtio_net_send,
+    .rx_poll = virtio_net_rx_poll,
+};
 
 static inline void vq_barrier(void)
 {
@@ -309,6 +318,7 @@ static int virtio_net_probe(pci_device_t *dev)
 
     add_status(VIRTIO_STATUS_DRIVER_OK);
     s_vnet.up = 1;
+    netdev_register(&virtio_net_ops);
     /* Post RX buffers only after DRIVER_OK so the notify is valid per spec. */
     rx_refill_all();
 

--- a/src/kernel/arch/i386/drivers/pci.c
+++ b/src/kernel/arch/i386/drivers/pci.c
@@ -184,6 +184,72 @@ const char *pci_class_name(uint8_t cls, uint8_t sub)
 }
 
 /* --------------------------------------------------------------------------
+ * Driver binding
+ * -------------------------------------------------------------------------- */
+
+#define PCI_MAX_DRIVERS 16
+static const pci_driver_t *pci_drivers[PCI_MAX_DRIVERS];
+static int                 pci_driver_count = 0;
+
+void pci_register_driver(const pci_driver_t *drv)
+{
+    if (!drv || pci_driver_count >= PCI_MAX_DRIVERS) return;
+    pci_drivers[pci_driver_count++] = drv;
+}
+
+static int driver_matches(const pci_driver_t *drv, const pci_device_t *d)
+{
+    if (drv->match_class)
+        return drv->class_code == d->class_code && drv->subclass == d->subclass;
+    if (drv->vendor != d->vendor_id) return 0;
+    return drv->device == PCI_MATCH_ANY || drv->device == d->device_id;
+}
+
+int pci_probe_all(void)
+{
+    int bound = 0;
+    for (int i = 0; i < pci_device_count; i++) {
+        pci_device_t *d = &pci_devices[i];
+        if (d->driver) continue;                 /* already claimed */
+        for (int j = 0; j < pci_driver_count; j++) {
+            const pci_driver_t *drv = pci_drivers[j];
+            if (!driver_matches(drv, d)) continue;
+            if (drv->probe && drv->probe(d) != 0) continue;
+            d->driver = drv->name;
+            bound++;
+            Serial_WriteString("pci: bound ");
+            Serial_WriteString(drv->name);
+            Serial_WriteString(" -> ");
+            Serial_WriteHex(d->vendor_id);
+            Serial_WriteString(":");
+            Serial_WriteHex(d->device_id);
+            Serial_WriteString("\n");
+            break;                               /* one driver per device */
+        }
+    }
+    return bound;
+}
+
+void pci_enable_bus_master(pci_device_t *d)
+{
+    uint32_t cmd = pci_read32(d->bus, d->dev, d->func, 0x04);
+    cmd |= (1u << 0) | (1u << 1) | (1u << 2);    /* I/O space, MMIO, bus master */
+    pci_write32(d->bus, d->dev, d->func, 0x04, cmd);
+}
+
+uint32_t pci_bar_io(const pci_device_t *d, int idx)
+{
+    if (idx < 0 || idx > 5) return 0;
+    return d->bar[idx] & ~0x3u;
+}
+
+uint32_t pci_bar_mem(const pci_device_t *d, int idx)
+{
+    if (idx < 0 || idx > 5) return 0;
+    return d->bar[idx] & ~0xFu;
+}
+
+/* --------------------------------------------------------------------------
  * Enumeration
  * -------------------------------------------------------------------------- */
 
@@ -194,6 +260,7 @@ static void scan_function(uint8_t bus, uint8_t dev, uint8_t func)
     if (pci_device_count >= PCI_MAX_DEVICES) return;
 
     pci_device_t *d = &pci_devices[pci_device_count++];
+    d->driver = NULL;
     d->bus  = bus;
     d->dev  = dev;
     d->func = func;

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -244,6 +244,8 @@ static const char *state_name(int s)
     case 0: return "READY";
     case 1: return "RUN";
     case 2: return "DEAD";
+    case 3: return "ZOMB";
+    case 4: return "BLOK";
     default: return "?";
     }
 }

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -20,6 +20,7 @@ $(ARCHDIR)/drivers/partition.o \
 $(ARCHDIR)/drivers/acpi.o \
 $(ARCHDIR)/drivers/rtc.o \
 $(ARCHDIR)/drivers/pci.o \
+$(ARCHDIR)/drivers/net/virtio_net.o \
 $(ARCHDIR)/fs/fat32.o \
 $(ARCHDIR)/fs/ext2.o \
 $(ARCHDIR)/fs/iso9660.o \

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -40,6 +40,7 @@ $(ARCHDIR)/display/bochs_vbe.o \
 $(ARCHDIR)/proc/system.o \
 $(ARCHDIR)/proc/task_asm.o \
 $(ARCHDIR)/proc/task.o \
+$(ARCHDIR)/proc/ipc.o \
 $(ARCHDIR)/proc/syscall.o \
 $(ARCHDIR)/proc/signal.o \
 $(ARCHDIR)/proc/fd.o \

--- a/src/kernel/arch/i386/make.config
+++ b/src/kernel/arch/i386/make.config
@@ -20,6 +20,7 @@ $(ARCHDIR)/drivers/partition.o \
 $(ARCHDIR)/drivers/acpi.o \
 $(ARCHDIR)/drivers/rtc.o \
 $(ARCHDIR)/drivers/pci.o \
+$(ARCHDIR)/drivers/net/netdev.o \
 $(ARCHDIR)/drivers/net/virtio_net.o \
 $(ARCHDIR)/fs/fat32.o \
 $(ARCHDIR)/fs/ext2.o \

--- a/src/kernel/arch/i386/mm/pmm.c
+++ b/src/kernel/arch/i386/mm/pmm.c
@@ -3,47 +3,130 @@
 #include <kernel/serial.h>
 #include <string.h>
 
-/* 4 GB / 4 KB = 1 048 576 frames, stored as 32 768 32-bit words. */
-#define PMM_MAX_FRAMES   (0x100000U)
-#define PMM_BITMAP_WORDS (PMM_MAX_FRAMES / 32)
-
-/* bit = 1 → frame used   bit = 0 → frame free */
-static uint32_t bitmap[PMM_BITMAP_WORDS];
-
-/* Per-frame reference count (slice 12a, fork+COW prep).
+/* ---------------------------------------------------------------------------
+ * Physical memory manager -- Linux-style buddy allocator over a per-frame
+ * page descriptor table (a lean `struct page`).
  *
- * Indexed by frame number = phys_addr / PMM_FRAME_SIZE.  refcount[f] == 0
- * iff the frame is free (matches bit cleared in `bitmap`).  pmm_alloc_frame
- * sets refcount to 1; pmm_inc_ref bumps it (used by COW clone); pmm_free_frame
- * decrements and only physically releases the frame when refcount reaches 0.
+ * The pool is a set of per-order free lists (orders 0..PMM_MAX_ORDER-1).
+ * alloc_pages(order) returns 2^order physically-contiguous, naturally-aligned
+ * frames by splitting a larger free block; free_pages coalesces a block with
+ * its buddy whenever the buddy is also free at the same order, which keeps
+ * large contiguous regions available (anti-fragmentation).
  *
- * Storage: 1 MiB of BSS (uint8_t × 1 048 576).  Saturates at 255 -- a frame
- * shared by more than 255 tasks is a pathological case we don't support; the
- * inc path warns to serial rather than wrapping.  Pre-fork the kernel never
- * shares user frames, so refcounts are always 0 (free) or 1 (allocated). */
-static uint8_t refcount[PMM_MAX_FRAMES];
+ * The legacy single-frame API (pmm_alloc_frame / pmm_free_frame / pmm_inc_ref
+ * / pmm_ref_count) is preserved exactly: a single frame is just an order-0
+ * block, and per-frame reference counts (used by fork/COW) live in the page
+ * descriptor's `refcount` field.
+ *
+ * Managed window: PMM_MAX_FRAMES caps the pool at 256 MiB, matching the
+ * kernel's identity-mapped low region (paging_init maps 256 MiB with 4 MiB
+ * pages).  Frames above that ceiling cannot be touched by the kernel without
+ * a temporary mapping, so we don't manage them yet; lifting this is the job
+ * of a future highmem/zone split.  Sizing the descriptor table to this window
+ * (rather than the full 4 GiB the old bitmap covered) also shrinks the static
+ * footprint to ~0.75 MiB.
+ * ------------------------------------------------------------------------- */
 
-/* Total managed (= bootloader-available, minus null page + kernel image)
- * frames.  Constant after pmm_init.  Used by /proc/meminfo to expose
- * MemTotal so userspace tools (maktop) can show a memory bar. */
-static uint32_t s_total_managed_frames;
+#define PMM_MAX_FRAMES   (0x10000U)        /* 65 536 frames = 256 MiB window  */
+#define PMM_NIL          0xFFFFFFFFU       /* free-list / index sentinel       */
 
-static inline void pmm_set_frame(uint32_t frame)
+#define PG_BUDDY  0x01                     /* frame is the free head of a block */
+
+/* Per-frame descriptor.  Indexed by frame number = phys_addr / FRAME_SIZE.
+ *
+ *   next/prev : doubly-linked free-list links (frame indices), valid only
+ *               while the frame is a free block head (PG_BUDDY set).
+ *   order     : buddy order of the block this frame heads.  Set at alloc and
+ *               while free; read back at free so callers cannot mismatch.
+ *   refcount  : 0 = free.  Set to 1 on alloc; bumped by pmm_inc_ref for COW
+ *               sharing; the block returns to the pool when it hits 0.
+ *   flags     : PG_BUDDY etc.
+ *
+ * 12 bytes/frame * 65 536 frames = 768 KiB of BSS. */
+typedef struct {
+	uint32_t next;
+	uint32_t prev;
+	uint8_t  order;
+	uint8_t  refcount;
+	uint8_t  flags;
+	uint8_t  _pad;
+} page_t;
+
+static page_t   mem_map[PMM_MAX_FRAMES];
+static uint32_t free_lists[PMM_MAX_ORDER];  /* head frame index per order */
+static uint32_t s_max_frames;               /* highest managed frame + 1   */
+static uint32_t s_free_frames;              /* O(1) free-frame accounting   */
+static uint32_t s_total_managed_frames;     /* constant after pmm_init      */
+
+/* --------------------------------------------------------------------------
+ * Free-list primitives (doubly-linked via frame indices)
+ * -------------------------------------------------------------------------- */
+
+static void list_add(uint32_t order, uint32_t f)
 {
-	bitmap[frame / 32] |= (1U << (frame % 32));
+	uint32_t head = free_lists[order];
+	mem_map[f].next = head;
+	mem_map[f].prev = PMM_NIL;
+	if (head != PMM_NIL)
+		mem_map[head].prev = f;
+	free_lists[order] = f;
+	mem_map[f].order  = (uint8_t)order;
+	mem_map[f].flags |= PG_BUDDY;
 }
 
-static inline void pmm_clear_frame(uint32_t frame)
+static void list_del(uint32_t order, uint32_t f)
 {
-	bitmap[frame / 32] &= ~(1U << (frame % 32));
+	uint32_t p = mem_map[f].prev;
+	uint32_t n = mem_map[f].next;
+	if (p != PMM_NIL) mem_map[p].next = n; else free_lists[order] = n;
+	if (n != PMM_NIL) mem_map[n].prev = p;
+	mem_map[f].flags &= (uint8_t)~PG_BUDDY;
 }
+
+/* A frame is a coalescible buddy at `order` iff it is in range and currently
+ * a free head of exactly that order. */
+static int buddy_is_free(uint32_t b, uint32_t order)
+{
+	return b < s_max_frames
+	    && (mem_map[b].flags & PG_BUDDY)
+	    && mem_map[b].order == (uint8_t)order;
+}
+
+/* Return a block of 2^order frames (head frame index `f`) to the pool,
+ * coalescing upward with free buddies. */
+static void buddy_free(uint32_t f, uint32_t order)
+{
+	s_free_frames += (1U << order);
+
+	while (order < PMM_MAX_ORDER - 1) {
+		uint32_t buddy = f ^ (1U << order);
+		if (!buddy_is_free(buddy, order))
+			break;
+		list_del(order, buddy);
+		if (buddy < f)
+			f = buddy;          /* merged block starts at the lower frame */
+		order++;
+	}
+
+	mem_map[f].refcount = 0;
+	list_add(order, f);
+}
+
+/* --------------------------------------------------------------------------
+ * Initialisation
+ * -------------------------------------------------------------------------- */
 
 void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 {
 	extern uint32_t _kernel_end;
 
-	/* Start with every frame marked as used. */
-	memset(bitmap, 0xFF, sizeof(bitmap));
+	/* Everything starts reserved: a zeroed descriptor table means refcount 0,
+	 * no PG_BUDDY, off every free list -- i.e. not allocatable until freed. */
+	memset(mem_map, 0, sizeof(mem_map));
+	for (uint32_t o = 0; o < PMM_MAX_ORDER; o++)
+		free_lists[o] = PMM_NIL;
+	s_max_frames  = 0;
+	s_free_frames = 0;
 
 	if (magic != MULTIBOOT2_BOOTLOADER_MAGIC) {
 		t_writestring("PMM: invalid multiboot2 magic, no memory freed\n");
@@ -51,25 +134,19 @@ void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 		return;
 	}
 
-	/* Walk the Multiboot 2 tag list.  Tags start immediately after the
-	   8-byte info header and are each padded to an 8-byte boundary. */
+	/* Locate the memory-map tag. */
 	multiboot2_tag_mmap_t *mmap_tag = NULL;
-
-	uint8_t *tag_ptr = (uint8_t *)mbi + sizeof(multiboot2_info_t);
+	uint8_t *tag_ptr  = (uint8_t *)mbi + sizeof(multiboot2_info_t);
 	uint8_t *info_end = (uint8_t *)mbi + mbi->total_size;
 
 	while (tag_ptr < info_end) {
 		multiboot2_tag_t *tag = (multiboot2_tag_t *)tag_ptr;
-
 		if (tag->type == MULTIBOOT2_TAG_TYPE_END)
 			break;
-
 		if (tag->type == MULTIBOOT2_TAG_TYPE_MMAP) {
 			mmap_tag = (multiboot2_tag_mmap_t *)tag;
 			break;
 		}
-
-		/* Advance to next tag, aligned to 8 bytes. */
 		tag_ptr += (tag->size + 7) & ~7u;
 	}
 
@@ -79,7 +156,14 @@ void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 		return;
 	}
 
-	/* Walk memory map entries. */
+	/* Reserved frames the bootloader-available map must not hand out: the
+	 * null page (guards NULL derefs) and the whole kernel image, which on
+	 * this build includes mem_map[] itself (static BSS below _kernel_end). */
+	uint32_t kstart = 0x100000 / PMM_FRAME_SIZE;
+	uint32_t kend   = ((uint32_t)&_kernel_end + PMM_FRAME_SIZE - 1) / PMM_FRAME_SIZE;
+
+	/* Free every usable frame within the managed window into the buddy pool.
+	 * Ascending order lets even/odd pairs coalesce as we go. */
 	uint8_t *entry_ptr = (uint8_t *)mmap_tag + sizeof(multiboot2_tag_mmap_t);
 	uint8_t *mmap_end  = (uint8_t *)mmap_tag + mmap_tag->size;
 
@@ -87,107 +171,143 @@ void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 		multiboot2_mmap_entry_t *entry = (multiboot2_mmap_entry_t *)entry_ptr;
 
 		if (entry->type == MULTIBOOT2_MEMORY_AVAILABLE) {
-			/* Round start up and end down to 4 KiB boundaries. */
 			uint64_t region_start =
 				(entry->base_addr + PMM_FRAME_SIZE - 1) & ~(uint64_t)(PMM_FRAME_SIZE - 1);
 			uint64_t region_end =
 				(entry->base_addr + entry->length) & ~(uint64_t)(PMM_FRAME_SIZE - 1);
 
 			for (uint64_t addr = region_start; addr < region_end; addr += PMM_FRAME_SIZE) {
-				if (addr < (uint64_t)PMM_MAX_FRAMES * PMM_FRAME_SIZE)
-					pmm_clear_frame((uint32_t)(addr / PMM_FRAME_SIZE));
+				uint32_t f = (uint32_t)(addr / PMM_FRAME_SIZE);
+				if (f >= PMM_MAX_FRAMES)
+					break;                 /* past the 256 MiB window */
+				if (f == 0 || (f >= kstart && f < kend))
+					continue;              /* null page / kernel image */
+				if (f + 1 > s_max_frames)
+					s_max_frames = f + 1;
+				buddy_free(f, 0);
 			}
 		}
 
 		entry_ptr += mmap_tag->entry_size;
 	}
 
-	/* Re-mark the null page as used (guard against NULL dereferences). */
-	pmm_set_frame(0);
+	s_total_managed_frames = s_free_frames;
 
-	/* Re-mark all frames occupied by the kernel image as used.
-	   The kernel is loaded at 1 MiB; _kernel_end is the first address
-	   beyond the last kernel section, as defined in linker.ld. */
-	uint32_t kstart = 0x100000 / PMM_FRAME_SIZE;
-	uint32_t kend   = ((uint32_t)&_kernel_end + PMM_FRAME_SIZE - 1) / PMM_FRAME_SIZE;
-	for (uint32_t f = kstart; f < kend; f++)
-		pmm_set_frame(f);
-
-	/* Capture the pool size before any runtime allocations; this is
-	 * what /proc/meminfo's MemTotal reports.  pmm_free_count() walks
-	 * the bitmap so we cache the result rather than re-counting. */
-	uint32_t free_frames = pmm_free_count();
-	s_total_managed_frames = free_frames;
 	t_writestring("PMM: ");
-	t_dec(free_frames);
+	t_dec(s_free_frames);
 	t_writestring(" frames free (");
-	t_dec((free_frames * PMM_FRAME_SIZE) / (1024 * 1024));
-	t_writestring(" MiB)\n");
+	t_dec((s_free_frames * PMM_FRAME_SIZE) / (1024 * 1024));
+	t_writestring(" MiB), buddy max order ");
+	t_dec(pmm_largest_free_order());
+	t_putchar('\n');
 
 	KLOG("pmm_init: ");
-	KLOG_DEC(free_frames);
+	KLOG_DEC(s_free_frames);
 	KLOG(" frames free (");
-	KLOG_DEC((free_frames * PMM_FRAME_SIZE) / (1024 * 1024));
+	KLOG_DEC((s_free_frames * PMM_FRAME_SIZE) / (1024 * 1024));
 	KLOG(" MiB)\n");
+}
+
+/* --------------------------------------------------------------------------
+ * Allocation
+ * -------------------------------------------------------------------------- */
+
+uint32_t pmm_alloc_pages(unsigned order)
+{
+	if (order >= PMM_MAX_ORDER)
+		return PMM_ALLOC_ERROR;
+
+	/* Find the smallest available order >= the request. */
+	unsigned o = order;
+	while (o < PMM_MAX_ORDER && free_lists[o] == PMM_NIL)
+		o++;
+	if (o >= PMM_MAX_ORDER)
+		return PMM_ALLOC_ERROR;           /* out of memory at this size */
+
+	uint32_t f = free_lists[o];
+	list_del(o, f);
+
+	/* Split down to the requested order, parking each upper buddy half on the
+	 * next lower free list. */
+	while (o > order) {
+		o--;
+		uint32_t buddy = f + (1U << o);
+		list_add(o, buddy);
+	}
+
+	mem_map[f].order    = (uint8_t)order;
+	mem_map[f].refcount = 1;
+	mem_map[f].flags   &= (uint8_t)~PG_BUDDY;
+	s_free_frames      -= (1U << order);
+
+	return f * PMM_FRAME_SIZE;
 }
 
 uint32_t pmm_alloc_frame(void)
 {
-	for (uint32_t i = 0; i < PMM_BITMAP_WORDS; i++) {
-		if (bitmap[i] == 0xFFFFFFFF)
-			continue;  /* all 32 frames in this word are used */
-		for (uint32_t bit = 0; bit < 32; bit++) {
-			if (!((bitmap[i] >> bit) & 1)) {
-				uint32_t frame = i * 32 + bit;
-				pmm_set_frame(frame);
-				refcount[frame] = 1;
-				return frame * PMM_FRAME_SIZE;
-			}
-		}
+	return pmm_alloc_pages(0);
+}
+
+/* --------------------------------------------------------------------------
+ * Freeing / reference counting
+ * -------------------------------------------------------------------------- */
+
+void pmm_free_pages(uint32_t addr, unsigned order)
+{
+	uint32_t f = addr / PMM_FRAME_SIZE;
+	if (f >= s_max_frames)
+		return;
+
+	if (mem_map[f].refcount == 0) {
+		KLOG("pmm_free_pages: refcount underflow at frame ");
+		KLOG_HEX(f);
+		KLOG("\n");
+		return;
 	}
-	return PMM_ALLOC_ERROR;  /* out of memory */
+
+	/* Trust the descriptor's recorded order over the caller's argument so a
+	 * mismatched free can't corrupt the buddy structure. */
+	(void)order;
+	if (--mem_map[f].refcount == 0)
+		buddy_free(f, mem_map[f].order);
 }
 
 void pmm_free_frame(uint32_t addr)
 {
-	uint32_t frame = addr / PMM_FRAME_SIZE;
-	if (refcount[frame] == 0) {
-		/* Caller dropped a frame they didn't own.  Likely a double free
-		 * or a free of a kernel-image / BIOS frame that was never handed
-		 * out by pmm_alloc_frame.  Don't unbalance the bitmap. */
-		KLOG("pmm_free_frame: refcount underflow at frame ");
-		KLOG_HEX(frame);
-		KLOG("\n");
-		return;
-	}
-	if (--refcount[frame] == 0)
-		pmm_clear_frame(frame);
+	pmm_free_pages(addr, 0);
 }
 
 void pmm_inc_ref(uint32_t addr)
 {
 	uint32_t frame = addr / PMM_FRAME_SIZE;
-	if (refcount[frame] == 0) {
-		/* Sharing a frame that isn't actually allocated -- this is always
-		 * a bug in the caller (COW clone of a freed PTE, for example). */
+	if (frame >= s_max_frames)
+		return;
+	if (mem_map[frame].refcount == 0) {
 		KLOG("pmm_inc_ref: frame not allocated, refcount=0 at ");
 		KLOG_HEX(frame);
 		KLOG("\n");
 		return;
 	}
-	if (refcount[frame] == 0xFF) {
+	if (mem_map[frame].refcount == 0xFF) {
 		KLOG("pmm_inc_ref: refcount saturated at 255 for frame ");
 		KLOG_HEX(frame);
 		KLOG("\n");
 		return;
 	}
-	refcount[frame]++;
+	mem_map[frame].refcount++;
 }
 
 uint8_t pmm_ref_count(uint32_t addr)
 {
-	return refcount[addr / PMM_FRAME_SIZE];
+	uint32_t frame = addr / PMM_FRAME_SIZE;
+	if (frame >= s_max_frames)
+		return 0;
+	return mem_map[frame].refcount;
 }
+
+/* --------------------------------------------------------------------------
+ * Accounting / diagnostics
+ * -------------------------------------------------------------------------- */
 
 uint32_t pmm_managed_count(void)
 {
@@ -196,14 +316,13 @@ uint32_t pmm_managed_count(void)
 
 uint32_t pmm_free_count(void)
 {
-	uint32_t count = 0;
-	for (uint32_t i = 0; i < PMM_BITMAP_WORDS; i++) {
-		uint32_t word = ~bitmap[i];  /* flip bits: 1 now means free */
-		/* Brian Kernighan's bit-count */
-		while (word) {
-			count++;
-			word &= word - 1;
-		}
-	}
-	return count;
+	return s_free_frames;
+}
+
+unsigned pmm_largest_free_order(void)
+{
+	for (unsigned o = PMM_MAX_ORDER; o-- > 0; )
+		if (free_lists[o] != PMM_NIL)
+			return o;
+	return PMM_MAX_ORDER;   /* pool empty */
 }

--- a/src/kernel/arch/i386/proc/ipc.c
+++ b/src/kernel/arch/i386/proc/ipc.c
@@ -1,0 +1,193 @@
+#include <kernel/ipc.h>
+#include <kernel/task.h>
+#include <kernel/serial.h>
+#include <string.h>
+
+/* errno-style return codes (matches the small negatives used elsewhere). */
+#define IPC_ESRCH   (-3)    /* no such / dead destination task */
+#define IPC_EFAULT  (-14)   /* bad message pointer             */
+#define IPC_EINVAL  (-22)   /* invalid argument (e.g. self-send) */
+
+/* Local IRQ save/restore -- task.c's helpers are file-static, so the IPC
+ * critical sections use their own.  Single-CPU: cli/sti is sufficient to
+ * serialise the rendezvous against the preempting timer IRQ. */
+static inline uint32_t ipc_irq_save(void)
+{
+    uint32_t f;
+    __asm__ volatile("pushf\n\tpop %0\n\tcli" : "=r"(f) :: "memory");
+    return f;
+}
+static inline void ipc_irq_restore(uint32_t f)
+{
+    __asm__ volatile("push %0\n\tpopf" :: "r"(f) : "memory", "cc");
+}
+
+/* Block the current task until a peer sets it back to TASK_READY.  Must be
+ * called with the descriptor bookkeeping already done; the scheduler skips
+ * any non-READY task, so simply marking ourselves BLOCKED and yielding parks
+ * us until the rendezvous partner wakes us. */
+static void ipc_block(task_t *cur)
+{
+    cur->state = TASK_BLOCKED;
+    task_yield();     /* returns once the partner flips us back to READY */
+}
+
+void ipc_task_init(struct task *t)
+{
+    task_t *tt = (task_t *)t;
+    tt->ipc_state    = IPC_STATE_IDLE;
+    tt->ipc_partner  = 0;
+    tt->ipc_rc       = 0;
+    tt->ipc_sender_q = NULL;
+    tt->ipc_sq_next  = NULL;
+}
+
+void ipc_task_cleanup(struct task *t)
+{
+    task_t  *tt = (task_t *)t;
+    uint32_t fl = ipc_irq_save();
+
+    /* Wake every sender still blocked on us; their send fails with -ESRCH. */
+    task_t *s = tt->ipc_sender_q;
+    while (s) {
+        task_t *nx = s->ipc_sq_next;
+        s->ipc_sq_next = NULL;
+        s->ipc_rc      = IPC_ESRCH;
+        s->ipc_state   = IPC_STATE_IDLE;
+        if (s->state == TASK_BLOCKED)
+            s->state = TASK_READY;
+        s = nx;
+    }
+    tt->ipc_sender_q = NULL;
+
+    /* If we were ourselves blocked sending, unlink from the destination's
+     * queue so it never dereferences a freed slot. */
+    if (tt->ipc_state == IPC_STATE_SENDING) {
+        task_t *d = task_by_pid(tt->ipc_partner);
+        if (d) {
+            task_t *prev = NULL, *p = d->ipc_sender_q;
+            while (p) {
+                if (p == tt) {
+                    if (prev) prev->ipc_sq_next = p->ipc_sq_next;
+                    else      d->ipc_sender_q   = p->ipc_sq_next;
+                    break;
+                }
+                prev = p;
+                p = p->ipc_sq_next;
+            }
+        }
+    }
+    tt->ipc_state   = IPC_STATE_IDLE;
+    tt->ipc_sq_next = NULL;
+
+    ipc_irq_restore(fl);
+}
+
+int ipc_send(int dst, const ipc_msg_t *msg)
+{
+    task_t *cur = task_current();
+    if (!cur)  return IPC_EINVAL;
+    if (!msg)  return IPC_EFAULT;
+    if (dst == cur->pid) return IPC_EINVAL;     /* no self-send */
+
+    /* Stage the message in our own kernel buffer (valid in our context). */
+    memcpy(&cur->ipc_buf, msg, sizeof(ipc_msg_t));
+    cur->ipc_buf.src = cur->pid;
+
+    uint32_t fl = ipc_irq_save();
+
+    task_t *d = task_by_pid(dst);
+    if (!d || d->state == TASK_DEAD || d->state == TASK_ZOMBIE) {
+        ipc_irq_restore(fl);
+        return IPC_ESRCH;
+    }
+
+    /* Fast path: the destination is already waiting to receive from us (or
+     * from anyone).  Hand the message over and let it run; we don't block. */
+    if (d->ipc_state == IPC_STATE_RECVING &&
+        (d->ipc_partner == IPC_ANY || d->ipc_partner == cur->pid)) {
+        memcpy(&d->ipc_buf, &cur->ipc_buf, sizeof(ipc_msg_t));
+        d->ipc_state   = IPC_STATE_IDLE;
+        d->ipc_partner = 0;
+        d->ipc_rc      = 0;
+        if (d->state == TASK_BLOCKED)
+            d->state = TASK_READY;
+        ipc_irq_restore(fl);
+        return 0;
+    }
+
+    /* Slow path: enqueue on the destination's sender queue and block. */
+    cur->ipc_state   = IPC_STATE_SENDING;
+    cur->ipc_partner = dst;
+    cur->ipc_rc      = 0;
+    cur->ipc_sq_next = d->ipc_sender_q;
+    d->ipc_sender_q  = cur;
+
+    ipc_block(cur);                 /* sleep until a receiver collects us */
+
+    int rc = cur->ipc_rc;           /* 0, or -ESRCH if the dest died first */
+    cur->ipc_state = IPC_STATE_IDLE;
+    ipc_irq_restore(fl);
+    return rc;
+}
+
+int ipc_recv(int from, ipc_msg_t *out)
+{
+    task_t *cur = task_current();
+    if (!cur)  return IPC_EINVAL;
+    if (!out)  return IPC_EFAULT;
+
+    uint32_t fl = ipc_irq_save();
+
+    /* Is a matching sender already queued on us? */
+    task_t *prev = NULL, *s = cur->ipc_sender_q;
+    while (s) {
+        if (from == IPC_ANY || s->pid == from)
+            break;
+        prev = s;
+        s = s->ipc_sq_next;
+    }
+
+    if (s) {
+        /* Dequeue the sender, take its message, complete its send. */
+        if (prev) prev->ipc_sq_next = s->ipc_sq_next;
+        else      cur->ipc_sender_q = s->ipc_sq_next;
+        s->ipc_sq_next = NULL;
+
+        memcpy(&cur->ipc_buf, &s->ipc_buf, sizeof(ipc_msg_t));
+
+        s->ipc_rc      = 0;
+        s->ipc_state   = IPC_STATE_IDLE;
+        s->ipc_partner = 0;
+        if (s->state == TASK_BLOCKED)
+            s->state = TASK_READY;
+
+        ipc_irq_restore(fl);
+        memcpy(out, &cur->ipc_buf, sizeof(ipc_msg_t));   /* our context */
+        return 0;
+    }
+
+    /* No sender yet: block until one delivers into our staging buffer. */
+    cur->ipc_state   = IPC_STATE_RECVING;
+    cur->ipc_partner = from;
+    cur->ipc_rc      = 0;
+
+    ipc_block(cur);
+
+    int rc = cur->ipc_rc;
+    cur->ipc_state = IPC_STATE_IDLE;
+    ipc_irq_restore(fl);
+
+    if (rc == 0)
+        memcpy(out, &cur->ipc_buf, sizeof(ipc_msg_t));
+    return rc;
+}
+
+int ipc_sendrec(int dst, ipc_msg_t *msg)
+{
+    int rc = ipc_send(dst, msg);
+    if (rc != 0)
+        return rc;
+    /* Await the reply specifically from dst, overwriting the request. */
+    return ipc_recv(dst, msg);
+}

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -9,7 +9,7 @@
 #include <kernel/acpi.h>
 #include <kernel/partition.h>
 #include <kernel/pci.h>
-#include <kernel/virtio_net.h>
+#include <kernel/netdev.h>
 #include <kernel/pmm.h>
 #include <kernel/heap.h>
 #include <kernel/vmm.h>
@@ -310,17 +310,19 @@ static uint32_t rd_be32(const uint8_t *p)
 
 static void test_virtio_net(void)
 {
-    ktest_begin("virtio_net", "legacy virtio-net TX ARP request + polled RX reply from QEMU slirp");
+    ktest_begin("netdev", "active Ethernet netdev TX ARP request + polled RX reply from QEMU slirp");
 
-    if (!virtio_net_present()) {
-        Serial_WriteString("[ktest] virtio_net: no device, skipping\n");
+    if (!netdev_present()) {
+        Serial_WriteString("[ktest] netdev: no device, skipping\n");
         KTEST_ASSERT(1);
         ktest_summary();
         return;
     }
 
-    const uint8_t *mac = virtio_net_mac();
-    Serial_WriteString("[ktest] virtio_net: device up, mac=");
+    const uint8_t *mac = netdev_mac();
+    Serial_WriteString("[ktest] netdev: device=");
+    Serial_WriteString((char *)(netdev_name() ? netdev_name() : "unknown"));
+    Serial_WriteString(" mac=");
     for (int i = 0; i < 6; i++) {
         if (i) Serial_WriteString(":");
         Serial_WriteHex(mac[i]);
@@ -342,9 +344,9 @@ static void test_virtio_net(void)
     be32(arp + 28, 0x0a00020f);   /* 10.0.2.15 */
     be32(arp + 38, 0x0a000202);   /* 10.0.2.2 */
 
-    Serial_WriteString("[ktest] virtio_net: TX ARP who-has 10.0.2.2\n");
-    int tx_rc = virtio_net_send(arp, sizeof(arp));
-    Serial_WriteString("[ktest] virtio_net: TX rc=");
+    Serial_WriteString("[ktest] netdev: TX ARP who-has 10.0.2.2\n");
+    int tx_rc = netdev_send(arp, sizeof(arp));
+    Serial_WriteString("[ktest] netdev: TX rc=");
     Serial_WriteDec((uint32_t)tx_rc);
     Serial_WriteString("\n");
     KTEST_ASSERT(tx_rc == 0);
@@ -357,10 +359,10 @@ static void test_virtio_net(void)
     int rx_frames = 0;
     uint32_t t0 = timer_get_ticks();
     while (timer_get_ticks() - t0 < 300) {
-        int n = virtio_net_rx_poll(rx, sizeof(rx));
+        int n = netdev_rx_poll(rx, sizeof(rx));
         if (n > 0) {
             rx_frames++;
-            Serial_WriteString("[ktest] virtio_net: RX frame len=");
+            Serial_WriteString("[ktest] netdev: RX frame len=");
             Serial_WriteDec((uint32_t)n);
             Serial_WriteString(" ethertype=");
             Serial_WriteHex(rd_be16(rx + 12));
@@ -378,7 +380,7 @@ static void test_virtio_net(void)
         task_yield();
     }
 
-    Serial_WriteString("[ktest] virtio_net: rx_frames=");
+    Serial_WriteString("[ktest] netdev: rx_frames=");
     Serial_WriteDec((uint32_t)rx_frames);
     Serial_WriteString(got_reply ? " ARP reply received\n" : " TIMEOUT (no ARP reply)\n");
     KTEST_ASSERT(got_reply);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -9,6 +9,7 @@
 #include <kernel/acpi.h>
 #include <kernel/partition.h>
 #include <kernel/pci.h>
+#include <kernel/virtio_net.h>
 #include <kernel/pmm.h>
 #include <kernel/heap.h>
 #include <kernel/vmm.h>
@@ -279,6 +280,108 @@ static void test_pci_bind(void)
 
     KTEST_ASSERT(pci_probe_all() == 0);          /* re-probe skips bound devices */
 
+    ktest_summary();
+}
+
+static void be16(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)v;
+}
+
+static void be32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+
+static uint16_t rd_be16(const uint8_t *p)
+{
+    return (uint16_t)(((uint16_t)p[0] << 8) | p[1]);
+}
+
+static uint32_t rd_be32(const uint8_t *p)
+{
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | p[3];
+}
+
+static void test_virtio_net(void)
+{
+    ktest_begin("virtio_net", "legacy virtio-net TX ARP request + polled RX reply from QEMU slirp");
+
+    if (!virtio_net_present()) {
+        Serial_WriteString("[ktest] virtio_net: no device, skipping\n");
+        KTEST_ASSERT(1);
+        ktest_summary();
+        return;
+    }
+
+    const uint8_t *mac = virtio_net_mac();
+    Serial_WriteString("[ktest] virtio_net: device up, mac=");
+    for (int i = 0; i < 6; i++) {
+        if (i) Serial_WriteString(":");
+        Serial_WriteHex(mac[i]);
+    }
+    Serial_WriteString("\n");
+
+    uint8_t arp[42];
+    memset(arp, 0, sizeof(arp));
+    for (int i = 0; i < 6; i++)
+        arp[i] = 0xff;
+    memcpy(arp + 6, mac, 6);
+    be16(arp + 12, 0x0806);       /* Ethernet type: ARP */
+    be16(arp + 14, 0x0001);       /* Ethernet hardware */
+    be16(arp + 16, 0x0800);       /* IPv4 protocol */
+    arp[18] = 6;                  /* hardware length */
+    arp[19] = 4;                  /* protocol length */
+    be16(arp + 20, 0x0001);       /* request */
+    memcpy(arp + 22, mac, 6);
+    be32(arp + 28, 0x0a00020f);   /* 10.0.2.15 */
+    be32(arp + 38, 0x0a000202);   /* 10.0.2.2 */
+
+    Serial_WriteString("[ktest] virtio_net: TX ARP who-has 10.0.2.2\n");
+    int tx_rc = virtio_net_send(arp, sizeof(arp));
+    Serial_WriteString("[ktest] virtio_net: TX rc=");
+    Serial_WriteDec((uint32_t)tx_rc);
+    Serial_WriteString("\n");
+    KTEST_ASSERT(tx_rc == 0);
+
+    /* Poll RX, yielding each iteration: under QEMU/TCG the guest must yield
+     * the CPU so the device's TX/RX backend and slirp's ARP responder get to
+     * run.  ~3 s wall-clock budget at 100 Hz. */
+    uint8_t rx[1600];
+    int got_reply = 0;
+    int rx_frames = 0;
+    uint32_t t0 = timer_get_ticks();
+    while (timer_get_ticks() - t0 < 300) {
+        int n = virtio_net_rx_poll(rx, sizeof(rx));
+        if (n > 0) {
+            rx_frames++;
+            Serial_WriteString("[ktest] virtio_net: RX frame len=");
+            Serial_WriteDec((uint32_t)n);
+            Serial_WriteString(" ethertype=");
+            Serial_WriteHex(rd_be16(rx + 12));
+            Serial_WriteString("\n");
+        }
+        if (n >= 42 &&
+            rd_be16(rx + 12) == 0x0806 &&      /* ARP                     */
+            rd_be16(rx + 20) == 0x0002 &&      /* reply                   */
+            rd_be32(rx + 28) == 0x0a000202 &&  /* sender 10.0.2.2 (slirp) */
+            rd_be32(rx + 38) == 0x0a00020f &&  /* target 10.0.2.15 (us)   */
+            memcmp(rx + 32, mac, 6) == 0) {    /* target MAC = ours       */
+            got_reply = 1;
+            break;
+        }
+        task_yield();
+    }
+
+    Serial_WriteString("[ktest] virtio_net: rx_frames=");
+    Serial_WriteDec((uint32_t)rx_frames);
+    Serial_WriteString(got_reply ? " ARP reply received\n" : " TIMEOUT (no ARP reply)\n");
+    KTEST_ASSERT(got_reply);
     ktest_summary();
 }
 
@@ -2659,6 +2762,10 @@ int ktest_run_all(void)
     total_fail += ktest_fail_count;
 
     test_pci_bind();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
+    test_virtio_net();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -8,6 +8,7 @@
 #include <kernel/ktest.h>
 #include <kernel/acpi.h>
 #include <kernel/partition.h>
+#include <kernel/pci.h>
 #include <kernel/pmm.h>
 #include <kernel/heap.h>
 #include <kernel/vmm.h>
@@ -243,6 +244,43 @@ static void test_partition(void)
  *   - The primary ATA disk (hda) is probed when present (HDD boots, or live
  *     boots with an installed disk attached).
  * ------------------------------------------------------------------------- */
+
+/* ---------------------------------------------------------------------------
+ * Suite: PCI driver binding (pci_driver_t registration + pci_probe_all)
+ * Matches the always-present i440FX host bridge (class 0x06/0x00) with a
+ * dummy class-match driver and proves probe firing, claim, and idempotency.
+ * ------------------------------------------------------------------------- */
+static int test_pci_probe_hits;
+static int test_pci_probe_fn(pci_device_t *dev) { (void)dev; test_pci_probe_hits++; return 0; }
+static const pci_driver_t test_pci_drv = {
+    .name = "ktest-hostbridge", .match_class = 1,
+    .class_code = 0x06, .subclass = 0x00, .probe = test_pci_probe_fn,
+};
+
+static void test_pci_bind(void)
+{
+    ktest_begin("pci_bind", "pci_driver_t registration + pci_probe_all class match");
+
+    KTEST_ASSERT(pci_device_count > 0);          /* QEMU always enumerates devices */
+
+    test_pci_probe_hits = 0;
+    pci_register_driver(&test_pci_drv);
+    int bound = pci_probe_all();
+
+    KTEST_ASSERT(test_pci_probe_hits >= 1);      /* host bridge probed */
+    KTEST_ASSERT(bound >= 1);                    /* and claimed */
+
+    int named = 0;
+    for (int i = 0; i < pci_device_count; i++)
+        if (pci_devices[i].driver &&
+            strcmp(pci_devices[i].driver, "ktest-hostbridge") == 0)
+            named++;
+    KTEST_ASSERT(named >= 1);                     /* dev->driver carries the name */
+
+    KTEST_ASSERT(pci_probe_all() == 0);          /* re-probe skips bound devices */
+
+    ktest_summary();
+}
 
 static void test_devfs(void)
 {
@@ -2460,6 +2498,10 @@ int ktest_run_all(void)
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 
+    test_pci_bind();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
     test_devfs();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
@@ -2617,6 +2659,7 @@ void ktest_bg_task(void)
     RUN(test_fpu);
     RUN(test_string);
     RUN(test_partition);
+    RUN(test_pci_bind);
     RUN(test_devfs);
     RUN(test_tmpfs);
     RUN(test_rootfs_mount_layout);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -548,6 +548,80 @@ static void test_pmm(void)
 }
 
 /* ---------------------------------------------------------------------------
+ * Suite: buddy allocator
+ *
+ * Exercises the multi-order page allocator beneath pmm_alloc_frame: contiguous
+ * power-of-two blocks, natural alignment (what DMA rings need), real writable
+ * backing RAM, exact free-frame accounting, and coalescing on free.
+ * ------------------------------------------------------------------------- */
+
+static void test_buddy(void)
+{
+    ktest_begin("buddy", "buddy allocator: contiguous alloc, alignment, RAM, coalescing, accounting");
+
+    uint32_t free0 = pmm_free_count();
+
+    /* Order-0 path == legacy pmm_alloc_frame. */
+    uint32_t a = pmm_alloc_pages(0);
+    KTEST_ASSERT(a != PMM_ALLOC_ERROR);
+    KTEST_ASSERT((a & (PMM_FRAME_SIZE - 1)) == 0);
+    KTEST_ASSERT(pmm_free_count() == free0 - 1);
+    pmm_free_pages(a, 0);
+    KTEST_ASSERT(pmm_free_count() == free0);
+
+    /* Order-3: 8 contiguous frames, naturally aligned to 8*4 KiB = 32 KiB. */
+    uint32_t blk = pmm_alloc_pages(3);
+    KTEST_ASSERT(blk != PMM_ALLOC_ERROR);
+    KTEST_ASSERT((blk & ((8u * PMM_FRAME_SIZE) - 1)) == 0);
+    KTEST_ASSERT(pmm_free_count() == free0 - 8);
+
+    /* The block is real, writable RAM (identity-mapped below 256 MiB):
+     * stamp one word per frame and read it back. */
+    volatile uint32_t *p = (volatile uint32_t *)blk;
+    for (int i = 0; i < 8; i++)
+        p[i * (PMM_FRAME_SIZE / 4)] = 0xB0B00000u + (uint32_t)i;
+    int ram_ok = 1;
+    for (int i = 0; i < 8; i++)
+        if (p[i * (PMM_FRAME_SIZE / 4)] != 0xB0B00000u + (uint32_t)i)
+            ram_ok = 0;
+    KTEST_ASSERT(ram_ok);
+
+    pmm_free_pages(blk, 3);
+    KTEST_ASSERT(pmm_free_count() == free0);
+
+    /* Order-5: 128 KiB-aligned. */
+    uint32_t big = pmm_alloc_pages(5);
+    KTEST_ASSERT(big != PMM_ALLOC_ERROR);
+    KTEST_ASSERT((big & ((32u * PMM_FRAME_SIZE) - 1)) == 0);
+    pmm_free_pages(big, 5);
+    KTEST_ASSERT(pmm_free_count() == free0);
+
+    /* Coalescing: an order-4 alloc splits a larger block into buddies; freeing
+     * it must merge them back so the *same* block is handed out next time. */
+    uint32_t c1 = pmm_alloc_pages(4);
+    KTEST_ASSERT(c1 != PMM_ALLOC_ERROR);
+    pmm_free_pages(c1, 4);
+    uint32_t c2 = pmm_alloc_pages(4);
+    KTEST_ASSERT(c2 == c1);                 /* coalesced, not left fragmented */
+    pmm_free_pages(c2, 4);
+
+    /* A mixed alloc/free storm must not leak or double-count frames. */
+    for (int it = 0; it < 64; it++) {
+        unsigned ord = (unsigned)(it % 6);          /* orders 0..5 */
+        uint32_t x = pmm_alloc_pages(ord);
+        KTEST_ASSERT(x != PMM_ALLOC_ERROR);
+        KTEST_ASSERT((x & (((1u << ord) * PMM_FRAME_SIZE) - 1)) == 0);
+        pmm_free_pages(x, ord);
+    }
+    KTEST_ASSERT(pmm_free_count() == free0);
+
+    /* Over-large order is rejected, not serviced. */
+    KTEST_ASSERT(pmm_alloc_pages(PMM_MAX_ORDER) == PMM_ALLOC_ERROR);
+
+    ktest_summary();
+}
+
+/* ---------------------------------------------------------------------------
  * Suite: heap
  *
  * Tests the kmalloc/kfree/krealloc first-fit allocator.
@@ -2522,6 +2596,10 @@ int ktest_run_all(void)
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 
+    test_buddy();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
     test_heap();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
@@ -2664,6 +2742,7 @@ void ktest_bg_task(void)
     RUN(test_tmpfs);
     RUN(test_rootfs_mount_layout);
     RUN(test_pmm);
+    RUN(test_buddy);
     RUN(test_heap);
     RUN(test_vmm);
     RUN(test_task);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -22,6 +22,7 @@
 #include <kernel/syscall.h>
 #include <kernel/serial.h>
 #include <kernel/tty.h>
+#include <kernel/vt.h>
 #include <kernel/vesa.h>
 #include <kernel/vesa_tty.h>
 #include <kernel/bochs_vbe.h>
@@ -186,6 +187,42 @@ static void test_string(void)
     memcpy(buf, "hello", 6);
     KTEST_ASSERT(strcmp(buf, "hello") == 0);
 
+    ktest_summary();
+}
+
+static void test_vt_status_scroll(void)
+{
+    ktest_begin("vt_status_scroll", "VT scroll region reserves status row");
+
+    vt_buf_t vt;
+    memset(&vt, 0, sizeof vt);
+    KTEST_ASSERT(vt_init(&vt, 4, 4, 0x00FFFFFFu, 0x00000000u));
+    if (!vt.cells) {
+        ktest_summary();
+        return;
+    }
+
+    vt_set_usable_rows(&vt, 3);
+    vt_put_at(&vt, 'A', 0, 0);
+    vt_put_at(&vt, 'B', 0, 1);
+    vt_put_at(&vt, 'C', 0, 2);
+    vt_put_at(&vt, 'S', 0, 3);
+
+    vt_set_cursor(&vt, 0, 2);
+    vt_putchar(&vt, '\n');
+
+    KTEST_ASSERT(vt.cur_row == 2);
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 0).ch == 'B');
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 1).ch == 'C');
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 2).ch == ' ');
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 3).ch == 'S');
+
+    vt_set_usable_rows(&vt, 4);
+    vt_set_cursor(&vt, 0, 3);
+    vt_putchar(&vt, 'Z');
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 3).ch == 'Z');
+
+    kfree(vt.cells);
     ktest_summary();
 }
 
@@ -2756,6 +2793,10 @@ int ktest_run_all(void)
     total_fail += ktest_fail_count;
 
     test_string();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
+    test_vt_status_scroll();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -924,6 +924,92 @@ static void test_task(void)
 }
 
 /* ---------------------------------------------------------------------------
+ * Suite: IPC (microkernel synchronous message passing)
+ *
+ * Spawns a server task that loops on ipc_recv(IPC_ANY) and replies, then
+ * drives it as an RPC client via ipc_sendrec.  Exercises both rendezvous
+ * orderings (sender-blocks-first and receiver-blocks-first), the sender
+ * queue, message integrity, src stamping, and clean teardown via a QUIT
+ * message.  Proves the blocking primitive the whole microkernel direction
+ * rests on.
+ * ------------------------------------------------------------------------- */
+
+#define TEST_IPC_REQ    1
+#define TEST_IPC_QUIT   2
+#define TEST_IPC_REPLY  100
+
+static int s_ipc_server_pid;
+
+static void test_ipc_server(void)
+{
+    for (;;) {
+        ipc_msg_t m;
+        if (ipc_recv(IPC_ANY, &m) != 0)
+            break;                       /* partner gone -- bail */
+        if (m.type == TEST_IPC_QUIT)
+            break;
+        if (m.type == TEST_IPC_REQ) {
+            ipc_msg_t r;
+            r.type    = TEST_IPC_REPLY;
+            r.data[0] = m.data[0] + 1;   /* server transforms the payload */
+            ipc_send(m.src, &r);         /* reply to whoever asked */
+        }
+    }
+    task_exit();
+}
+
+static void test_ipc(void)
+{
+    ktest_begin("ipc",
+                "MINIX-style synchronous IPC: sendrec RPC to a server task, "
+                "blocking rendezvous + sender queue + teardown");
+
+    task_t *srv = task_create("ipc_server", test_ipc_server);
+    KTEST_ASSERT(srv != NULL);
+    if (!srv) { ktest_summary(); return; }
+    s_ipc_server_pid = srv->pid;
+
+    /* First request: the server hasn't run yet, so our send blocks and
+     * enqueues -- exercises the sender-blocks-first path.  Later iterations
+     * find the server already waiting in recv -- the fast path. */
+    int all_ok = 1;
+    for (int i = 0; i < 8; i++) {
+        ipc_msg_t m;
+        memset(&m, 0, sizeof(m));
+        m.type    = TEST_IPC_REQ;
+        m.data[0] = (uint32_t)(i * 10);
+
+        int rc = ipc_sendrec(srv->pid, &m);
+        if (rc != 0)                              { all_ok = 0; break; }
+        if (m.type != TEST_IPC_REPLY)             { all_ok = 0; break; }
+        if (m.data[0] != (uint32_t)(i * 10 + 1))  { all_ok = 0; break; }
+        if (m.src != srv->pid)                    { all_ok = 0; break; }
+    }
+    KTEST_ASSERT(all_ok);
+
+    /* Self-send is rejected. */
+    {
+        ipc_msg_t m; memset(&m, 0, sizeof(m));
+        KTEST_ASSERT(ipc_send(task_current()->pid, &m) != 0);
+    }
+
+    /* Send to a non-existent endpoint fails with an error, not a hang. */
+    {
+        ipc_msg_t m; memset(&m, 0, sizeof(m)); m.type = TEST_IPC_REQ;
+        KTEST_ASSERT(ipc_send(0x7fffffff, &m) != 0);
+    }
+
+    /* Tell the server to quit, then join. */
+    ipc_msg_t q; memset(&q, 0, sizeof(q)); q.type = TEST_IPC_QUIT;
+    ipc_send(srv->pid, &q);
+    for (int i = 0; i < 256 && srv->state != TASK_DEAD; i++)
+        task_yield();
+    KTEST_ASSERT(srv->state == TASK_DEAD);
+
+    ktest_summary();
+}
+
+/* ---------------------------------------------------------------------------
  * Suite: procfs task listing
  *
  * /proc/tasks is bulk kernel behavior, not a keyboard/UI behavior.  Dead task
@@ -2612,6 +2698,10 @@ int ktest_run_all(void)
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 
+    test_ipc();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
     test_procfs_tasks();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
@@ -2746,6 +2836,7 @@ void ktest_bg_task(void)
     RUN(test_heap);
     RUN(test_vmm);
     RUN(test_task);
+    RUN(test_ipc);
     RUN(test_procfs_tasks);
     RUN(test_getpid);
     RUN(test_rtc_unix_time);

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -2098,6 +2098,21 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    case SYS_IPC_SEND:
+        regs->eax = (uint32_t)ipc_send((int)regs->ebx,
+                                       (const ipc_msg_t *)(uintptr_t)regs->ecx);
+        break;
+
+    case SYS_IPC_RECV:
+        regs->eax = (uint32_t)ipc_recv((int)regs->ebx,
+                                       (ipc_msg_t *)(uintptr_t)regs->ecx);
+        break;
+
+    case SYS_IPC_SENDREC:
+        regs->eax = (uint32_t)ipc_sendrec((int)regs->ebx,
+                                          (ipc_msg_t *)(uintptr_t)regs->ecx);
+        break;
+
     default:
         /* Unknown syscall - return -ENOSYS. */
         regs->eax = (uint32_t)-38;   /* -ENOSYS */

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -45,6 +45,7 @@
 #include <kernel/vt.h>
 #include <kernel/ide.h>
 #include <kernel/pci.h>
+#include <kernel/netdev.h>
 #include <kernel/timer.h>
 #include <kernel/rtc.h>
 #include <string.h>
@@ -1685,6 +1686,59 @@ void syscall_dispatch(registers_t *regs)
 #undef PCI_BYTE_HEX
 #undef PCI_WORD_HEX
 #undef PCI_DEC
+        buf[off] = '\0';
+        regs->eax = off;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_NET_INFO(253): render active Ethernet netdev state as text.
+     * EBX = buf, ECX = bufsz.  Returns bytes written.
+     * ------------------------------------------------------------------ */
+    case SYS_NET_INFO: {
+        char    *buf = (char *)(uintptr_t)regs->ebx;
+        uint32_t cap = regs->ecx;
+        if (!buf || cap == 0) { regs->eax = 0; break; }
+        uint32_t off = 0;
+
+#define NET_APPEND(s) do { for (const char *_p = (s); *_p && off < cap - 2; _p++) buf[off++] = *_p; } while(0)
+#define NET_BYTE_HEX(v) do { \
+    static const char _h[] = "0123456789abcdef"; \
+    uint8_t _v = (uint8_t)(v); \
+    if (off + 2 < cap) { buf[off++] = _h[(_v >> 4) & 0xF]; buf[off++] = _h[_v & 0xF]; } \
+} while(0)
+
+        NET_APPEND("Makar Network Configuration\n\n");
+
+        if (!netdev_present()) {
+            NET_APPEND("Ethernet adapters: none\n");
+        } else {
+            const char *name = netdev_name();
+            const uint8_t *mac = netdev_mac();
+            NET_APPEND("Ethernet adapter eth0:\n");
+            NET_APPEND("   Driver . . . . . . . . . . : ");
+            NET_APPEND(name ? name : "unknown");
+            NET_APPEND("\n");
+            NET_APPEND("   Link State . . . . . . . . : up\n");
+            NET_APPEND("   Physical Address. . . . . . : ");
+            if (mac) {
+                for (int i = 0; i < 6; i++) {
+                    if (i && off < cap - 2) buf[off++] = '-';
+                    NET_BYTE_HEX(mac[i]);
+                }
+                if (off < cap - 2) buf[off++] = '\n';
+            } else {
+                NET_APPEND("unknown\n");
+            }
+            NET_APPEND("   DHCP Enabled. . . . . . . . : no\n");
+            NET_APPEND("   IPv4 Address. . . . . . . . : 10.0.2.15\n");
+            NET_APPEND("   Subnet Mask . . . . . . . . : 255.255.255.0\n");
+            NET_APPEND("   Default Gateway . . . . . . : 10.0.2.2\n");
+            NET_APPEND("   DNS Servers . . . . . . . . : 10.0.2.3\n");
+        }
+
+#undef NET_APPEND
+#undef NET_BYTE_HEX
         buf[off] = '\0';
         regs->eax = off;
         break;

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -243,6 +243,7 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->pid         = next_pid++;
     t->parent_pid  = current_task ? current_task->pid : 0;
     t->exit_status = 0;
+    ipc_task_init(t);   /* reset IPC state (covers reused slots too) */
     t->kticks      = 0;
     t->unkillable  = 0;     /* default: ordinary task, no protection   */
     t->fb_touched  = 0;     /* clean slate even when reclaiming a DEAD slot
@@ -615,6 +616,11 @@ void task_terminate(task_t *t, int status)
 {
     if (!t)
         return;
+
+    /* Detach from the IPC graph before the slot can be reused: wake any
+     * senders blocked on us and unlink us from a receiver's queue. */
+    ipc_task_cleanup(t);
+
     t->exit_status = status;
 
     /* Decide whether to leave a zombie behind for wait4.  Only makes

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -79,14 +79,9 @@ void vtty_init(void)
     vtty_current = 0;
 
     uint32_t cols = 0, rows = 0;
-    bool reserve_status = false;
     if (vesa_tty_is_ready()) {
         cols = vesa_tty_get_cols();
         rows = vesa_tty_get_rows();
-        if (rows > VESA_TTY_STATUS_ROWS) {
-            rows -= VESA_TTY_STATUS_ROWS;
-            reserve_status = true;
-        }
     }
     if (cols == 0 || rows == 0) {
         cols = 80;
@@ -105,19 +100,20 @@ void vtty_init(void)
 
     vtty_bufs_ready = true;
     for (int i = 0; i < VTTY_MAX; i++) {
-        /* Root slot (mak.sh0) gets full tty height so text and scrolling
-         * can reach the bottom row when no status bar is visible.
-         * Makmux slots 0-3 use the status-bar-reserved height. */
-        uint32_t slot_rows = (i == VTTY_ROOT_SLOT) ? vesa_tty_get_rows() : rows;
-        if (!vt_init(&vtty_bufs[i], cols, slot_rows,
+        /* Allocate every VT at physical height, then let vt->usable_rows
+         * define the active console scroll region.  That mirrors Linux's
+         * split between screen capacity and the current visible/scroll area:
+         * enabling the status bar reserves the last row, disabling it gives
+         * that row back without reallocating each VT buffer. */
+        if (!vt_init(&vtty_bufs[i], cols, rows,
                      VTTY_DEFAULT_FG, VTTY_DEFAULT_BG)) {
             /* Allocation failed: leave cells == NULL so vt_putchar
              * becomes a no-op for that slot.  Better than panic at boot. */
             vtty_bufs[i].cells = NULL;
+        } else if (vesa_tty_is_ready()) {
+            vt_set_usable_rows(&vtty_bufs[i], vesa_tty_usable_rows());
         }
     }
-
-    (void)reserve_status;
 }
 
 /*

--- a/src/kernel/arch/i386/shell/shell_cmd_disk.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_disk.c
@@ -419,6 +419,9 @@ static void cmd_lspci(int argc, char **argv)
         if (d->irq_line && d->irq_line != 0xFF) {
             t_writestring("  IRQ="); t_dec((uint32_t)d->irq_line);
         }
+        if (d->driver) {
+            t_writestring("  driver="); t_writestring(d->driver);
+        }
         t_putchar('\n');
     }
 }

--- a/src/kernel/arch/i386/shell/shell_cmd_system.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_system.c
@@ -71,7 +71,9 @@ static void cmd_uptime(int argc, char **argv)
 static void cmd_tasks(int argc, char **argv)
 {
     (void)argc; (void)argv;
-    static const char * const state_names[] = { "ready", "running", "dead" };
+    static const char * const state_names[] = {
+        "ready", "running", "dead", "zombie", "blocked"
+    };
     int n = task_count();
 
     t_writestring("Tasks (");
@@ -87,7 +89,9 @@ static void cmd_tasks(int argc, char **argv)
         t_writestring("] ");
         t_writestring(t->name ? t->name : "(unnamed)");
         t_writestring(" - ");
-        t_writestring(state_names[t->state]);
+        t_writestring((unsigned)t->state <
+                          sizeof(state_names) / sizeof(state_names[0])
+                      ? state_names[t->state] : "?");
         t_putchar('\n');
     }
 }

--- a/src/kernel/include/kernel/ipc.h
+++ b/src/kernel/include/kernel/ipc.h
@@ -1,0 +1,55 @@
+#ifndef _KERNEL_IPC_H
+#define _KERNEL_IPC_H
+
+#include <stdint.h>
+
+/* ---------------------------------------------------------------------------
+ * Synchronous message-passing IPC -- the microkernel primitive.
+ *
+ * MINIX-style rendezvous: endpoints are task PIDs, messages are fixed-size,
+ * and transfer is synchronous.  A send blocks until the destination is in a
+ * matching receive (and vice-versa); at the rendezvous the kernel copies the
+ * message directly between the two tasks.  sendrec is an atomic
+ * send-then-await-reply for request/response RPC to a server task -- the shape
+ * every user-space driver/filesystem server will be driven through.
+ *
+ * Cross-address-space safety: each task owns a kernel-resident staging buffer
+ * (task_t.ipc_buf).  A caller's user/kernel message is copied into its own
+ * staging buffer in its own context; the rendezvous copy is kernel->kernel
+ * (always reachable); the receiver copies out in its own context.  So the
+ * sender and receiver never touch each other's address space.
+ * ------------------------------------------------------------------------- */
+
+#define IPC_MSG_DATA_WORDS 6
+
+typedef struct {
+    int32_t  src;     /* sender pid; filled in by the kernel on receive */
+    int32_t  type;    /* caller-defined opcode                          */
+    uint32_t data[IPC_MSG_DATA_WORDS];
+} ipc_msg_t;          /* 32 bytes */
+
+#define IPC_ANY  (-1)              /* recv-from-anyone wildcard */
+
+/* task_t.ipc_state values */
+#define IPC_STATE_IDLE     0
+#define IPC_STATE_SENDING  1
+#define IPC_STATE_RECVING  2
+
+struct task;  /* forward decl -- avoids a task.h <-> ipc.h cycle */
+
+/* Reset a task's IPC state.  Called from task_create. */
+void ipc_task_init(struct task *t);
+
+/* Detach a dying task from the IPC graph: wake any senders blocked on it
+ * (handing them -ESRCH) and unlink it from a receiver's sender queue if it
+ * was itself blocked sending.  Called from task_terminate. */
+void ipc_task_cleanup(struct task *t);
+
+/* Kernel-callable IPC.  `msg`/`out` must be valid in the *calling* task's
+ * current address space (a ring-3 caller passes a user pointer; a kernel
+ * task passes a kernel pointer).  Return 0 on success, negative on error. */
+int ipc_send   (int dst,  const ipc_msg_t *msg);
+int ipc_recv   (int from, ipc_msg_t *out);
+int ipc_sendrec(int dst,  ipc_msg_t *msg);   /* in: request -> out: reply */
+
+#endif /* _KERNEL_IPC_H */

--- a/src/kernel/include/kernel/netdev.h
+++ b/src/kernel/include/kernel/netdev.h
@@ -1,0 +1,22 @@
+#ifndef _KERNEL_NETDEV_H
+#define _KERNEL_NETDEV_H
+
+#include <stdint.h>
+
+typedef struct {
+    const char *name;
+    int (*present)(void);
+    const uint8_t *(*mac)(void);
+    int (*send)(const void *frame, uint16_t len);
+    int (*rx_poll)(void *buf, uint16_t bufsz);
+} netdev_ops_t;
+
+void netdev_register(const netdev_ops_t *ops);
+
+int netdev_present(void);
+const char *netdev_name(void);
+const uint8_t *netdev_mac(void);
+int netdev_send(const void *frame, uint16_t len);
+int netdev_rx_poll(void *buf, uint16_t bufsz);
+
+#endif /* _KERNEL_NETDEV_H */

--- a/src/kernel/include/kernel/pci.h
+++ b/src/kernel/include/kernel/pci.h
@@ -20,10 +20,40 @@ typedef struct {
     uint8_t  header_type;
     uint8_t  irq_line;
     uint32_t bar[6];
+    const char *driver;   /* name of bound driver, NULL if unclaimed */
 } pci_device_t;
 
 extern pci_device_t pci_devices[PCI_MAX_DEVICES];
 extern int          pci_device_count;
+
+/* --------------------------------------------------------------------------
+ * Driver binding.  A driver matches either by vendor/device id, or (when
+ * match_class is set) by class_code/subclass.  PCI_MATCH_ANY in the device
+ * field matches every device of the given vendor.  pci_probe_all() walks the
+ * scanned device table once and calls each registered driver's probe() on a
+ * match; probe() returns 0 to claim the device (sets dev->driver).
+ * -------------------------------------------------------------------------- */
+#define PCI_MATCH_ANY 0xFFFFu
+
+typedef int (*pci_probe_fn)(pci_device_t *dev);
+
+typedef struct {
+    const char  *name;
+    uint16_t     vendor;       /* matched when match_class == 0 */
+    uint16_t     device;       /* PCI_MATCH_ANY = any device of vendor */
+    uint8_t      class_code;   /* matched when match_class != 0 */
+    uint8_t      subclass;
+    uint8_t      match_class;  /* 0 = match by id, 1 = match by class/subclass */
+    pci_probe_fn probe;
+} pci_driver_t;
+
+void pci_register_driver(const pci_driver_t *drv);
+int  pci_probe_all(void);   /* returns number of devices successfully bound */
+
+/* Common config-space helpers used by bound drivers. */
+void     pci_enable_bus_master(pci_device_t *d);
+uint32_t pci_bar_io (const pci_device_t *d, int idx);  /* I/O base  (BAR & ~0x3) */
+uint32_t pci_bar_mem(const pci_device_t *d, int idx);  /* MMIO base (BAR & ~0xF) */
 
 void        pci_init(void);
 uint32_t    pci_read32 (uint8_t bus, uint8_t dev, uint8_t func, uint8_t off);

--- a/src/kernel/include/kernel/pmm.h
+++ b/src/kernel/include/kernel/pmm.h
@@ -12,10 +12,32 @@
    the null page and all kernel frames as used. */
 void     pmm_init(uint32_t magic, multiboot2_info_t *mbi);
 
+/* Number of buddy orders.  Orders 0..PMM_MAX_ORDER-1; the largest block is
+   2^(PMM_MAX_ORDER-1) frames = 4 MiB (matches Linux's default MAX_ORDER). */
+#define PMM_MAX_ORDER 11
+
 /* Allocate one physical frame.  Returns the physical address of the
    frame (always a multiple of PMM_FRAME_SIZE), or PMM_ALLOC_ERROR if
-   no free frame is available. */
+   no free frame is available.  Equivalent to pmm_alloc_pages(0). */
 uint32_t pmm_alloc_frame(void);
+
+/* Allocate 2^order physically-contiguous frames via the buddy allocator.
+   The returned physical address is naturally aligned to the block size
+   (2^order * PMM_FRAME_SIZE), which is what DMA ring buffers and page-table
+   pools need.  Returns PMM_ALLOC_ERROR if no block of that order is free.
+   order must be < PMM_MAX_ORDER. */
+uint32_t pmm_alloc_pages(unsigned order);
+
+/* Free a block previously returned by pmm_alloc_pages(order).  Drops one
+   reference on the head frame and, when it reaches zero, returns the block
+   to the buddy pool (coalescing with a free buddy where possible).  The
+   order must match the original allocation. */
+void     pmm_free_pages(uint32_t addr, unsigned order);
+
+/* Diagnostic: the highest order whose free list is non-empty, or
+   PMM_MAX_ORDER if the pool is entirely empty.  Lets ktests observe
+   coalescing. */
+unsigned pmm_largest_free_order(void);
 
 /* Drop one reference to the physical frame at addr.
    When the refcount hits zero the frame is returned to the free pool.

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -154,6 +154,7 @@
 #define SYS_IPC_SEND       249  /* int ipc_send(int dst, const ipc_msg_t *)        */
 #define SYS_IPC_RECV       250  /* int ipc_recv(int from, ipc_msg_t *)             */
 #define SYS_IPC_SENDREC    251  /* int ipc_sendrec(int dst, ipc_msg_t *)           */
+#define SYS_NET_INFO       253  /* int net_info(char *buf, uint32_t bufsz)         */
 
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -149,6 +149,12 @@
 #define SYS_STATFS         246  /* int statfs(uint32_t *total_kb, uint32_t *free_kb)
                                  * rootfs usage in KiB (ext2 only).  Returns 0/-1. */
 
+/* Microkernel IPC (MINIX-style synchronous message passing).  ebx = endpoint
+ * pid (or IPC_ANY for recv), ecx = ipc_msg_t*.  See kernel/ipc.h. */
+#define SYS_IPC_SEND       249  /* int ipc_send(int dst, const ipc_msg_t *)        */
+#define SYS_IPC_RECV       250  /* int ipc_recv(int from, ipc_msg_t *)             */
+#define SYS_IPC_SENDREC    251  /* int ipc_sendrec(int dst, ipc_msg_t *)           */
+
 /* Back to Linux i386 ABI numbers for the next set. */
 #define SYS_FCNTL      55   /* int fcntl(int fd, int cmd, int arg) - F_GETFL/F_SETFL */
 #define SYS_GETPPID    64   /* pid_t getppid(void)                              */

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -6,6 +6,7 @@
 #include <kernel/vfs.h>      /* VFS_PATH_MAX */
 #include <kernel/fd.h>       /* fd_table_t, TASK_MAX_FDS */
 #include <kernel/isr.h>      /* registers_t for task_fork */
+#include <kernel/ipc.h>      /* ipc_msg_t + IPC_STATE_* for the IPC fields */
 
 /* Size of the private kernel stack allocated for each task. */
 #define TASK_STACK_SIZE  8192
@@ -30,6 +31,11 @@ typedef enum {
      * from DEAD so task_create's reclaim path won't reuse the slot
      * before the parent reads the status. */
     TASK_ZOMBIE  = 3,
+    /* TASK_BLOCKED -- parked in a synchronous IPC rendezvous (send waiting
+     * for a receiver, or recv waiting for a sender).  The scheduler only
+     * runs TASK_READY tasks, so a blocked task is simply skipped; its
+     * rendezvous partner flips it back to TASK_READY on wake.  See ipc.c. */
+    TASK_BLOCKED = 4,
 } task_state_t;
 
 typedef struct task {
@@ -140,6 +146,25 @@ typedef struct task {
      * Allocated lazily on first assignment by sh_vars_set().  See
      * src/kernel/arch/i386/shell/sh_vars.c. */
     void         *script_vars;
+
+    /* --- IPC (microkernel synchronous message passing) ---
+     * ipc_buf:       kernel-resident staging buffer for the in-flight message
+     *                (decouples sender/receiver address spaces).
+     * ipc_state:     IPC_STATE_IDLE / SENDING / RECVING.
+     * ipc_partner:   dest pid while SENDING, or src filter (pid / IPC_ANY)
+     *                while RECVING.
+     * ipc_rc:        result handed back to this task when it is woken from a
+     *                blocked send/recv (0, or -ESRCH if the partner died).
+     * ipc_sender_q:  head of the list of tasks blocked SENDING to this task.
+     * ipc_sq_next:   this task's link while queued in some receiver's
+     *                ipc_sender_q.
+     * See arch/i386/proc/ipc.c. */
+    ipc_msg_t     ipc_buf;
+    int           ipc_state;
+    int           ipc_partner;
+    int           ipc_rc;
+    struct task  *ipc_sender_q;
+    struct task  *ipc_sq_next;
 } task_t;
 
 /*

--- a/src/kernel/include/kernel/virtio_net.h
+++ b/src/kernel/include/kernel/virtio_net.h
@@ -1,0 +1,32 @@
+#ifndef _KERNEL_VIRTIO_NET_H
+#define _KERNEL_VIRTIO_NET_H
+
+#include <stdint.h>
+
+/* Legacy virtio-net (transitional PCI device 1AF4:1000) driver.
+ *
+ * Polled split-ring transport over the legacy I/O-BAR register window.  This
+ * is the raw Ethernet frame in/out layer; a TCP/IP stack (lwIP) sits on top
+ * via the four entry points below.  No IRQ yet -- rx is drained by polling
+ * virtio_net_rx_poll() from the network poll loop.
+ */
+
+/* Register the PCI driver.  Call before pci_probe_all() so the device binds. */
+void virtio_net_register(void);
+
+/* 1 once a device has been bound and brought up, 0 otherwise. */
+int  virtio_net_present(void);
+
+/* The device MAC (6 bytes), or NULL if no device is up. */
+const uint8_t *virtio_net_mac(void);
+
+/* Transmit one Ethernet frame (without the virtio_net_hdr; the driver
+ * prepends it).  Returns 0 on success, negative on error/timeout. */
+int  virtio_net_send(const void *frame, uint16_t len);
+
+/* Poll the receive ring for one frame.  Copies up to bufsz bytes of the
+ * Ethernet frame (virtio_net_hdr already stripped) into buf and returns the
+ * frame length, 0 if nothing is pending, negative on error. */
+int  virtio_net_rx_poll(void *buf, uint16_t bufsz);
+
+#endif /* _KERNEL_VIRTIO_NET_H */

--- a/src/kernel/include/kernel/vt.h
+++ b/src/kernel/include/kernel/vt.h
@@ -29,6 +29,7 @@ typedef struct vt_cell {
 typedef struct vt_buf {
     uint32_t   cols;
     uint32_t   rows;
+    uint32_t   usable_rows;
     uint32_t   cur_col;
     uint32_t   cur_row;
     uint32_t   fg;        /* current attribute applied to incoming chars */
@@ -69,6 +70,11 @@ void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row);
 /* Set the current attribute applied to subsequent vt_putchar / vt_put_at
  * calls.  Does not repaint existing cells. */
 void vt_set_color(vt_buf_t *vt, uint32_t fg, uint32_t bg);
+
+/* Set the number of rows used for cursor movement, clearing, and scrolling.
+ * The backing allocation remains vt->rows rows deep so the full screen can be
+ * restored when a reserved status row is released. */
+void vt_set_usable_rows(vt_buf_t *vt, uint32_t rows);
 
 /* Move the cursor.  Coordinates are clamped to the grid. */
 void vt_set_cursor(vt_buf_t *vt, uint32_t col, uint32_t row);

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -25,6 +25,7 @@
 #include <kernel/syscall.h>
 #include <kernel/acpi.h>
 #include <kernel/pci.h>
+#include <kernel/virtio_net.h>
 #include <kernel/ktest.h>
 #include <kernel/vtty.h>
 #include <kernel/sh_script.h>
@@ -299,6 +300,7 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 
 	t_writestring("Scanning PCI bus");
 	kprint_ok();
+	virtio_net_register();
 	pci_init();
 	pci_probe_all();   /* bind registered drivers to scanned devices */
 	KLOG("pci: bus scan complete\n");

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -300,6 +300,7 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 	t_writestring("Scanning PCI bus");
 	kprint_ok();
 	pci_init();
+	pci_probe_all();   /* bind registered drivers to scanned devices */
 	KLOG("pci: bus scan complete\n");
 
 	/* Parse Multiboot 2 tags: boot device and kernel command line. */

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -16,7 +16,7 @@ LDFLAGS=-T link.ld -nostdlib
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf ktest_uspace.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf ktest_uspace.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -71,6 +71,9 @@ diskinfo.elf: crt0.o diskinfo.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 lspci.elf: crt0.o lspci.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+maknetcfg.elf: crt0.o maknetcfg.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 makbox.elf: crt0.o makbox.o

--- a/src/userspace/help.c
+++ b/src/userspace/help.c
@@ -66,6 +66,7 @@ int main(int argc, char **argv)
     PUTS("  echo.elf [args..]            echo arguments\n");
     PUTS("  hello.elf                    hello world\n");
     PUTS("  help.elf                     this help text\n");
+    PUTS("  maknetcfg.elf                show network interface state\n");
 
     return 0;
 }

--- a/src/userspace/incore.sh
+++ b/src/userspace/incore.sh
@@ -35,4 +35,8 @@ echo INCORE: RUN ktest_uspace
 exec /apps/ktest_uspace.elf
 if [ $? -eq 0 ]; then echo INCORE: PASS ktest_uspace; else echo INCORE: FAIL ktest_uspace; fail=1; fi
 
+echo INCORE: RUN maknetcfg
+exec /apps/maknetcfg.elf
+if [ $? -eq 0 ]; then echo INCORE: PASS maknetcfg; else echo INCORE: FAIL maknetcfg; fail=1; fi
+
 if [ $fail -eq 0 ]; then echo INCORE: ALL PASS; else echo INCORE: FAIL; fi

--- a/src/userspace/maknetcfg.c
+++ b/src/userspace/maknetcfg.c
@@ -1,0 +1,33 @@
+#include "syscall.h"
+
+static char buf[1024];
+
+static unsigned int slen(const char *s)
+{
+    unsigned int n = 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static void put_s(const char *s)
+{
+    sys_write(1, s, slen(s));
+}
+
+int main(int argc, char **argv)
+{
+    if (argc > 1) {
+        put_s("Usage: maknetcfg\n");
+        put_s("Shows the active Ethernet netdev and static QEMU-slirp defaults.\n");
+        return 1;
+    }
+
+    (void)argv;
+    int n = sys_net_info(buf, (unsigned int)sizeof(buf));
+    if (n <= 0) {
+        put_s("maknetcfg: no network information available\n");
+        return 1;
+    }
+    sys_write(1, buf, (unsigned int)n);
+    return 0;
+}

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -110,6 +110,7 @@ struct timespec { int tv_sec; int tv_nsec; };
 #define SYS_STAT        106
 #define SYS_FSTAT       108
 #define SYS_READDIR     141
+#define SYS_NET_INFO    253
 
 /* dirent shape -- must match kernel struct dirent in kernel/syscall.h. */
 #define DIRENT_NAME_MAX 256
@@ -622,6 +623,12 @@ static inline int sys_disk_info(char *buf, unsigned int bufsz)
 static inline int sys_pci_info(char *buf, unsigned int bufsz)
 {
     return (int)syscall2(SYS_PCI_INFO, (long)buf, (long)bufsz);
+}
+
+/* Get active Ethernet netdev info as text. Returns bytes written. */
+static inline int sys_net_info(char *buf, unsigned int bufsz)
+{
+    return (int)syscall2(SYS_NET_INFO, (long)buf, (long)bufsz);
 }
 
 /* Delete a file. Returns 0 on success, -1 on error. */


### PR DESCRIPTION
## Summary

This PR lays down the first practical networking path for Makar while keeping the pieces small enough to test independently.

### Core kernel groundwork

- Adds PCI driver registration/binding so device drivers can register match tables and be probed through a common path.
- Reworks physical page allocation around a buddy allocator, including contiguous page block allocation for DMA-style device needs.
- Adds MINIX-style synchronous IPC primitives as early microkernel-oriented plumbing.
- Adds the public virtio-net header and a legacy/transitional virtio-net PCI driver.
- Adds a generic Ethernet `netdev` layer so the rest of the kernel can talk to “the active NIC” without depending directly on virtio internals.

### Networking

- Registers legacy virtio-net as a PCI driver.
- Initializes virtqueues, negotiates MAC/status support, and exposes the device through `netdev`.
- Adds transmit and polled receive entry points for raw Ethernet frames.
- Keeps the virtio-net driver quiet by default: probe/normal TX/RX paths no longer spam serial logs.
- Adds a kernel ARP ktest that sends an ARP request through QEMU slirp and accepts the reply through the generic netdev path when the test VM has the virtio-net device attached.

### Userspace networking tools

- Adds `SYS_NET_INFO`.
- Adds `/apps/maknetcfg.elf`, an `ipconfig`-style interface summary command.
- Wires `maknetcfg.elf` into the userspace build, help output, ISO app staging, and `incore.sh`.
- Current output is intentionally static for IP-layer fields while DHCP/DNS/lwIP are not integrated yet:
  - active Ethernet driver name
  - MAC address
  - link state
  - QEMU slirp defaults for IPv4, mask, gateway, and DNS

### Console/statusbar behavior

- Treats the bottom statusbar row like a Linux/tmux-style reserved console row.
- Adds `vt->usable_rows` so each VT can retain a full physical backing buffer while scrolling/cursor movement only use the currently drawable region.
- When the statusbar is enabled, shell output scrolls at the row above the bar instead of typing behind it.
- When the statusbar is disabled, the full physical height becomes usable again without reallocating VT buffers.
- Keeps the statusbar stable: console scroll/repaint paths no longer repaint or blank the statusbar row on every newline.
- Adds a targeted `vt_status_scroll` ktest to pin the reserved-row behavior.

## Notes

- Regular `./run.sh iso boot` currently does not attach virtio-net, so `maknetcfg.elf` can legitimately report no Ethernet adapter there. The netdev ARP test is covered by the ktest/QEMU network path.
- DHCP, DNS, lwIP integration, ping, wget-lite, and making `maknetcfg` report dynamic IP-layer state are follow-up work.

## Test

- `./run.sh ktest`
  - Result: `KTEST_RESULT: PASS`
  - Total: `833 passed, 0 failed`
  - Includes new `vt_status_scroll` coverage.
- `./run.sh gui ktest`
  - Result: `KTEST_RESULT: PASS`
- `timeout 90 ./run.sh iso boot`
  - Built and booted the normal ISO/HDD path.
  - Mounted ext2 root and CD-ROM.
  - Background ktests reached `KTEST_BG: PASS`.

