### PR TITLE
GUI: window chrome/resize + tmux-style VTs (/dev/ttyN, per-tab statusbar)

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -150,6 +150,29 @@ live VFS (descend a real dir, confirm the cwd deepened, climb back) and emits
 headless-safe — this is the automated proof that "Files actually moves about the
 filesystem" without needing pixels.
 
+## Text-mode VTs, /dev/ttyN, and the per-tab status bar
+
+Outside the GUI, the text console runs `makmux` — a tmux-style virtual-terminal
+multiplexer (`src/userspace/makmux.c`). There are nine user VT slots plus a
+hidden root console; full model in [kernel/vtty](kernel/vtty.md). The relevant
+points for the desktop story:
+
+- **/dev/ttyN.** Every VT slot is addressable as a Linux-style character node:
+  `/dev/tty0` is the root console (mak.sh0) and `/dev/tty1`..`/dev/tty9` are the
+  nine makmux slots (slot `i` == `/dev/tty(i+1)`). Writing to one streams into
+  that VT's backing grid (`echo hi > /dev/tty2`); reads are EOF. They are always
+  present and ride the existing devfs `SYS_OPEN`/`SYS_WRITE` path — no new
+  syscall.
+- **tmux-style tabs.** makmux opens **one** shell by default; further tabs are
+  created on demand with **Alt+T** (`SYS_VT_OPEN_REQUEST`), up to nine. Alt+F1–F4
+  jump to the first four; Alt+Tab / Ctrl+Tab cycle the rest.
+- **Per-tab status bar.** `statusbar.elf` renders the layout of the *active* VT
+  (read from `SYS_VT_STATE`). Each tab can own its bar via `~/.sbrc.tty<N>`
+  (the `/dev/ttyN` number; root = `tty0`), which overrides the shared `~/.sbrc`;
+  switching tabs reloads and re-renders that tab's own bar. Layout/widget format
+  is the same `<section> <widget>...` `.sbrc` grammar (`left`/`center`/`right`
+  with `hostname user date time cpu mem rootfs command tabs`).
+
 ## DOOM windowed backend (`doomgeneric_makar.c`)
 
 `-surface <id>` selects windowed mode: `DG_Init` maps the surface instead of the

--- a/docs/kernel/vtty.md
+++ b/docs/kernel/vtty.md
@@ -10,19 +10,35 @@ grand_parent: Reference
 
 ## Purpose
 
-`VTTY_MAX = 5` slots exist in total:
+`VTTY_MAX = 10` slots exist in total:
 
-- **Slots 0–3** are the user-visible VT shells (makmux's VT1–VT4, switched via
-  Alt+F1–F4 or Ctrl+Tab / Ctrl+Shift+Tab).
-- **Slot 4 (`VTTY_ROOT_SLOT`)** is the hidden root console for mak.sh0. It has
-  a full backing buffer so mak.sh0's screen content is preserved across makmux
-  sessions, but it is excluded from Alt+Fn switching, Ctrl+Tab cycling,
-  `vtty_live_mask()`, and `vtty_count()` — exactly like Linux's tty0/console.
+- **Slots 0–8** are the nine user-visible VT shells (makmux's VT1–VT9). They
+  map 1:1 to the userspace numbering exposed under `/dev`: **slot `i` ==
+  `/dev/tty(i+1)`**. Alt+F1–F4 jump directly to slots 0–3; the rest are reached
+  by Alt+Tab / Ctrl+Tab (forward) and Alt+Shift+Tab / Ctrl+Shift+Tab (back).
+- **Slot 9 (`VTTY_ROOT_SLOT`)** is the hidden root console for mak.sh0, exposed
+  as `/dev/tty0`. It has a full backing buffer so mak.sh0's screen content is
+  preserved across makmux sessions, but it is excluded from Alt+Fn switching,
+  Ctrl+Tab cycling, `vtty_live_mask()`, and `vtty_count()` — exactly like
+  Linux's tty0/console.
+
+makmux drives these slots tmux-style: **one** shell exists by default and more
+are created on demand via Alt+T (`SYS_VT_OPEN_REQUEST`), up to nine.
 
 Only the active VT paints to the physical framebuffer; background VTs keep
 writing into their own [vt_buf_t](vt.md) and the accumulated state is
 repainted atomically when the user switches back. This is Linux's classic VT
 model.
+
+## /dev/ttyN nodes
+
+Every slot is addressable by a stable Linux-style path: `devfs` registers a
+`DEV_TTY` node for `/dev/tty0` (root console) and `/dev/tty1`..`/dev/tty9` (the
+nine user slots), always present regardless of makmux state. They are character
+sinks, not block devices — reads return EOF, and a write streams into the
+slot's backing grid via `vtty_write()` (painting the framebuffer when that VT
+is focused), so `echo hi > /dev/tty2` lands on VT2. `devfs_node_location`
+rejects them, so they can't be mounted.
 
 ## Authoritative state
 
@@ -31,9 +47,9 @@ bound to. vtty itself owns:
 
 | Field | Purpose |
 |---|---|
-| `vtty_nslots` | Number of registered user-visible slots (0–4; **excludes** `VTTY_ROOT_SLOT`) |
+| `vtty_nslots` | High-water number of registered user-visible slots (0–9; **excludes** `VTTY_ROOT_SLOT`) |
 | `vtty_current` | Index of the focused user-visible slot |
-| `vtty_bufs[VTTY_MAX]` | Per-slot [vt_buf_t](vt.md) backing grids (5 total) |
+| `vtty_bufs[VTTY_MAX]` | Per-slot [vt_buf_t](vt.md) backing grids (10 total) |
 | `vtty_pending` | Deferred-paint target (set in IRQ, drained in task context) |
 
 The "owning task" of slot N is resolved by walking the task pool for the
@@ -43,32 +59,33 @@ exec children inherit `tty` but always have higher pids).
 ## Root slot semantics
 
 mak.sh0 (the underlying ring-3 login shell spawned at boot) occupies
-`VTTY_ROOT_SLOT = 4` via `vtty_register_root()`:
+`VTTY_ROOT_SLOT = 9` (exposed as `/dev/tty0`) via `vtty_register_root()`:
 
 - `vtty_nslots` is **not** incremented, so the slot is invisible to
   `vtty_count()` and the Ctrl+Tab cycling range.
-- `vtty_buf_focused()` returns `vtty_bufs[4]` when `vtty_nslots == 0`
-  (no makmux VTs active), so mak.sh0's writes render to the framebuffer
-  normally.
-- `vtty_is_focused()` returns true for slot 4 whenever `vtty_nslots == 0`.
+- `vtty_buf_focused()` returns `vtty_bufs[VTTY_ROOT_SLOT]` when
+  `vtty_nslots == 0` (no makmux VTs active), so mak.sh0's writes render to the
+  framebuffer normally.
+- `vtty_is_focused()` returns true for the root slot whenever `vtty_nslots == 0`.
 - `task_fork` strips `VTTY_ROOT_SLOT` from children — they inherit
   `TASK_TTY_NONE` instead. This prevents makmux and its sh.elf children from
-  writing into `vtty_bufs[4]` and corrupting mak.sh0's preserved content.
+  writing into the root slot's grid and corrupting mak.sh0's preserved content.
 - When all makmux VTs close (`vtty_nslots` → 0), `vtty_close_pid` calls
   `vesa_tty_set_status_visible(0)` to erase the stale status-bar row, then
-  `SYS_WAIT4` requests a repaint of slot 4 — restoring mak.sh0's prior screen.
+  `SYS_WAIT4` requests a repaint of the root slot — restoring mak.sh0's screen.
 
 ## API
 
 | Function | Purpose |
 |---|---|
-| `vtty_init()` | Allocate five backing grids sized to the display geometry (last row reserved for the status bar). |
-| `vtty_register()` | Called by each makmux child via `SYS_VT_ENTER`. Assigns the calling task to the next free slot (0–3) and increments `vtty_nslots`. |
-| `vtty_register_root()` | Called by mak.sh0 at boot. Assigns `VTTY_ROOT_SLOT = 4` without touching `vtty_nslots`, making it permanently invisible to switching and the status bar. |
+| `vtty_init()` | Allocate ten backing grids sized to the display geometry (last row reserved for the status bar). |
+| `vtty_register()` | Called by each makmux child via `SYS_VT_ENTER`. Assigns the calling task to the next free slot (0–8) and raises the `vtty_nslots` high-water mark. |
+| `vtty_register_root()` | Called by mak.sh0 at boot. Assigns `VTTY_ROOT_SLOT = 9` without touching `vtty_nslots`, making it permanently invisible to switching and the status bar. |
 | `vtty_switch(n)` | Called from the keyboard IRQ when Alt+F<n+1> or Ctrl+Tab fires. Rejects `VTTY_ROOT_SLOT`. Updates focus, sends `KEY_FOCUS_GAIN` to the new owner, records a pending repaint target. Returns immediately — the paint is deferred. |
+| `vtty_write(n, buf, len)` | Stream bytes into slot `n`'s backing grid (the `/dev/ttyN` write sink); repaints the framebuffer if `n` is focused. |
 | `vtty_drain_pending()` | Drains a deferred switch repaint: if one is pending *and the calling task is on the destination TTY*, repaint that TTY's backing grid to the framebuffer (CAS'd so it fires exactly once per switch). Called from `keyboard_getchar`'s wait loop **and from the `SYS_YIELD` handler** so fullscreen ring-3 apps that never read the keyboard still flush the repaint. |
 | `vtty_close_pid(pid)` | Unregisters a VT child. Rejects `VTTY_ROOT_SLOT`. When `vtty_nslots` drops to 0, clears the status bar row. |
-| `vtty_buf(n)` / `vtty_buf_current()` / `vtty_buf_focused()` | Accessors for renderer code. `vtty_buf_focused()` returns `vtty_bufs[4]` when `vtty_nslots == 0`. |
+| `vtty_buf(n)` / `vtty_buf_current()` / `vtty_buf_focused()` | Accessors for renderer code. `vtty_buf_focused()` returns the root slot's grid when `vtty_nslots == 0`. |
 | `vtty_active()` / `vtty_count()` / `vtty_is_focused()` / `vtty_live_mask()` | State queries. All exclude `VTTY_ROOT_SLOT`. |
 | `vtty_request_repaint(slot)` | Deferred repaint trigger used by `SYS_WAIT4` after a fullscreen child exits. |
 
@@ -82,24 +99,30 @@ in task context keeps the IRQ short.
 
 ## Status bar
 
-The status bar is drawn entirely in **userspace** by `makmux.elf` via
+The status bar is drawn entirely in **userspace** by `statusbar.elf` via
 `SYS_PUTCH_AT`. The kernel only reserves the bottom framebuffer row
 (`VESA_TTY_STATUS_ROWS = 1`) and exposes `vesa_tty_paint_cell` so cells at
 `row >= pane_rows` bypass the default-pane clipping and reach the status row.
 
-The bar shows tab indicators `VT1 VT2 VT3 VT4` on an **amber/brown**
-background (`VGA_BROWN = 0xAA5500`), with the active slot highlighted in
-yellow-on-black. Alt+F5 toggles a live RTC clock in the label area.
+The bar shows tab indicators `VT1`..`VT9` on an **amber/brown** background
+(`VGA_BROWN = 0xAA5500`), with the active slot highlighted in yellow-on-black.
+
+The bar is **per-tab**: `statusbar.elf` renders the layout belonging to the
+active VT, read from `SYS_VT_STATE`. Each tab can own its layout via
+`~/.sbrc.tty<N>` (the `/dev/ttyN` number; root console = `tty0`), which
+overrides the shared `~/.sbrc`; switching VTs reloads and re-renders that tab's
+own bar. See [GUI](../gui.md) for the `.sbrc` widget format.
 
 **Switching shortcuts:**
 
 | Shortcut | Action |
 |---|---|
 | Alt+F1–F4 | Jump to VT 1–4 directly |
-| Ctrl+Tab | Cycle to the next VT |
-| Ctrl+Shift+Tab | Cycle to the previous VT |
+| Alt+T | Open a new tab (tmux-style; up to nine) |
+| Alt+Tab / Ctrl+Tab | Cycle to the next VT |
+| Alt+Shift+Tab / Ctrl+Shift+Tab | Cycle to the previous VT |
 
-Ctrl+Tab / Ctrl+Shift+Tab were added for Windows hosts where Alt+F4 is
+Ctrl+Tab / Ctrl+Shift+Tab were added for Windows hosts where Alt+Tab/Alt+F4 is
 captured by the OS.
 
 ## Display isolation for ring-3 apps
@@ -113,6 +136,6 @@ backgrounded fullscreen app can't bleed onto whatever VT is currently shown:
 - `SYS_DRAW_LINE` (raw pixels, no grid representation) is suppressed entirely
   when the task isn't on the active VT; the app redraws on its next frame.
 
-`VTTY_MAX = 5` (four user-visible slots + one hidden root console), and the
-task pool (`MAX_TASKS`) is 32, leaving room for a fullscreen app on every VT
-plus headroom.
+`VTTY_MAX = 10` (nine user-visible slots + one hidden root console), and the
+task pool (`MAX_TASKS`) is 32, leaving room for a fullscreen app on the active
+VTs plus headroom.

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -215,8 +215,8 @@ VT/app-tab syscalls support the userspace multiplexer:
 |---|---|
 | `SYS_VT_ENTER` | bind a task to a new VT slot |
 | `SYS_VT_CLOSE` | close/free a VT owner pid |
-| `SYS_VT_OPEN_REQUEST` | request another shell VT |
-| `SYS_VT_STATE` | return live VT state |
+| `SYS_VT_OPEN_REQUEST` | request another shell VT (the Alt+T route) |
+| `SYS_VT_STATE` | return live VT state: `(focused_slot << 16) \| live_mask` |
 | `SYS_VT_OPEN_APP` | queue or switch to a named app tab |
 | `SYS_VT_TAKE_APP` | makmux drains one queued app path |
 | `SYS_VT_SETNAME` | name the current VT/app tab |
@@ -224,6 +224,23 @@ VT/app-tab syscalls support the userspace multiplexer:
 
 `SYS_VT_TAKE_APP` is currently number 248. It was moved off 243 so Linux i386
 `set_thread_area` could use its standard number.
+
+There are **nine user-visible VT slots** (kernel slots 0–8) plus a hidden root
+console (`VTTY_ROOT_SLOT`). They are exposed to userspace as Linux-style
+character nodes under `/dev`:
+
+| Path | Slot | Notes |
+|---|---|---|
+| `/dev/tty0` | `VTTY_ROOT_SLOT` | the root console (mak.sh0), hidden from the tab strip |
+| `/dev/tty1` … `/dev/tty9` | 0 … 8 | the nine makmux VT slots (slot == ttyN − 1) |
+
+These nodes are **always present** (independent of makmux). They are character
+sinks, not block devices: reads return EOF, and a write streams into that
+slot's backing grid (`vtty_write`), painting the framebuffer if the VT is
+focused — e.g. `echo hi > /dev/tty2`. No new syscall: writes ride the existing
+`SYS_OPEN`/`SYS_WRITE` block-device fd path through devfs. makmux is tmux-style
+— it opens **one** shell by default and grows more on the `SYS_VT_OPEN_REQUEST`
+(Alt+T) route, up to nine.
 
 ## TLS Details
 

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1324,10 +1324,27 @@ void keyboard_test_driver(void)
     keyboard_inject_text("echo KBTEST_CTRLC_OK\n");
     ksleep(150);
 
-    /* 2: makmux + Alt-Tab / Alt-Shift-Tab VT cycling.  Asserts directly on
-     *    in-kernel state (vtty_active) -- no serial-scrape needed. */
+    /* 2: makmux + Alt-Tab / Alt-Shift-Tab VT cycling.  makmux is tmux-style:
+     *    it opens exactly ONE shell (VT1) at startup, so prove the on-demand
+     *    route first -- Alt+T (SYS_VT_OPEN_REQUEST) must grow a second tab --
+     *    then assert cycling on in-kernel state (vtty_active).  No
+     *    serial-scrape needed. */
     keyboard_inject_text("makmux\n");
-    ksleep(400);                /* let makmux fork mak.sh1-4 + take focus */
+    ksleep(400);                /* let makmux fork the first shell + take focus */
+    if (vtty_count() == 1) {
+        Serial_WriteString("KBTEST: makmux-default-1 PASS\n");
+    } else {
+        Serial_WriteString("KBTEST: makmux-default-1 FAIL\n");
+        pass = 0;
+    }
+    keyboard_inject_key(KC_T, 0, 0, 1);     /* Alt+T -> open a second tab */
+    ksleep(300);                /* makmux drains the open request + forks VT2 */
+    if (vtty_count() > 1) {
+        Serial_WriteString("KBTEST: alt-t-newtab PASS\n");
+    } else {
+        Serial_WriteString("KBTEST: alt-t-newtab FAIL\n");
+        pass = 0;
+    }
     if (vtty_count() > 1) {
         int a0 = vtty_active();
         keyboard_inject_key(KC_TAB, 0, 0, 1);   /* Alt+Tab       -> forward  */
@@ -1378,7 +1395,7 @@ void keyboard_test_driver(void)
          *    mak.sh0 (the root console).  Asserts vtty_count() drops to 0. */
         keyboard_inject_text("q");          /* quit maktop (q/Esc/F10) */
         ksleep(150);
-        for (int e = 0; e < 5; e++) {       /* exit the four VT shells */
+        for (int e = 0; e < 5; e++) {       /* exit the open VT shells (VT1/VT2) */
             keyboard_inject_text("exit\n");
             ksleep(120);
         }

--- a/src/kernel/arch/i386/fs/devfs.c
+++ b/src/kernel/arch/i386/fs/devfs.c
@@ -6,6 +6,7 @@
 #include <kernel/ide.h>
 #include <kernel/partition.h>
 #include <kernel/tty.h>
+#include <kernel/vtty.h>
 #include <string.h>
 
 #define DEVFS_MAX_NODES   32
@@ -16,11 +17,12 @@ typedef enum {
     DEV_DISK = 0,   /* whole ATA disk          */
     DEV_PART,       /* ATA partition window    */
     DEV_CDROM,      /* ATAPI optical drive     */
+    DEV_TTY,        /* virtual terminal (/dev/ttyN -> vtty slot) */
 } dev_kind_t;
 
 typedef struct {
     char       name[16];   /* node name, no leading '/' (e.g. "hda1")   */
-    uint8_t    drive;      /* IDE drive index 0-3                       */
+    uint8_t    drive;      /* IDE drive index 0-3 (DEV_TTY: vtty slot)  */
     uint8_t    kind;       /* dev_kind_t                                 */
     uint8_t    readonly;   /* 1 = writes rejected (CD-ROM)               */
     uint32_t   base_lba;   /* first sector of the window                */
@@ -97,6 +99,22 @@ void devfs_init(void)
 
         disk_letter++;
     }
+
+    /* Virtual terminals: /dev/tty0 is the root console (VTTY_ROOT_SLOT) and
+     * /dev/tty1../dev/tty9 are the nine user VT slots (slot == ttyN-1).  These
+     * are name/route nodes, not block-backed: reads are EOF, writes paint the
+     * slot's backing grid via vtty_write.  Always present so userspace can
+     * address a VT by a stable Linux-style path regardless of makmux state. */
+    for (int t = 0; t <= VTTY_SHELL_MAX; t++) {   /* tty0..tty9 */
+        char nm[16];
+        int o = 0;
+        nm[o++] = 't'; nm[o++] = 't'; nm[o++] = 'y';
+        nm[o++] = (char)('0' + t);
+        nm[o]   = '\0';
+        /* drive field carries the vtty slot: tty0 -> root, ttyN -> slot N-1. */
+        uint8_t slot = (t == 0) ? (uint8_t)VTTY_ROOT_SLOT : (uint8_t)(t - 1);
+        add_node(nm, slot, DEV_TTY, 0, 0, 0);
+    }
 }
 
 /* ------------------------------------------------------------------------- */
@@ -139,6 +157,7 @@ int devfs_node_readonly(int idx)
 int devfs_node_location(int idx, uint8_t *out_drive, uint32_t *out_base_lba)
 {
     if (idx < 0 || idx >= s_count) return -1;
+    if (s_nodes[idx].kind == DEV_TTY) return -1;   /* not a block device */
     if (out_drive)    *out_drive    = s_nodes[idx].drive;
     if (out_base_lba) *out_base_lba = s_nodes[idx].base_lba;
     return 0;
@@ -163,6 +182,7 @@ long devfs_pread(int idx, void *buf, uint32_t len, uint32_t off)
 {
     if (idx < 0 || idx >= s_count || !buf) return -1;
     dev_node_t *n = &s_nodes[idx];
+    if (n->kind == DEV_TTY) return 0;       /* VT sink: nothing to read back */
     uint32_t ssz   = node_sector_size(n);
     uint32_t total = n->sectors * ssz;
 
@@ -192,6 +212,8 @@ long devfs_pwrite(int idx, const void *buf, uint32_t len, uint32_t off)
 {
     if (idx < 0 || idx >= s_count || !buf) return -1;
     dev_node_t *n = &s_nodes[idx];
+    if (n->kind == DEV_TTY)                 /* route bytes to the VT grid */
+        return vtty_write((int)n->drive, (const char *)buf, len);
     if (n->readonly) return -1;
 
     uint32_t ssz   = node_sector_size(n);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -844,6 +844,26 @@ static void test_devfs(void)
         KTEST_ASSERT(n == (long)sizeof(blk));
     }
 
+    /* Virtual terminals: /dev/tty0 (root console) + /dev/tty1../dev/tty9 are
+     * always registered, regardless of makmux state.  They are character
+     * sinks, not block devices: writable, never read-only, no LBA location,
+     * reads return EOF, and a write is consumed into the slot's backing grid.
+     * Exercise tty9 (slot 8) -- a background slot during ktest, so painting it
+     * never disturbs the live console. */
+    int t0 = devfs_lookup("/tty0");
+    int t9 = devfs_lookup("/tty9");
+    KTEST_ASSERT(t0 >= 0 && t9 >= 0);
+    KTEST_ASSERT(devfs_file_exists("/tty0") == 1);
+    KTEST_ASSERT(devfs_node_readonly(t9) == 0);
+    {
+        uint8_t drv = 0xFF; uint32_t lba = 0xFFFFFFFFu;
+        KTEST_ASSERT(devfs_node_location(t9, &drv, &lba) < 0);   /* not a block dev */
+        char rb[4];
+        KTEST_ASSERT(devfs_pread(t9, rb, sizeof(rb), 0) == 0);    /* read = EOF */
+        const char msg[] = "ktest\n";
+        KTEST_ASSERT(devfs_pwrite(t9, msg, sizeof(msg) - 1, 0) == (long)(sizeof(msg) - 1));
+    }
+
     ktest_summary();
 }
 

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -529,6 +529,31 @@ vt_buf_t *vtty_buf(int n)
     return &vtty_bufs[n];
 }
 
+/* Write `len` bytes into slot `n`'s backing grid (the /dev/ttyN sink).
+ * Renders straight to the framebuffer when that slot is the focused VT,
+ * otherwise the bytes accumulate in the grid and surface on the next switch.
+ * Returns bytes consumed, or -1 if the slot is out of range / unallocated. */
+long vtty_write(int n, const char *buf, unsigned int len)
+{
+    if (n < 0 || n >= VTTY_MAX || !buf) return -1;
+    vt_buf_t *vt = vtty_buf(n);
+    if (!vt || !vt->cells) return -1;
+
+    int focused;
+    if (n == VTTY_ROOT_SLOT)
+        focused = (vtty_display_mode == VTTY_DISPLAY_ROOT_TEXT) ||
+                  (vtty_display_mode == VTTY_DISPLAY_VT && vtty_nslots == 0);
+    else
+        focused = (vtty_display_mode == VTTY_DISPLAY_VT && n == vtty_current);
+
+    for (unsigned int i = 0; i < len; i++)
+        vt_putchar(vt, buf[i]);
+
+    if (focused && vesa_tty_is_ready())
+        vesa_tty_paint_buf(vt);
+    return (long)len;
+}
+
 vt_buf_t *vtty_buf_current(void)
 {
     if (!vtty_bufs_ready) return NULL;

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -105,6 +105,11 @@ int          vtty_take_app_request(char *out, int cap);
  * or vtty has not initialised buffers yet. */
 vt_buf_t *vtty_buf(int n);
 
+/* Write len bytes into slot n's backing grid (the /dev/ttyN write sink).
+ * Repaints the framebuffer if n is the focused VT.  Returns bytes written,
+ * or -1 if n is out of range / has no allocated grid. */
+long vtty_write(int n, const char *buf, unsigned int len);
+
 /* Returns the backing buffer bound to the calling task's TTY index, or
  * NULL if the task has TASK_TTY_NONE (e.g. idle, ktest_bg, boot CPU). */
 vt_buf_t *vtty_buf_current(void);

--- a/src/kernel/include/kernel/vtty.h
+++ b/src/kernel/include/kernel/vtty.h
@@ -12,16 +12,18 @@
 #include <kernel/task.h>
 #include <kernel/vt.h>
 
-/* Slots 0..VTTY_MAX-2 are the user-visible VT slots: 0-3 are makmux's VT
- * shells (mak.sh1-4, reached via Alt+F1-F4) and 4-7 are dynamic named
- * app-tabs (maktop/vix/clock/..., reached via Alt-Tab cycling).
- * Slot VTTY_ROOT_SLOT is the hidden "console" slot for mak.sh0: it has a
- * full backing buffer (so its content is preserved across makmux sessions)
- * but it is excluded from Alt-Tab cycling, Alt+Fn switching, and the
- * status bar — exactly like Linux's tty0/console. */
-#define VTTY_MAX        9
-#define VTTY_SHELL_MAX  4   /* slots 0..3 = the VT shells (Alt+F1-F4) */
-#define VTTY_ROOT_SLOT  8   /* hidden root console = the last slot */
+/* Slots 0..VTTY_MAX-2 are the user-visible VT slots, exposed to userspace as
+ * /dev/tty1../dev/tty9 (slot i == /dev/tty(i+1)).  makmux runs them tmux-style:
+ * exactly one shell exists by default and more are created on demand (Alt+T /
+ * SYS_VT_OPEN_REQUEST), up to VTTY_SHELL_MAX.  A slot may instead carry a named
+ * app-tab (maktop/vix/clock/...).  All are reached via Alt+F1-F9 or Alt-Tab.
+ * Slot VTTY_ROOT_SLOT is the hidden "console" slot for mak.sh0 (exposed as
+ * /dev/tty0): it has a full backing buffer (so its content is preserved across
+ * makmux sessions) but it is excluded from Alt-Tab cycling, Alt+Fn switching,
+ * and the status bar — exactly like Linux's tty0/console. */
+#define VTTY_MAX        10
+#define VTTY_SHELL_MAX  9   /* slots 0..8 = the VT shells (Alt+F1-F9, tty1-9) */
+#define VTTY_ROOT_SLOT  9   /* hidden root console (tty0) = the last slot */
 
 /* Call once before spawning shell tasks.  Allocates per-slot backing
  * grids sized from the active display geometry (VESA cell dims if the

--- a/src/userspace/makmux.c
+++ b/src/userspace/makmux.c
@@ -1,16 +1,19 @@
 /*
- * makmux.c -- userspace VT multiplexer scaffold.
+ * makmux.c -- userspace VT multiplexer (tmux-style).
  *
- * mak.sh0 starts this explicitly with `makmux`.  The mux process stays
- * alive on the root tty and owns the child login shells mak.sh1..mak.sh4.
- * Each child attaches itself to one of the four kernel VT slots, then execs
- * the normal userspace shell.  Keep this freestanding: in-OS TCC must be
- * able to rebuild it from /src/userspace/makmux.c.
+ * mak.sh0 starts this explicitly with `makmux`.  The mux process stays alive
+ * on the root tty and owns the child login shells.  Like tmux, exactly ONE
+ * shell exists by default; further tabs are created on demand via Alt+T
+ * (SYS_VT_OPEN_REQUEST), up to CHILD_COUNT (the nine kernel VT slots, exposed
+ * as /dev/tty1../dev/tty9).  Each child attaches itself to one kernel VT slot
+ * then execs the normal userspace shell.  Keep this freestanding: in-OS TCC
+ * must be able to rebuild it from /src/userspace/makmux.c.
  */
 
 #include "syscall.h"
 
-#define CHILD_COUNT 4
+/* Up to nine VT shells (kernel slots 0..8 == tty1..tty9). */
+#define CHILD_COUNT 9
 
 static int s_child_pids[CHILD_COUNT];
 static int s_child_focus = 0;
@@ -86,7 +89,7 @@ static int spawn_child(int idx, int focus)
  * the 4 VT shells.  The kernel queues a launch (vtty_open_app, after a
  * switch-if-exists check); makmux drains it here and forks a child that takes
  * a fresh VT slot, names it after the app, and execs it. */
-#define APP_MAX 4
+#define APP_MAX 9
 static int s_app_pids[APP_MAX];
 
 static void child_app(const char *path)
@@ -173,20 +176,16 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    put_s("makmux: starting mak.sh1-4\n");
+    put_s("makmux: starting mak.sh1 (tmux-style: one tab; Alt+T adds more)\n");
 
-    int ok = 1;
-    for (int i = 0; i < CHILD_COUNT; i++) {
-        if (spawn_child(i, 0) != 0) {
-            put_s("makmux: fork failed for mak.sh");
-            put_dec(i + 1);
-            put_s("\n");
-            ok = 0;
-        }
+    /* tmux model: open exactly one shell at startup.  Focus it so the user
+     * lands on VT1 immediately; Alt+T opens further tabs on demand. */
+    if (spawn_child(0, 1) != 0) {
+        put_s("makmux: fork failed for mak.sh1\n");
+        return 1;
     }
 
-    put_s("makmux: use Alt+F1..Alt+F4 for mak.sh1..mak.sh4\n");
-    if (!ok) put_s("makmux: one or more child shells failed to start\n");
+    put_s("makmux: Alt+T = new tab, Alt+F1..Alt+F4 / Alt+Tab = switch\n");
 
     /* makmux now only manages the VT children.  The bottom status bar
      * (hostname + VT tabs + clock) is drawn by the kernel statusbar task,

--- a/src/userspace/shell-smoke.sh
+++ b/src/userspace/shell-smoke.sh
@@ -64,6 +64,20 @@ else
     fail=1
 fi
 
+# /dev/ttyN: the VT slots are addressable as Linux-style terminal nodes.
+# tty3 is a background slot here (no makmux running under the smoke driver),
+# so writing to it just lands in that VT's backing grid -- a clean exit (0)
+# proves open+write routed through devfs DEV_TTY -> vtty_write.
+echo SHELL-SMOKE: dev-tty-write
+echo vtwrite > /dev/tty3
+if [ $? -eq 0 ]
+then
+    echo SHELL-SMOKE: [PASS] dev-tty-write
+else
+    echo SHELL-SMOKE: [FAIL] dev-tty-write
+    fail=1
+fi
+
 echo SHELL-SMOKE: ls-mnt
 ls /mnt
 if [ $? -eq 0 ]

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -7,7 +7,11 @@
  * Everything about *what* the bar shows lives here (Linux/tmux model).
  *
  * Layout + widgets are configured by ~/.sbrc (re-read live so edits + the
- * post-login user change are picked up).  Each non-comment line is:
+ * post-login user change are picked up).  The bar is PER-TAB: each VT can own
+ * its layout via ~/.sbrc.tty<N> (the /dev/ttyN number; root console = tty0),
+ * which overrides the shared ~/.sbrc for that tab.  The active tab is read
+ * from sys_vt_state, so switching VTs re-renders that tab's own bar -- no new
+ * syscall surface.  Each non-comment line is:
  *
  *     <section> <widget> [<widget> ...]        section = left | center | right
  *
@@ -249,24 +253,30 @@ static void set_default_layout(void)
     o=0; s_cat(g_right,&o,SEC_MAX,"cpu mem rootfs time");
 }
 
-/* Build "/home/<user>/.sbrc" (root -> /root/.sbrc) into path. */
-static void sbrc_path(char *path,unsigned int cap)
+/* Build "/home/<user>/.sbrc" (root -> /root/.sbrc) into path, optionally with
+ * a per-tab suffix ".ttyN" so each VT can carry its OWN status-bar layout.
+ * suffix_tty < 0 selects the shared ~/.sbrc; >= 0 selects ~/.sbrc.tty<N>. */
+static void sbrc_path(char *path,unsigned int cap,int suffix_tty)
 {
     unsigned int o=0;
     if(s_eq(g_user,"root")){ s_cat(path,&o,cap,"/root"); }
     else { s_cat(path,&o,cap,"/home/"); s_cat(path,&o,cap,g_user); }
     s_cat(path,&o,cap,"/.sbrc");
+    if(suffix_tty>=0){
+        char num[12]; sb_uitoa((unsigned int)suffix_tty,num);
+        s_cat(path,&o,cap,".tty");
+        s_cat(path,&o,cap,num);
+    }
 }
 
-static void load_sbrc(void)
+/* Parse one ~/.sbrc-format file at `path` into the section lists.  Returns 1
+ * if the file existed and was read, 0 otherwise (caller keeps defaults). */
+static int load_sbrc_file(const char *path)
 {
-    set_default_layout();
-
-    char path[80]; sbrc_path(path,sizeof(path));
     int fd=sys_open(path,O_RDONLY);
-    if(fd<0) return;                 /* no config -> keep defaults */
+    if(fd<0) return 0;               /* no config -> keep defaults */
     char buf[RC_MAX]; long r=sys_read(fd,buf,sizeof(buf)-1); sys_close(fd);
-    if(r<=0) return;
+    if(r<=0) return 0;
     buf[r]='\0';
 
     int saw_any=0;
@@ -295,6 +305,23 @@ static void load_sbrc(void)
         unsigned int o=0; dst[0]='\0';
         s_cat(dst,&o,SEC_MAX,p);
     }
+    return 1;
+}
+
+/* Load the layout for the currently-active tab.  Each VT can own its bar:
+ * ~/.sbrc.tty<N> overrides the shared ~/.sbrc for tab N; if neither exists the
+ * built-in default layout is used.  tty<N> is 1-based (the /dev/ttyN number);
+ * the root console (tab 0) uses ~/.sbrc.tty0.  Picking the file off the active
+ * tab is what makes the bar per-tab without any new syscall surface. */
+static void load_sbrc(int active_tty)
+{
+    set_default_layout();
+
+    char path[96];
+    sbrc_path(path,sizeof(path),active_tty);   /* per-tab override first */
+    if(load_sbrc_file(path)) return;
+    sbrc_path(path,sizeof(path),-1);           /* fall back to shared ~/.sbrc */
+    load_sbrc_file(path);
 }
 
 /* Render a section's widget list into out[] (widgets joined by "  "). */
@@ -413,6 +440,15 @@ static void draw(void)
     sys_putch_at(cells,n);
 }
 
+/* Active VT slot -> /dev/ttyN number: root slot (9) is tty0, the nine user
+ * slots 0..8 are tty1..tty9.  This is the per-tab config key. */
+static int active_tty_num(void)
+{
+    unsigned int active=((unsigned int)sys_vt_state()>>16)&0xFFFFu;
+    if(active==9u) return 0;            /* VTTY_ROOT_SLOT -> tty0 */
+    return (int)active+1;              /* slot N -> tty(N+1) */
+}
+
 int main(void)
 {
     if(sys_gethostname(g_host,sizeof(g_host))<=0){
@@ -423,12 +459,16 @@ int main(void)
 
     unsigned int last=sys_uptime();
     unsigned int rc_next=0;             /* force an immediate ~/.sbrc load */
+    int last_tty=-2;                    /* force a reload on the first frame */
     for(;;){
-        /* Re-read user + ~/.sbrc every ~3 s (picks up login + edits). */
+        /* Reload the layout when the active tab changes (so each VT shows its
+         * own bar) and every ~3 s otherwise (picks up login + ~/.sbrc edits). */
         unsigned int now=sys_uptime();
-        if(now>=rc_next){
+        int tty=active_tty_num();
+        if(now>=rc_next || tty!=last_tty){
             if(sys_whoami(g_user,sizeof(g_user))<=0){ g_user[0]='u';g_user[1]='s';g_user[2]='e';g_user[3]='r';g_user[4]='\0'; }
-            load_sbrc();
+            load_sbrc(tty);
+            last_tty=tty;
             rc_next=now+300u;           /* 3 s at 100 Hz */
         }
 

--- a/src/userspace/statusbar.c
+++ b/src/userspace/statusbar.c
@@ -101,7 +101,7 @@ static void active_command(char *out,unsigned int cap)
     if(r<=0) return; buf[r]='\0';
 
     long i=0; int line=0; int best_pid=-1; char best[20]; best[0]='\0';
-    int root_console = active == 8u;
+    int root_console = active == 9u;   /* VTTY_ROOT_SLOT (tty0) */
     while(i<r){
         char tok[5][20]; int nt=0;
         while(i<r && buf[i]!='\n'){
@@ -344,10 +344,10 @@ static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,
     unsigned int mask=state&0xFFFFu;
     if(!mask || hi<=lo) return 0;
 
-    char  lab[8][18];
-    int   idx[8], cnt=0;
+    char  lab[9][18];
+    int   idx[9], cnt=0;
     unsigned int total=0;
-    for(int i=0;i<8;i++){
+    for(int i=0;i<9;i++){
         if(!(mask&(1u<<i))) continue;
         char nm[16]; int ln=sys_vt_getname(i,nm,sizeof(nm));
         char *l=lab[cnt]; unsigned int w=0;
@@ -356,7 +356,7 @@ static int render_tabs(tty_cell_t *cells,unsigned int *n,unsigned int row,
         else    { l[w++]='V'; l[w++]='T'; l[w++]=(char)('1'+i); }
         l[w++]=' '; l[w]='\0';
         idx[cnt]=i; total+=w; cnt++;
-        if(cnt>=8) break;
+        if(cnt>=9) break;
     }
     if(!cnt) return 0;
 


### PR DESCRIPTION
makx GUI track. Includes the window-chrome commit (so the standalone feat/makx is retired).

- Window chrome: small macOS-style minimise/maximise/close dots (was an oversized close box), minimise-to-dock, maximise toggle, **resizable** windows (bottom-right grip), and a 1:1 Doom blit (no per-frame scale when the window fits 640x400).
- VTs: widened to 9 user VTs + a root console (VTTY_MAX=10); slot i <-> /dev/tty(i+1), root <-> /dev/tty0; **/dev/ttyN char nodes** in devfs (writes stream to the slot grid via vtty_write; no new syscall).
- makmux is **tmux-style**: one shell by default, Alt+T grows up to 9 tabs via the existing route.
- **Per-tab statusbar**: statusbar.elf loads ~/.sbrc.tty<N> for the active tab, reloading on switch.
- Headless coverage: ktest devfs tty asserts, kbtest makmux-default-1 + alt-t-newtab, shell-smoke dev-tty-write. Docs updated (gui.md, kernel/vtty.md, syscalls.md).

Gates green: ktest (874), kbtest ALL PASS, iso test ALL PASSED, guitest GUI: READY.