### PR TITLE
tests: deflake the gdb-hdd HDD-content check

### DIFF
--- a/tests/groups/hdd_content.py
+++ b/tests/groups/hdd_content.py
@@ -16,18 +16,39 @@ EXPECTED_FILES = [
 ]
 
 
-def run():
-    for path in EXPECTED_FILES:
+# vfs_file_exists() runs here as a GDB *inferior function call*: the stopped
+# guest executes the kernel's FAT32 directory walk, which issues a real ATA
+# read.  Driven that way (mid-breakpoint, off the normal scheduler) a directory
+# /FAT sector read can transiently miss, so the lookup returns 0 for a file that
+# IS on the image -- historically a flaky "X.elf not found", a different file
+# each run, cleared by re-running the whole job.  Re-issuing the call re-reads
+# the sector, so a short retry deflakes it without masking a genuinely absent
+# file (which fails all attempts).
+RETRIES = 8
+
+
+def _exists(path):
+    last = 0
+    for _ in range(RETRIES):
         try:
-            result = int(gdb.parse_and_eval(
+            last = int(gdb.parse_and_eval(
                 'vfs_file_exists("{}")'.format(path)))
         except gdb.error as exc:
-            print('FAIL: could not check {}: {}'.format(path, exc),
-                  flush=True)
-            return False
+            print('FAIL: could not check {}: {}'.format(path, exc), flush=True)
+            return None
+        if last == 1:
+            return 1
+    return last
 
+
+def run():
+    for path in EXPECTED_FILES:
+        result = _exists(path)
+        if result is None:
+            return False
         if result != 1:
-            print('FAIL: {} not found on HDD'.format(path), flush=True)
+            print('FAIL: {} not found on HDD (after {} retries)'.format(
+                path, RETRIES), flush=True)
             return False
 
         print('PASS: {} exists'.format(path), flush=True)


### PR DESCRIPTION
The 'HDD content' group calls vfs_file_exists() as a GDB inferior function call, so the stopped guest runs a real FAT32/ATA directory read mid-breakpoint; that read transiently misses a sector and returns 0 for a file that IS on the image. Symptom: intermittent 'X.elf not found on HDD', a *different* file each run, across unrelated PRs (#191/#193/#194), always cleared by re-running.

Fix: retry the inferior vfs_file_exists() up to 8 times (re-reads the sector) before declaring the file absent — deflakes the transient miss without masking a genuinely missing file (which fails all attempts).