### PR TITLE
kernel: higher-half at 0xC0000000

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,14 @@ Bochs VBE, else VGA 80×50) → timer(100Hz)/keyboard/IDE → cmdline parse
 (`test_mode`, `console=ttyS0`, `root=<spec>`) → `vfs_init`/`vfs_mount_root`/
 `vfs_auto_mount` → `tasking_init` + shell/ktest tasks → `syscall_init` → idle.
 
-**Memory map**: `0x0–0x0FFFFFFF` kernel identity (4 MiB pages); `0x40000000`
-ring-3 code; `0x90000000` anon-mmap window; `0xBFFF0000` ring-3 stack top
-(`USER_STACK_PAGES=8`).
+**Memory map** (higher-half kernel): kernel linked at `0xC0000000` (loaded at
+phys 1 MiB via `AT()`); runtime page directory keeps `0x0–0x0FFFFFFF` as a low
+identity window (4 MiB pages) for phys access (PMM frames, MBI, framebuffer,
+ACPI) alongside the `0xC0000000+` high kernel map. User space (below
+`0xC0000000`): `0x40000000` ring-3 code; `0x90000000` anon-mmap window;
+`0xBFFF0000` ring-3 stack top (`USER_STACK_PAGES=8`). Hand any kernel pointer to
+DMA/hardware via `kvirt_to_phys()` (`kernel/paging.h`). TCC in-OS build links
+low-half (`KERNEL_VBASE=0`).
 
 **Subsystems** (source is the source of truth):
 - Tasking/scheduler, per-task `task_t`: `kernel/task.h`, `proc/task.c`

--- a/src/kernel/arch/i386/boot/boot.S
+++ b/src/kernel/arch/i386/boot/boot.S
@@ -10,9 +10,17 @@
 .set MB2_HEADER_LEN,   48
 .set MB2_CHECKSUM,     -(MB2_MAGIC + MB2_ARCH + MB2_HEADER_LEN)
 
+# Higher-half kernel virtual base.  Must match KERNEL_VBASE in linker.ld.
+.set KERNEL_VBASE,     0xC0000000
+# Page directory index of KERNEL_VBASE (0xC0000000 >> 22 = 768).
+.set KERNEL_PD_IDX,    (KERNEL_VBASE >> 22)
+
+# 4 MiB-page PDE flags: present | writable | page-size (PSE large page).
+.set PDE_PRESENT_RW_LARGE, 0x83
+
 # Declare a Multiboot 2 header.  Must be 8-byte aligned and within the
 # first 32768 bytes of the binary image.
-# Under gcc, the linker script places *(.multiboot2) at the front of .text.
+# Under gcc, the linker script places *(.multiboot2) at the front of .boot.
 # TCC's linker has no script support, so under TCC we drop the header into
 # .text directly and rely on boot.o being linked first.
 #ifdef __TINYC__
@@ -43,23 +51,140 @@ mb2_header_start:
 .long  8
 mb2_header_end:
 
-# Reserve a stack for the initial thread.
+# Reserve a stack for the initial thread.  Linked high (.bss); only used once
+# paging is on.
 .section .bss
 .align 16
 stack_bottom:
 .skip 16384 # 16 KiB
 stack_top:
 
-# The kernel entry point.
+#ifndef __TINYC__
+# Static boot page directory, 4 KiB aligned.  Linked high (.bss) so it is
+# zeroed by the Multiboot loader; the boot stub fills the few entries it needs
+# using its PHYSICAL address (virtual - KERNEL_VBASE), since paging is off.
+.align 4096
+.global boot_page_directory
+boot_page_directory:
+.skip 4096
+#endif
+
+#ifdef __TINYC__
+# ---------------------------------------------------------------------------
+# TCC build: no linker script, kernel is linked + runs low-half (identity).
+# Paging stays off here and is enabled later by paging_init().  This is the
+# original, pre-higher-half entry path.
+# ---------------------------------------------------------------------------
 .section .text
 .global _start
 .type _start, @function
 _start:
 	movl $stack_top, %esp
 
-	# Save the MBI pointer (ebx) and multiboot2 magic (eax) before calling
-	# _init, which may clobber caller-saved registers including eax.
 	pushl %eax
+	pushl %ebx
+	call _init
+	popl %ebx
+	popl %eax
+	pushl %ebx
+	pushl %eax
+	call kernel_main
+
+	cli
+1:	hlt
+	jmp 1b
+.size _start, . - _start
+
+#else
+# ---------------------------------------------------------------------------
+# GCC higher-half build.
+#
+# Boot stub.  Linked + loaded at physical 1 MiB and runs with paging OFF, so
+# it lives in .boot where virtual address == physical address.  It builds a
+# minimal page directory (identity-maps the low 16 MiB so EIP/ESP/MBI stay
+# valid the instant paging turns on, and maps 0xC0000000.. -> 0x0.. so the
+# high kernel image becomes reachable), enables paging, then far-jumps into
+# the high virtual image.
+# ---------------------------------------------------------------------------
+.section .boot, "ax"
+.global _start
+.type _start, @function
+_start:
+	cli
+
+	# Stash the Multiboot2 magic (EAX) in ESI before the boot stub uses EAX as
+	# scratch for the PDE flags / CR4 / CR0 below.  ESI is untouched through the
+	# stub and the far jump, so higher_half_entry can recover the magic from it.
+	# (EBX = MBI pointer is never clobbered by the stub, so it needs no save.)
+	movl %eax, %esi
+
+	# Physical address of the boot page directory.
+	movl $(boot_page_directory - KERNEL_VBASE), %edi
+
+	# Identity-map the first 16 MiB: PDE[0..3] -> 0,4,8,12 MiB (4 MiB large
+	# pages).  This covers the boot stub, MBI, GRUB modules and low data so
+	# the instruction stream and stack survive the moment paging turns on.
+	movl $PDE_PRESENT_RW_LARGE, %eax        # phys 0 | flags
+	movl $4, %ecx
+	movl %edi, %ebp
+1:
+	movl %eax, (%ebp)
+	addl $0x00400000, %eax                  # next 4 MiB physical frame
+	addl $4, %ebp
+	loop 1b
+
+	# High-half map: PDE[768..771] (0xC0000000..0xC1000000) -> 0..16 MiB.
+	# Four large pages give the kernel image 16 MiB of headroom (image +
+	# static BSS such as mem_map[] and the boot PD).
+	movl $PDE_PRESENT_RW_LARGE, %eax        # phys 0 | flags
+	leal (KERNEL_PD_IDX * 4)(%edi), %ebp    # &boot_page_directory[768] (phys)
+	movl $4, %ecx
+2:
+	movl %eax, (%ebp)
+	addl $0x00400000, %eax
+	addl $4, %ebp
+	loop 2b
+
+	# Load CR3 with the physical address of the boot page directory.
+	movl %edi, %cr3
+
+	# Enable CR4.PSE so the PS bit in the PDEs selects 4 MiB large pages.
+	movl %cr4, %eax
+	orl  $0x00000010, %eax                  # CR4.PSE
+	movl %eax, %cr4
+
+	# Enable paging (CR0.PG) and write-protect (CR0.WP, bit 16).
+	movl %cr0, %eax
+	orl  $0x80010000, %eax                  # PG | WP
+	movl %eax, %cr0
+
+	# Paging is on.  EIP is still executing from the identity-mapped low copy.
+	# Jump into the high virtual image to load EIP with the high label.  Use
+	# ECX as the scratch register -- NOT EAX (holds the Multiboot2 magic) or
+	# EBX (holds the MBI pointer), which higher_half_entry must still save.
+	leal higher_half_entry, %ecx
+	jmp  *%ecx
+
+# ---------------------------------------------------------------------------
+# From here on we run at high virtual addresses.  This code lives in .text
+# (linked high), so the label resolves to a 0xC01xxxxx address.
+# ---------------------------------------------------------------------------
+.section .text
+.type higher_half_entry, @function
+higher_half_entry:
+	# Switch to the high virtual stack.
+	movl $stack_top, %esp
+
+	# The low identity map (PDE[0..3]) is left in place: the kernel keeps a
+	# permanent identity window for the low physical region (PMM frames,
+	# Multiboot info, VGA buffer, ACPI tables).  paging_init() later installs
+	# the full runtime page directory (256 MiB identity + 256 MiB high).
+
+	# Save the multiboot2 magic (stashed in ESI by _start, since the boot stub
+	# clobbered EAX) and the MBI pointer (EBX) before calling _init, which may
+	# clobber caller-saved registers.  EBX is a PHYSICAL pointer into low
+	# memory; it stays valid via the identity map.
+	pushl %esi
 	pushl %ebx
 
 	# Call the global constructors.
@@ -78,4 +203,6 @@ _start:
 	cli
 1:	hlt
 	jmp 1b
-.size _start, . - _start
+.size higher_half_entry, . - higher_half_entry
+
+#endif /* __TINYC__ */

--- a/src/kernel/arch/i386/drivers/ide.c
+++ b/src/kernel/arch/i386/drivers/ide.c
@@ -12,6 +12,7 @@
  */
 
 #include <kernel/ide.h>
+#include <kernel/paging.h>
 #include <kernel/asm.h>
 #include <kernel/tty.h>
 #include <kernel/serial.h>
@@ -217,12 +218,16 @@ static void bm_setup(uint8_t ch, uint16_t nbytes, int to_mem)
 {
     uint16_t bm = (uint16_t)(s_bmide_base + ch * 8);
 
-    s_prdt[0].addr  = (uint32_t)(uintptr_t)s_dma_buf;  /* phys == virt */
+    /* The BMIDE engine addresses memory physically.  s_dma_buf and s_prdt are
+     * kernel statics linked high under the higher-half kernel, so hand it their
+     * PHYSICAL addresses (kvirt_to_phys); equals the virtual address on the
+     * low-half/identity TCC build. */
+    s_prdt[0].addr  = (uint32_t)kvirt_to_phys(s_dma_buf);
     s_prdt[0].count = nbytes;
     s_prdt[0].flags = 0x8000u;                         /* EOT */
 
     outb(bm + BM_REG_CMD, 0x00);                       /* stop engine */
-    outl(bm + BM_REG_PRDT, (uint32_t)(uintptr_t)s_prdt);
+    outl(bm + BM_REG_PRDT, (uint32_t)kvirt_to_phys(s_prdt));
     outb(bm + BM_REG_CMD, to_mem ? BM_CMD_TO_MEM : 0x00);
     outb(bm + BM_REG_STATUS, (uint8_t)(BM_SR_ERR | BM_SR_IRQ)); /* W1C */
 }

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -211,8 +211,9 @@ static void render_meminfo(pf_writer_t *w)
      * the kernel image into the total) so MemUsed reflects the real working
      * set instead of sitting near zero on a freshly booted 32 MiB system --
      * this is what maktop and the statusbar mem widget display. */
-    extern uint32_t _kernel_end;
-    uint32_t kernel_kb    = (uint32_t)&_kernel_end / 1024u;
+    /* Higher-half kernel: _kernel_phys_end is the physical end of the image. */
+    extern uint32_t _kernel_phys_end;
+    uint32_t kernel_kb    = (uint32_t)&_kernel_phys_end / 1024u;
     uint32_t heap_used_kb = (uint32_t)(heap_u / 1024u);
     uint32_t total_kb = total_frames * 4u + kernel_kb;
     uint32_t used_kb  = used_frames  * 4u + heap_used_kb + kernel_kb;

--- a/src/kernel/arch/i386/linker.ld
+++ b/src/kernel/arch/i386/linker.ld
@@ -2,47 +2,75 @@
    designated at the entry point. */
 ENTRY(_start)
 
-/* Tell where the various sections of the object files will be put in the final
-   kernel image. */
+/* Higher-half kernel.
+ *
+ * The kernel is *loaded* by GRUB at physical 1 MiB (the conventional spot) but
+ * *linked* to run at virtual 0xC0100000 (KERNEL_VBASE + 1 MiB).  The boot stub
+ * in boot.S runs at its physical address with paging off, builds a page
+ * directory mapping the kernel both identity (low) and at 0xC0000000, turns
+ * paging on, then far-jumps into the high virtual image.
+ *
+ * The .boot section (early entry + the static boot page tables) is the only
+ * code that runs with paging off, so it is linked at its physical load address
+ * (no virtual offset).  Everything else is linked high and placed at a low
+ * physical LMA via AT(ADDR(.section) - KERNEL_VBASE).
+ */
+KERNEL_VBASE = 0xC0000000;
+
 SECTIONS
 {
-	/* Begin putting sections at 1 MiB, a conventional place for kernels to be
-	   loaded at by the bootloader. */
+	/* The boot stub: linked + loaded at physical 1 MiB.  Runs with paging
+	   off, so its virtual address must equal its physical address.  The
+	   Multiboot 2 header must live very early in the image, so it goes here
+	   too.  _start (the Multiboot entry) therefore has a low (physical)
+	   address, which is what the bootloader jumps to and what the GDB boot
+	   test breaks on while paging is still off. */
 	. = 1M;
 
-	/* First put the Multiboot 2 header, as it is required to be put very
-	   early in the image or the bootloader won't recognize the file format.
-	   The Multiboot 2 spec requires the header to be 8-byte aligned and
-	   within the first 32768 bytes of the binary.
-	   Next we'll put the .text section. */
-	.text BLOCK(4K) : ALIGN(4K)
+	_kernel_phys_start = .;
+
+	.boot BLOCK(4K) : ALIGN(4K)
 	{
 		*(.multiboot2)
+		*(.boot)
+	}
+
+	/* The rest of the kernel is linked high (KERNEL_VBASE + ...) but loaded
+	   immediately after the boot stub in physical memory. */
+	. += KERNEL_VBASE;
+
+	.text BLOCK(4K) : AT(ADDR(.text) - KERNEL_VBASE) ALIGN(4K)
+	{
 		*(.text)
 	}
 
 	/* Read-only data. */
-	.rodata BLOCK(4K) : ALIGN(4K)
+	.rodata BLOCK(4K) : AT(ADDR(.rodata) - KERNEL_VBASE) ALIGN(4K)
 	{
 		*(.rodata)
 	}
 
 	/* Read-write data (initialized) */
-	.data BLOCK(4K) : ALIGN(4K)
+	.data BLOCK(4K) : AT(ADDR(.data) - KERNEL_VBASE) ALIGN(4K)
 	{
 		*(.data)
 	}
 
 	/* Read-write data (uninitialized) and stack */
-	.bss BLOCK(4K) : ALIGN(4K)
+	.bss BLOCK(4K) : AT(ADDR(.bss) - KERNEL_VBASE) ALIGN(4K)
 	{
 		*(COMMON)
 		*(.bss)
 	}
 
-	/* Symbol marking the end of the kernel image. Used by the PMM to
-	   determine which physical frames are occupied by the kernel. */
+	/* Symbol marking the end of the kernel image.  Used by the PMM to
+	   determine which physical frames are occupied by the kernel.  This is a
+	   *virtual* (high) address; the PMM subtracts KERNEL_VBASE to get the
+	   physical end. */
 	_kernel_end = .;
+
+	/* Physical end of the loaded kernel image, for the PMM reservation. */
+	_kernel_phys_end = . - KERNEL_VBASE;
 
 	/* The compiler may produce other sections, put them in the proper place in
 	   in this file, if you'd like to include them in the final kernel. */

--- a/src/kernel/arch/i386/mm/paging.c
+++ b/src/kernel/arch/i386/mm/paging.c
@@ -33,6 +33,29 @@
    of additional mappable virtual address space.                              */
 #define EXTRA_PAGE_TABLES 32
 
+/* Higher-half kernel virtual base (must match KERNEL_VBASE in linker.ld and
+ * boot.S).  The kernel image and all its static structures (page_directory[],
+ * extra_page_tables[], mem_map[], ...) are linked at KERNEL_VBASE + phys, but
+ * the low physical region is also permanently identity-mapped (the boot stub
+ * sets up PDE[0..3] and paging_init() extends the identity window to 256 MiB).
+ *
+ * CR3 and PDE entries need PHYSICAL addresses; a kernel static address minus
+ * KERNEL_VBASE yields its physical address. */
+/* The in-OS TCC rebuild (build-kernel-tcc.sh / rebuild-kernel.sh) has no GNU
+ * ld script and links the kernel low-half (identity).  In that case KERNEL_VBASE
+ * is 0 so V2P() is the identity and the "high" PD window coincides with the
+ * low one -- the kernel stays at its physical address.  The gcc build links
+ * higher-half at 0xC0000000 (linker.ld + boot.S). */
+#ifdef __TINYC__
+#define KERNEL_VBASE   0x00000000u
+#else
+#define KERNEL_VBASE   0xC0000000u
+#endif
+#define V2P(x)         ((uint32_t)(x) - KERNEL_VBASE)
+
+/* First high page-directory index (0xC0000000 >> 22 = 768; 0 under TCC). */
+#define KERNEL_PD_IDX  (KERNEL_VBASE >> 22)
+
 /* Page-entry flags */
 #define PAGE_PRESENT   0x1u
 #define PAGE_WRITABLE  0x2u
@@ -107,15 +130,25 @@ void paging_init(void)
     cr4 |= (1u << 4);   /* PSE – Page Size Extensions */
     asm volatile("mov %0, %%cr4" :: "r"(cr4) : "memory");
 
-    /* Identity-map 0–256 MiB: one PDE per 4 MiB region, PS bit set.
-       No intermediate page table is needed for these entries.              */
+    /* Build the runtime page directory.  Two windows, both via 4 MiB PSE
+       large pages, both pointing at the same low physical memory:
+         • Identity window  0x00000000..0x10000000 (PDE 0..63)   -> phys 0..256M
+         • Higher-half      0xC0000000..0xD0000000 (PDE 768..831)-> phys 0..256M
+       The kernel runs at the higher-half addresses; the identity window is kept
+       permanently so the PMM/heap/VMM can dereference low physical frames as
+       (uint32_t *)phys, the Multiboot info pointer (a low physical address in
+       EBX) stays reachable, and the VGA buffer / ACPI tables map phys==virt.   */
     for (uint32_t i = 0; i < IDENTITY_LARGE_PAGES; i++) {
         uint32_t phys = i * LARGE_PAGE_SIZE;
-        page_directory[i] = phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_LARGE;
+        uint32_t pde  = phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_LARGE;
+        page_directory[i]                 = pde;   /* identity  */
+        page_directory[KERNEL_PD_IDX + i] = pde;   /* higher-half */
     }
 
-    /* Load CR3 with the physical address of the page directory. */
-    asm volatile("mov %0, %%cr3" :: "r"(page_directory) : "memory");
+    /* Load CR3 with the PHYSICAL address of the page directory (it is a kernel
+       static, so its linked address is high; subtract KERNEL_VBASE).  This
+       replaces the minimal boot page directory built in boot.S.              */
+    asm volatile("mov %0, %%cr3" :: "r"(V2P(page_directory)) : "memory");
 
     /* Enable paging and write-protect:
      *   bit 31 (PG): turn paging on.
@@ -132,8 +165,8 @@ void paging_init(void)
 
     paging_init_pat();
 
-    t_writestring("Paging: enabled (identity-mapped 0-256 MiB, 4 MiB large pages, WP on)\n");
-    KLOG("paging_init: 256 MiB identity map via PSE large pages, CR0.WP=1\n");
+    t_writestring("Paging: higher-half (0xC0000000->0, +256 MiB identity, 4 MiB pages, WP on)\n");
+    KLOG("paging_init: higher-half kernel @ 0xC0000000, 256 MiB identity + high map, CR0.WP=1\n");
 }
 
 static void map_region_flags(uint32_t phys_start, uint32_t size, uint32_t extra_flags)
@@ -179,10 +212,13 @@ static void map_region_flags(uint32_t phys_start, uint32_t size, uint32_t extra_
             for (uint32_t i = 0; i < 1024; i++)
                 pt[i] = 0;
 
-            page_directory[pdi] = (uint32_t)pt | PAGE_PRESENT | PAGE_WRITABLE;
+            /* PDE stores the PHYSICAL address of the page table.  extra_page_tables
+               is a kernel static (high virtual); subtract KERNEL_VBASE.          */
+            page_directory[pdi] = V2P(pt) | PAGE_PRESENT | PAGE_WRITABLE;
         }
 
-        /* Map the 4 KiB page if it is not already present. */
+        /* Map the 4 KiB page if it is not already present.  The PDE holds a
+           physical PT address; dereference it through the low identity map. */
         uint32_t *pt = (uint32_t *)(page_directory[pdi] & ~0xFFFu);
         if (!(pt[pti] & PAGE_PRESENT))
             pt[pti] = addr | PAGE_PRESENT | PAGE_WRITABLE | extra_flags;

--- a/src/kernel/arch/i386/mm/pmm.c
+++ b/src/kernel/arch/i386/mm/pmm.c
@@ -118,7 +118,10 @@ static void buddy_free(uint32_t f, uint32_t order)
 
 void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 {
-	extern uint32_t _kernel_end;
+	/* The kernel is linked higher-half; _kernel_phys_end is the PHYSICAL end
+	 * of the loaded image (linker.ld computes it as _kernel_end - KERNEL_VBASE).
+	 * Use it directly so the kernel reservation lands in low physical frames. */
+	extern uint32_t _kernel_phys_end;
 
 	/* Everything starts reserved: a zeroed descriptor table means refcount 0,
 	 * no PG_BUDDY, off every free list -- i.e. not allocatable until freed. */
@@ -160,7 +163,7 @@ void pmm_init(uint32_t magic, multiboot2_info_t *mbi)
 	 * null page (guards NULL derefs) and the whole kernel image, which on
 	 * this build includes mem_map[] itself (static BSS below _kernel_end). */
 	uint32_t kstart = 0x100000 / PMM_FRAME_SIZE;
-	uint32_t kend   = ((uint32_t)&_kernel_end + PMM_FRAME_SIZE - 1) / PMM_FRAME_SIZE;
+	uint32_t kend   = ((uint32_t)&_kernel_phys_end + PMM_FRAME_SIZE - 1) / PMM_FRAME_SIZE;
 
 	/* Free every usable frame within the managed window into the buddy pool.
 	 * Ascending order lets even/odd pairs coalesce as we go. */

--- a/src/kernel/arch/i386/mm/vmm.c
+++ b/src/kernel/arch/i386/mm/vmm.c
@@ -9,6 +9,25 @@
 #define PAGE_USER      0x4u
 #define PAGE_LARGE     0x80u
 
+/* Higher-half kernel virtual base (must match KERNEL_VBASE in linker.ld /
+ * boot.S / paging.c).  Per-task user page directories come from
+ * pmm_alloc_frame() and so are addressed by their (low) physical address,
+ * which equals their virtual address via the permanent identity map.  The
+ * kernel's own page directory, however, is a kernel static linked high; its
+ * pointer is >= KERNEL_VBASE and must be converted to a physical address
+ * before it can be loaded into CR3.  v2p_pd() does that translation. */
+#ifdef __TINYC__
+#define KERNEL_VBASE   0x00000000u   /* low-half TCC build: identity */
+#else
+#define KERNEL_VBASE   0xC0000000u
+#endif
+
+static inline uint32_t v2p_pd(uint32_t *pd)
+{
+    uint32_t a = (uint32_t)pd;
+    return (a >= KERNEL_VBASE) ? (a - KERNEL_VBASE) : a;
+}
+
 uint32_t *vmm_create_pd(void)
 {
     uint32_t phys = pmm_alloc_frame();
@@ -66,16 +85,19 @@ void vmm_unmap_page(uint32_t *pd, uint32_t virt)
 
     pt[pti] = 0;
 
-    /* Flush TLB entry only if this PD is currently loaded. */
+    /* Flush TLB entry only if this PD is currently loaded.  CR3 holds a
+       physical address; translate pd before comparing. */
     uint32_t cr3;
     asm volatile("mov %%cr3, %0" : "=r"(cr3));
-    if (cr3 == (uint32_t)pd)
+    if (cr3 == v2p_pd(pd))
         asm volatile("invlpg (%0)" :: "r"(virt) : "memory");
 }
 
 void vmm_switch(uint32_t *pd)
 {
-    asm volatile("mov %0, %%cr3" :: "r"((uint32_t)pd) : "memory");
+    /* CR3 needs a physical address.  User PDs are physical already; the kernel
+       PD is a high-linked static and must be translated down. */
+    asm volatile("mov %0, %%cr3" :: "r"(v2p_pd(pd)) : "memory");
 }
 
 /* Kernel identity-map upper bound (paging.c maps 0-256 MiB via 4 MiB PSE

--- a/src/kernel/include/kernel/paging.h
+++ b/src/kernel/include/kernel/paging.h
@@ -3,6 +3,26 @@
 
 #include <stdint.h>
 
+/* Higher-half kernel virtual base (must match KERNEL_VBASE in linker.ld,
+ * boot.S, paging.c and vmm.c).  The in-OS TCC rebuild links the kernel
+ * low-half (identity), so KERNEL_VBASE is 0 there. */
+#ifdef __TINYC__
+#define KERNEL_VBASE   0x00000000u
+#else
+#define KERNEL_VBASE   0xC0000000u
+#endif
+
+/* Physical address of a kernel pointer.  Kernel statics are linked high
+ * (>= KERNEL_VBASE) and mapped 0xC0000000->0x0, so their physical address is
+ * (virt - KERNEL_VBASE); anything already below KERNEL_VBASE is in the
+ * permanent low identity window (phys == virt).  Use this for any value handed
+ * to hardware that does physical addressing -- e.g. DMA PRD / PRDT entries. */
+static inline uintptr_t kvirt_to_phys(const void *p)
+{
+    uintptr_t a = (uintptr_t)p;
+    return (a >= KERNEL_VBASE) ? (a - KERNEL_VBASE) : a;
+}
+
 /* Set up paging:
  *   - enable CR4.PSE (Page Size Extensions)
  *   - identity-map the first 256 MiB using 4 MiB large pages (PS bit set),

--- a/src/userspace/kend.S
+++ b/src/userspace/kend.S
@@ -1,13 +1,17 @@
 /*
- * kend.S -- supplies the _kernel_end symbol consumed by pmm_init.
+ * kend.S -- supplies the _kernel_end / _kernel_phys_end symbols consumed by
+ * pmm_init (and procfs meminfo).
  *
- * The host kernel build gets this from arch/i386/linker.ld (`_kernel_end = .;`
- * after all sections).  The TCC link recipe used by build-kernel-tcc.sh and
- * the in-OS rebuild-kernel.sh has no GNU ld script support, so we emit the
- * symbol manually and link this object LAST -- it lands at the high end of
- * .bss and gives the same semantics.
+ * The host kernel build gets these from arch/i386/linker.ld (`_kernel_end = .;`
+ * and `_kernel_phys_end = . - KERNEL_VBASE;` after all sections).  The TCC link
+ * recipe used by build-kernel-tcc.sh and the in-OS rebuild-kernel.sh has no GNU
+ * ld script support, so we emit the symbols manually and link this object LAST
+ * -- it lands at the high end of .bss and gives the same semantics.  The TCC
+ * kernel is linked low-half (identity), so its physical end equals _kernel_end.
  */
 .section .bss
 .global _kernel_end
+.global _kernel_phys_end
 _kernel_end:
+_kernel_phys_end:
 .byte 0


### PR DESCRIPTION
Converts the kernel from lower-half (linked/run at phys+virt 1 MiB, identity) to a **higher-half kernel based at 0xC0000000**.

- linker.ld: kernel linked at 0xC0100000, loaded at phys 1 MiB via AT(); a .boot stub (VA==PA) builds a boot page directory (identity low 16 MiB + 0xC0000000->0x0, 4 MiB PSE), enables paging+WP, jumps high, switches to the high stack. paging_init installs the runtime PD (256 MiB identity + 256 MiB high). vmm/paging/pmm/procfs use a KERNEL_VBASE V2P for CR3/PDE phys + image end. #ifdef __TINYC__ keeps the in-OS TCC rebuild low-half.
- Boot-register fix: the Multiboot2 magic (EAX) was clobbered by the stub's CR4/CR0 scratch use before it was saved (PMM got no memory -> fault). Stash it in ESI at _start; far-jump via ECX.
- DMA phys-addr fix: the BMIDE bounce buffer + PRDT are kernel statics linked high, but the engine addresses memory physically -- added kvirt_to_phys() (paging.h) and applied it to the PRD entry + PRDT register (CD/disk reads were failing).

User space is unchanged (it already lived below 0xC0000000). Layout hygiene, not a perf change.

Gates green: ktest PASS (852), gdb iso ALL GROUPS PASSED, guitest GUI: READY.