### PR TITLE
GUI/terminal + OS polish: 250 Hz scheduler, ANSI terminal + TUI bridge, power menu, graphical passwd, FreeDOOM, fast install, rescue root

### DIFF
--- a/.claude/skills/makar-conventions/SKILL.md
+++ b/.claude/skills/makar-conventions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: makar-conventions
+description: Makar OS house rules and style. Use whenever writing, editing, reviewing, committing, testing, or documenting code in the Makar repo (kernel C/AT&T-asm, ring-3 apps, run.sh, docs) so changes match the project's conventions. Apply before opening a PR.
+---
+
+# Makar OS — conventions & style
+
+Makar is a hobby i386 bare-metal OS (GRUB Multiboot2, 32-bit protected mode,
+QEMU, Docker build via `./run.sh`). Follow these rules exactly; they override
+generic defaults. `CLAUDE.md` is the index — read it and the `docs/` it points
+to before non-trivial work.
+
+## Golden rule — What Would Linux Do?
+When a design or hardware detail is ambiguous, default to the **Linux**
+convention (syscall ABI, driver shape, ACPI/HID/AHCI layout, single-user mode,
+ANSI/VT100, USER_HZ, block layer). Lean on documented references (Linux source,
+OSDev wiki, public-domain libs like stb_image/miniz) over hand-rolling.
+
+## Commits
+- **One commit per discrete work item.** Imperative subject, body explains *why*.
+- **NEVER** add `Co-Authored-By`, "Generated with Claude Code", or any
+  AI-attribution footer of any kind.
+- Commit/push only when the user asks. Branch off `main`; never commit to `main`.
+- End each commit body with the gate results you actually ran (e.g.
+  "ktest 875/0; guitest GUI: READY").
+
+## Testing — in-guest and headless only
+- **No host-driven keyboard, no monitor `sendkey`, no framebuffer scraping. Ever.**
+- Two mechanisms, both asserting on COM1 serial markers:
+  1. In-guest `.sh` script drivers (`src/userspace/{shell-smoke,incore,libc-tcc}.sh`)
+     run by `./run.sh iso test` after `ktest_run_all()`.
+  2. Key injection (`./run.sh kbtest`) via `keyboard_inject_text/_key()` +
+     `keyboard_test_driver()` emitting `KBTEST:` markers.
+- Add coverage there or as a `ktest` in `proc/ktest.c` (`kernel/ktest.h` macros) —
+  never a host harness.
+- Gates: `./run.sh ktest`, `iso test`, `guitest`, `kbtest`, `gdb iso|hdd`.
+  KVM is OFF for ktest/gdb/CI (correctness); the gdb-hdd content check is known
+  flaky — re-run to clear.
+- Run the relevant gates before every commit; state real results, never assume.
+
+## Build / run
+- Everything goes through `./run.sh` (wraps the Docker toolchain). Single kernel,
+  two ISOs (`makar.iso` interactive, `makar-test.iso` test_mode) differing only
+  in `grub.cfg`. `iso build` emits only `makar.iso` unless `TEST_ISO=1`.
+- IDE/clang "missing kernel header" errors are expected; the build uses the right
+  include paths.
+
+## Code style
+- **Match the surrounding code** — comment density, naming, idiom. Kernel C +
+  AT&T asm. Read the neighbours before adding.
+- Higher-half kernel at `0xC0000000`; hand any kernel pointer to DMA/hardware via
+  `kvirt_to_phys()`. User space below `0xC0000000`.
+- **Syscall ABI is one source of truth**: numbers/signals/keys/typed structs in
+  `src/kernel/include/makar_{syscalls,signals,keys,abi}.h`, included by kernel
+  *and* userspace. Never duplicate or drift. Allocate new numbers past the
+  current max; document in `docs/syscalls.md`.
+- Respect layering: e.g. the timer IRQ never reaches into the display layer —
+  modules register tick hooks. Follow the existing seam, don't punch through it.
+- **Fallback-gate** every hypervisor/hardware-specific change (`vm_kind()`,
+  PCI-id, boot-mode, capability bits) so the tested QEMU (BIOS+IDE+PS/2) path is
+  never regressed.
+- Paths follow Linux: `/usr` `/apps` `/root` `/proc` `/dev` `/mnt/<name>`;
+  apps at `/apps/*.elf`, libc at `/usr/lib/libc.a`.
+
+## Docs — cover everything, update as you go
+- Update `docs/` **in the same commit** as the code it describes — not at the end.
+- Every app, component, framework, and library gets documentation: each `mx*`
+  client, the `gui_gfx`/`gui_ui`/`makx`/`gui_browser` libs, kernel subsystems and
+  drivers, syscalls, the glossary. If you add an element, add its doc.
+- `CLAUDE.md` is an **index/router only** — do not paste detail into it. Put detail
+  in `docs/`, the companion files (`CLAUDE.history.md`, `CLAUDE.roadmap.md`,
+  `SURVEY.md`), or the source, and add/keep a one-line pointer in `CLAUDE.md`.
+- New abbreviations → `docs/glossary.md`. New third-party code/assets → keep the
+  upstream licence in-tree and record it in `THIRD-PARTY-NOTICES.md` / `LICENSES/`.
+- Record shipped PRs in `CLAUDE.history.md`; queue future work in
+  `CLAUDE.roadmap.md`.
+
+## When unsure
+Check `CLAUDE.md` → the relevant `docs/` page → the source. Ask the user only for
+decisions you genuinely can't resolve from those; otherwise pick the obvious
+option and say so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,8 @@ tests/                       GDB boot-test suite
   `SURVEY.md`; `toolchain/README.md`.
 
 ## Conventions
+- Full house rules + style: the **`makar-conventions`** Claude skill
+  (`.claude/skills/makar-conventions/SKILL.md`) — read it before non-trivial work.
 - Paths follow Linux: `/usr` `/apps` `/root` `/proc` `/dev` `/mnt/<name>`
   `/mnt/cdrom`; apps at `/apps/*.elf`, libc at `/usr/lib/libc.a`.
 - **Commits**: one per discrete work item; **no `Co-Authored-By`, no "Generated

--- a/CLAUDE.roadmap.md
+++ b/CLAUDE.roadmap.md
@@ -5,6 +5,39 @@ day-to-day work — consult when planning new features or asked about direction.
 
 ## Future roadmap
 
+### In flight — the GUI/OS-polish effort, split into focused PRs
+
+The large `feat/gpu-drivers-and-os-polish` effort is being **split into several
+PRs** (it grew too big for one):
+
+- **PR #1 (current branch):** GUI/session + terminal + OS polish — 250 Hz
+  scheduler + USER_HZ; fast install (multi-sector FS writes); FreeDOOM
+  (auto-download); GUI power menu + graphical passwd (`SYS_PASSWD`) +
+  Ctrl-Alt-Del→power menu (`SYS_CAD_PENDING`); rescue→root autologin; ANSI/VT100
+  terminal (`vt100.c`) + cell-API→ANSI bridge (`SYS_PTY_WINSIZE`); `halt`/
+  `poweroff` aliases; `makar-conventions` skill. Branch name is now a misnomer
+  (GPU drivers moved out) — the PR title should describe the GUI/terminal scope.
+- **PR #2 — Hypervisor GPU drivers:** a `video.c` driver framework + VBE
+  fallback + VMware SVGA II (CI-testable via `-device vmware-svga`) + Hyper-V
+  synthvid (fallback-gated). HW cursor in `wm.c` rides on this.
+- **PR #3 — Modern hardware:** AHCI (+ a `blkdev` vtable), USB HID kbd/mouse
+  (UHCI→xHCI), UEFI boot survivability (OVMF). Each fallback-gated so the tested
+  QEMU BIOS+IDE+PS/2 path never regresses. See "Hardware / platform" below.
+- **PR #4 — GUI applications:** `mxclock`/`mxcalc`/`mxdisk`/`mxnet` + an Install
+  icon, plus an **image viewer** (PNG/JPEG/GIF/BMP — vendor stb_image/miniz) and
+  a **web browser** (HTTP over lwIP + a minimal HTML renderer; no TLS/JS/CSS).
+- **PR #5 — Memory management + GC:** **on-demand file I/O / page cache**
+  (`vfs_read_at` + per-FS range reads; stop eager-loading whole files into the
+  kernel heap — the reason FreeDOOM needed a band-aid), PMM accounting +
+  demand-paging hook, and **reclaim/GC** (evict clean cached pages under
+  pressure, reap orphaned heap/surfaces/fds, heap coalesce/shrink). Reverts the
+  `SYSCALL_FILE_MAX`→32 MiB / interactive `-m 256` band-aid (commit d530731);
+  with on-demand I/O, 64 MiB is plenty (FreeDOOM runs on DOS in <16 MiB).
+
+Longer-term, separately: a self-hosted OSDev toolchain toward **x86_64** (see
+"OS-specific cross toolchain" below), then possibly a **microkernel** evolution
+(the IPC + makx server/client split are the groundwork).
+
 ### makx GUI follow-ups (after the server/client split)
 
 The display server/client split has landed (`gui.elf` = makx server; terminal,

--- a/CLAUDE.roadmap.md
+++ b/CLAUDE.roadmap.md
@@ -37,6 +37,12 @@ files, editor, tasks, doom are client `.elf`s over IPC + shared surfaces; see
 
 ### OS-specific cross toolchain (`i686-makar`)
 
+> **Designated next major PR** (after `feat/gpu-drivers-and-os-polish` merges):
+> a proper **self-hosted** OSDev toolchain in the style of Linux / **SerenityOS**
+> — build the `i686-makar` cross toolchain + hosted libc, make it self-hosting
+> in-OS (`tcc.elf` is the seed), and carry it far enough to reach **x86_64**
+> (the 64-bit port below is the destination this unlocks).
+
 Per the OSDev wiki (https://wiki.osdev.org/OS_Specific_Toolchain and
 https://wiki.osdev.org/Creating_an_Operating_System — both 403 to automated
 fetches, read in a browser). Today the build uses a generic `i686-elf` cross-

--- a/LICENSES/freedoom.md
+++ b/LICENSES/freedoom.md
@@ -1,0 +1,47 @@
+# FreeDOOM (game data)
+
+**Files:** `wads/freedoom1.wad`, `wads/freedoom2.wad` — fetched at build time by
+[`getfreedoom.sh`](../getfreedoom.sh) into the gitignored `wads/` directory and
+staged onto the ISO at `/apps/`.  **Not committed to this repository.**
+
+## License / Origin
+
+FreeDOOM is a project to create a complete, free-content IWAD for the DOOM
+engine.  Its game data (the `freedoom1.wad` / `freedoom2.wad` IWADs) is
+distributed under the **BSD 3-Clause License**.
+
+- Project: https://freedoom.github.io/
+- Source / releases: https://github.com/freedoom/freedoom
+- License text: https://github.com/freedoom/freedoom/blob/master/COPYING.adoc
+
+```
+Copyright (c) 2001-2024 Contributors to the Freedoom project.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the names of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE.
+```
+
+## Why it's here
+
+FreeDOOM lets Makar ship a **playable DOOM out of the box** without
+distributing id Software's copyrighted `DOOM.WAD`.  The DOOM *engine* code
+(doomgeneric / id's GPLv2 source) is a separate program, `doom.elf`; FreeDOOM
+provides only the freely-licensed game *assets* it loads.  `getfreedoom.sh`
+downloads it on demand; `doomgeneric_makar.c` prefers `freedoom1.wad` over any
+`DOOM.WAD`.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -17,6 +17,7 @@ kept as separate, independently-licensed *programs* (e.g. `doom.elf`) and are
 | **lwIP** | BSD-3-Clause | https://github.com/lwip-tcpip/lwip | `vendor/lwip/COPYING` | TCP/IP stack |
 | **Limine** (v12.3.0) | BSD-2-Clause | https://github.com/limine-bootloader/limine | `vendor/limine/LICENSE` | BIOS boot binaries the installer deploys |
 | **font8x8** (D. Hepper) | Public domain | https://github.com/dhepper/font8x8 | header note | GUI/console 8×8 bitmap font (`src/userspace/font8x8.h`) |
+| **FreeDOOM** | BSD-3-Clause | https://freedoom.github.io/ | [`LICENSES/freedoom.md`](LICENSES/freedoom.md) | Freely redistributable IWAD game data (`freedoom1/2.wad`), fetched by `getfreedoom.sh` into the gitignored `wads/`; the default DOOM data so no copyrighted `DOOM.WAD` is shipped |
 
 ## Influence / reference (no code copied)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -38,6 +38,12 @@ this page — open an issue.
 | **WM** | Window Manager | The userspace GUI server (`gui.elf` / `wm.c`); sole compositor. |
 | **compositor** | — | The component that blits all window buffers into the one framebuffer. |
 | **DPI / fps** | dots per inch / frames per second | Pixel density / refresh rate. |
+| **ANSI / VT100** | — | The escape-sequence terminal standard (cursor moves, colours, scrolling). `mxterm` emulates it via the `vt100.c` core so TUI apps render in a GUI window. |
+| **CSI** | Control Sequence Introducer | The `ESC [` prefix of most ANSI sequences (e.g. `ESC[31m`, `ESC[2J`). |
+| **SGR** | Select Graphic Rendition | The `ESC[…m` family that sets colour/bold/reverse for following text. |
+| **CUP / ED / EL** | Cursor Position / Erase Display / Erase Line | Common CSI ops: move the cursor, clear the screen, clear a line. |
+| **pty** | pseudo-terminal | A terminal not backed by hardware — here the GUI terminal's pipe to its shell. `SYS_PTY_WINSIZE` publishes its size. |
+| **TUI** | Text User Interface | A full-screen text-mode app drawn with the cell API (maktop, vix, cfdisk). |
 
 ## Memory & CPU
 
@@ -59,6 +65,9 @@ this page — open an issue.
 | **FPU / SSE / FXSAVE** | Floating-Point Unit / Streaming SIMD Extensions | x87+SSE state, saved per task via the `fxsave`/`fxrstor` instructions. |
 | **TLS** | Thread-Local Storage | Per-task storage; i386 reaches it via a GDT segment (`%gs`). |
 | **GDT / IDT** | Global Descriptor Table / Interrupt Descriptor Table | The segment and interrupt-vector tables. |
+| **PIT** | Programmable Interval Timer | The 8253/8254 timer; Makar runs it at **TIMER_HZ** (250 Hz) to drive preemption. |
+| **TIMER_HZ / quantum** | — | Internal tick rate (250 Hz = 4 ms) and the per-task time-slice (`g_sched_quantum × sched_weight` ticks) before the scheduler preempts. |
+| **USER_HZ** | — | The *userspace-facing* tick rate, fixed at 100 Hz regardless of TIMER_HZ (like Linux). `SYS_UPTIME` and `/proc` CPU ticks report in these units so apps' timing stays correct. |
 
 ## Devices, power & virtualization
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -157,10 +157,27 @@ Clients (each an independent process, `src/userspace/mx*.c`):
 - **doom** is the windowed makx client (see below).
 
 An always-on **top menu bar** (drawn after the windows, never occluded) carries
-the Makar brand, the focused window's title, **Exit** (→ `sys_gui_close`, back
-to the CLI shell) and **Log Off** (→ `sys_logout`, ends the session). Both first
+the Makar brand, the focused window's title, and a **power icon** at the
+right. Clicking it (or pressing **Ctrl-Alt-Del**, see below) opens a centred
+modal **power menu** (`show_power_menu`) with: **Log out (graphical)**
+(→ `sys_logout`, re-shows login), **Log out to shell** (→ `sys_gui_close`,
+back to the CLI shell), **Shut down** (→ `sys_shutdown`), **Reboot**
+(→ `sys_reboot`), **Change password...** (the passwd dialog below), and
+**Cancel** (Esc). Shut down / reboot and the two log-out paths all first
 SIGKILL + reap every client child and restore statusbar state. Desktop + menu
 bar + dock are unconditional: the GUI is never chromeless.
+
+**Change-password dialog** (`show_passwd_dialog`): a centred modal with masked
+Current / New / Confirm fields (`ui_password`, Tab cycles, Esc cancels). OK
+calls **`SYS_PASSWD`** (`sys_passwd`, syscall 270) → `shadow_verify` the old
+password then `shadow_set_password` the new one; it needs a writable (installed)
+rootfs and reports "current password incorrect" / mismatch inline.
+
+**Ctrl-Alt-Del:** the kernel sets a pending flag from the keyboard IRQ; in a
+text session it opens `cad_menu`, but under the GUI the server polls
+**`SYS_CAD_PENDING`** (syscall 271, test-and-clear) every frame and opens the
+power menu instantly. Escape hatch: a *second* Ctrl-Alt-Del within ~1 s pulses
+an 8042 CPU reset from the IRQ, so a wedged GUI is still recoverable.
 
 **Still built into the server (this cut):** the desktop/dock/menu-bar/chrome (a
 compositor-owned panel + WM, like many simple stacks) and the graphical login

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -77,6 +77,11 @@ and reusable by future surface-rendering apps.
   windows first and only feeds the focused window a "live" ctx (others get a ctx
   with no buttons/keys so they still draw but don't react) — this is how the
   per-window focus model reaches individual widgets.
+- **vt100** (`vt100.{c,h}`) — a standalone ANSI/VT100+ terminal emulator core:
+  `vt_init`/`vt_resize`/`vt_putc` drive a colour `vt_cell` grid (cursor, scroll
+  region, SGR colours, ED/EL, IL/DL/ICH/DCH/ECH, alt-screen, UTF-8 → one cell).
+  Used by `mxterm` (and reusable by a future serial console); freestanding (no
+  libc). The front-end renders the grid via a 16-colour palette → `gfx_char`.
 
 ## makx protocol (`makx.h` / `makx.c`)
 
@@ -143,9 +148,14 @@ reserved window's surface.
 
 Clients (each an independent process, `src/userspace/mx*.c`):
 
-- **mxterm** hosts `sh.elf` over pipes (byte stream drawn as a grid), forwarding
-  the keys the server delivers to the shell's stdin. Ctrl-C / Ctrl-D there only
-  closes that terminal — `mak.sh0` is never in the blast radius.
+- **mxterm** hosts `sh.elf` over pipes, forwarding the keys the server delivers
+  to the shell's stdin. Ctrl-C / Ctrl-D there only closes that terminal —
+  `mak.sh0` is never in the blast radius. It is a **real ANSI/VT100+ terminal
+  emulator**: the child's byte stream runs through the reusable `vt100.c` core
+  (see below), so colour (SGR), cursor addressing (CUP/ED/EL), scroll regions,
+  insert/delete lines & chars, the alt-screen, and cursor show/hide all render
+  correctly — TUI programs (`maktop`, `vix`, `ls --color`, …) display properly
+  in the window. The grid resizes with the window.
 - **mxedit** is a native multi-line editor (caret, click-to-position) with an
   **Open / Save / Save As** dialog built on the shared file dialog (`br_dialog`,
   below).

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -83,6 +83,25 @@ and reusable by future surface-rendering apps.
   Used by `mxterm` (and reusable by a future serial console); freestanding (no
   libc). The front-end renders the grid via a 16-colour palette → `gfx_char`.
 
+### Text-mode (TUI) apps in the GUI terminal — cell-API → ANSI bridge
+
+The existing TUI apps (`maktop`, `vix`, `cfdisk`, the `install` flow, …) don't
+write bytes; they call the kernel **cell API** (`SYS_PUTCH_AT`, `SYS_SET_CURSOR`,
+`SYS_TTY_CLEAR`, `SYS_TERM_SIZE`) which targets a per-task VT backing grid. A
+process forked by `mxterm` has **no live VT slot** and its stdout is a pipe, so
+those calls would have nowhere to land.
+
+The kernel bridges them: when a cell-API call comes from a task with
+`vtty_buf_current() == NULL` **and** fd 1 is a pipe, it is translated to the
+equivalent **ANSI escape** written to fd 1 — `SYS_PUTCH_AT` → `CUP`+`SGR`+chars
+(coalescing same-row runs, VGA→ANSI colour remap), `SYS_SET_CURSOR` → `CUP`,
+`SYS_TTY_CLEAR` → `SGR`+`ED`+home — which `mxterm`'s vt100 core then renders.
+`SYS_TERM_SIZE` reports the terminal's published size: `mxterm` calls
+`SYS_PTY_WINSIZE` to stamp its grid dimensions onto the child's pipe. Grand-
+children inherit the piped fd 1, so a TUI app launched from the shell in the
+window works unchanged. The real text-VT path (non-NULL `vtty_buf_current()`) is
+untouched, so console/Alt-Fn VTs behave exactly as before.
+
 ## makx protocol (`makx.h` / `makx.c`)
 
 Control travels over the kernel's MINIX-style synchronous IPC (`kernel/ipc.h`,

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -227,6 +227,8 @@ than user/credential based.
 | 260 `SYS_LOGOUT` | — | end the root login session; `0` ok, `-1` |
 | 266 `SYS_LOGIN` | `user, pass` | `shadow_verify` + set session user; `0` ok, `-1` bad creds |
 | 270 `SYS_PASSWD` | `old, new` | change the current session user's password (`shadow_verify` old + `shadow_set_password` new); `0` ok, `-2` wrong current password, `-1` otherwise (bad args / read-only live rootfs) |
+| 271 `SYS_CAD_PENDING` | — | test-and-clear the Ctrl-Alt-Del flag; `1` if it was pressed. The GUI server polls it each frame to open its power menu |
+| 272 `SYS_PTY_WINSIZE` | `fd, (cols<<16)\|rows` | publish a pty window size onto a pipe fd so a piped child's `SYS_TERM_SIZE` reports it (GUI terminal → shell); `0` ok, `-1` if not a pipe |
 
 `SYS_LOGIN` backs the GUI graphical login (`gui.elf`'s `do_login`); `SYS_PASSWD`
 backs its change-password dialog (the power menu's "Change password..."). Both

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -226,9 +226,11 @@ than user/credential based.
 |---|---|---|
 | 260 `SYS_LOGOUT` | — | end the root login session; `0` ok, `-1` |
 | 266 `SYS_LOGIN` | `user, pass` | `shadow_verify` + set session user; `0` ok, `-1` bad creds |
+| 270 `SYS_PASSWD` | `old, new` | change the current session user's password (`shadow_verify` old + `shadow_set_password` new); `0` ok, `-2` wrong current password, `-1` otherwise (bad args / read-only live rootfs) |
 
-`SYS_LOGIN` backs the GUI graphical login (`gui.elf`'s `do_login`); see
-`docs/gui.md`.
+`SYS_LOGIN` backs the GUI graphical login (`gui.elf`'s `do_login`); `SYS_PASSWD`
+backs its change-password dialog (the power menu's "Change password..."). Both
+are documented in `docs/gui.md`.
 
 ### Virtual Terminals and makmux
 

--- a/docs/using-makar.md
+++ b/docs/using-makar.md
@@ -20,3 +20,20 @@ For host-side build, boot, and test commands, use
 [Building and running](building.md). For implementation details behind the
 user-facing behavior, use [Internals](internals.md) and the
 [Kernel subsystems](kernel/) reference.
+
+## Rescue shell (single-user mode)
+
+The GRUB entry **"Makar OS (rescue shell)"** boots with `shell=rescue` on the
+kernel command line. This skips the normal multi-VT userspace boot and starts a
+single bare **in-kernel** shell on VT0 — the recovery path for when
+`/apps/sh.elf` or the rootfs is broken.
+
+The rescue shell **logs in as `root` automatically with no password prompt**
+(the prompt shows `root@makar:/#`). This is intentional and matches the Unix
+single-user-mode trust model (Linux `init=/bin/sh`): whoever has the physical
+console already has full control of the machine, so a password would only be an
+obstacle during recovery, not real security. Protecting the console itself is a
+bootloader-password concern (GRUB), not the OS shell.
+
+Normal boots are unaffected — they still go through the usual login / autologin
+flow (`auth_try_autologin`; see [GUI](gui.md) and `auth.h`).

--- a/getfreedoom.sh
+++ b/getfreedoom.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# getfreedoom.sh -- fetch the FreeDOOM IWADs into ./wads/ at build time.
+#
+# FreeDOOM (https://freedoom.github.io/) is a BSD-licensed, freely
+# redistributable replacement for the copyrighted DOOM.WAD, so Makar can ship
+# a playable DOOM out of the box without distributing id Software's assets.
+# The WADs are NOT committed to git (wads/ is .gitignore'd); this script pulls
+# them on demand and the userspace Makefile stages whatever *.wad it finds.
+#
+# Idempotent: a no-op if the WADs already exist.  Best-effort: a download
+# failure (offline, mirror down) warns and exits 0 so it never breaks a build
+# -- DOOM just falls back to any DOOM.WAD present, or prints its usage.
+#
+#   bash getfreedoom.sh            # fetch into ./wads/
+#   FREEDOOM_VER=0.13.0 bash getfreedoom.sh
+#
+# Requires: curl (or wget) + unzip (or python3).  Auto-invoked from run.sh's
+# ISO build path outside CI; run it manually any time.
+
+set -u
+
+VER="${FREEDOOM_VER:-0.13.0}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WADS="$HERE/wads"
+URL="https://github.com/freedoom/freedoom/releases/download/v${VER}/freedoom-${VER}.zip"
+
+mkdir -p "$WADS"
+
+if [ -f "$WADS/freedoom1.wad" ] && [ -f "$WADS/freedoom2.wad" ]; then
+    echo "getfreedoom: freedoom{1,2}.wad already present -- skipping."
+    exit 0
+fi
+
+# Pick a downloader.
+fetch() {  # fetch <url> <dest>
+    if command -v curl >/dev/null 2>&1; then
+        curl -fL --retry 2 -o "$2" "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$2" "$1"
+    else
+        echo "getfreedoom: need curl or wget" >&2; return 1
+    fi
+}
+
+# Pick an extractor: unzip, else python3's zipfile module.
+extract() {  # extract <zip> <member-glob> <destdir>
+    if command -v unzip >/dev/null 2>&1; then
+        unzip -joq "$1" "$2" -d "$3"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 - "$1" "$3" <<'PY'
+import sys, zipfile, os, posixpath
+zf, dest = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(zf) as z:
+    for n in z.namelist():
+        if n.lower().endswith(".wad"):
+            data = z.read(n)
+            out = os.path.join(dest, posixpath.basename(n).lower())
+            with open(out, "wb") as f:
+                f.write(data)
+            print("getfreedoom: extracted", os.path.basename(out))
+PY
+    else
+        echo "getfreedoom: need unzip or python3" >&2; return 1
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "getfreedoom: downloading FreeDOOM ${VER} ..."
+if ! fetch "$URL" "$TMP/freedoom.zip"; then
+    echo "getfreedoom: download failed (offline?) -- continuing without FreeDOOM." >&2
+    exit 0
+fi
+
+if ! extract "$TMP/freedoom.zip" "*.wad" "$WADS"; then
+    echo "getfreedoom: extraction failed -- continuing without FreeDOOM." >&2
+    exit 0
+fi
+
+if [ -f "$WADS/freedoom1.wad" ]; then
+    echo "getfreedoom: ready -> $WADS/freedoom1.wad (+freedoom2.wad)"
+else
+    echo "getfreedoom: WADs not found in archive -- continuing." >&2
+fi
+exit 0

--- a/run.sh
+++ b/run.sh
@@ -373,19 +373,23 @@ _run_qemu_interactive() {
     # fallback has no /dev/kvm passthrough wired up.
     _accel=$(_qemu_accel)
 
+    # Interactive boots get 256 MiB: the kernel heap is fixed (HEAP_MAX) but the
+    # extra RAM gives the PMM enough user frames for memory-hungry apps -- e.g.
+    # DOOM's zone + a large IWAD (FreeDOOM is ~29 MiB) + the GUI back buffer,
+    # which starve at 64 MiB.  The correctness gates run their own -m 64.
     if [ -n "$_qemu" ]; then
         local _host_args="${_args//\/work\//$REPO_ROOT/}"
         # shellcheck disable=SC2086
-        "$_qemu" -m 64 $_accel $_host_args
+        "$_qemu" -m 256 $_accel $_host_args
     elif [ "$(_build_ctx)" = "docker" ]; then
         echo "==> Host QEMU not found - running QEMU in Docker (serial stdio)..."
         "$DOCKER_BIN" run --rm -it \
             --platform "$DOCKER_PLATFORM" \
             -v "$REPO_ROOT:/work" -w /work \
             "$DOCKER_IMAGE" \
-            bash -lc "qemu-system-i386 -m 64 $_args"
+            bash -lc "qemu-system-i386 -m 256 $_args"
     else
-        bash -lc "qemu-system-i386 -m 64 $_args"
+        bash -lc "qemu-system-i386 -m 256 $_args"
     fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -697,6 +697,12 @@ _clean_full() {
 _build_iso() {
     local _flags="${1:-}"
     echo "==> Building ISO${_flags:+ ($_flags)}..."
+    # Pull the BSD-licensed FreeDOOM IWADs into wads/ (best-effort, idempotent)
+    # so DOOM ships playable without the copyrighted DOOM.WAD.  Skipped in CI to
+    # keep the runners + ISO artifact lean (the gates never launch DOOM).
+    if [ -z "${CI:-}" ] && [ -f "$REPO_ROOT/getfreedoom.sh" ]; then
+        bash "$REPO_ROOT/getfreedoom.sh" || true
+    fi
     # Forward KERNEL_ARGS (extra GRUB cmdline, e.g. `kbtest`) into the build
     # container; iso.sh appends it to the interactive menuentry.
     local _kenv=()

--- a/src/kernel/arch/i386/auth/login.c
+++ b/src/kernel/arch/i386/auth/login.c
@@ -568,7 +568,17 @@ int auth_try_autologin(const char *cmdline_user)
     if (!user || !*user)
         return 0;                       /* no autologin configured */
 
-    if (!shadow_user_exists(user)) {
+    /* The user is configured (cmdline autologin / /etc/autologin) and the live
+     * CD genuinely ships it (user:user), so a miss here is almost always a
+     * transient /etc/shadow read during early boot (the rootfs/ATAPI is still
+     * settling).  Retry briefly before falling back to the login prompt so the
+     * live CD autologins reliably. */
+    int found = 0;
+    for (int tries = 0; tries < 10; tries++) {
+        if (shadow_user_exists(user)) { found = 1; break; }
+        ksleep(5);                      /* ~50 ms */
+    }
+    if (!found) {
         Serial_WriteString("[auth] autologin user not found, requiring login: ");
         Serial_WriteString((char *)user);
         Serial_WriteString("\n");

--- a/src/kernel/arch/i386/auth/login.c
+++ b/src/kernel/arch/i386/auth/login.c
@@ -48,6 +48,20 @@ const char *auth_current_user(void) { return s_current_user; }
  * while this is empty, forcing a fresh login_screen() first. */
 void auth_clear_user(void) { s_current_user[0] = '\0'; }
 
+/* Force the session user with no password check (rescue / single-user mode).
+ * Physical-console recovery is root-equivalent by design -- same trust model as
+ * Linux `init=/bin/sh`; do not use on a normal multi-user login path. */
+void auth_force_user(const char *user)
+{
+    if (!user) return;
+    size_t i = 0;
+    while (user[i] && i < sizeof(s_current_user) - 1) { s_current_user[i] = user[i]; i++; }
+    s_current_user[i] = '\0';
+    Serial_WriteString("[auth] rescue: forced session user ");
+    Serial_WriteString(s_current_user);
+    Serial_WriteString(" (single-user, no password)\n");
+}
+
 /* Verify + sign in (ring-3 GUI login via SYS_LOGIN).  Returns 0 / -1. */
 int auth_login(const char *username, const char *password)
 {

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -998,10 +998,19 @@ static void on_make(kc_t kc)
         default: break;
     }
 
-    /* Ctrl-Alt-Del: request the text-session system menu (Log off / Change
-     * password).  Serviced in task context by keyboard_getchar -> cad_menu;
-     * gated there to the active root text session (not the GUI). */
+    /* Ctrl-Alt-Del: request the system menu.  In a text session it's serviced
+     * by keyboard_getchar -> cad_menu; under the GUI the WM polls
+     * SYS_CAD_PENDING and opens its power menu.  Escape hatch: a *second* CAD
+     * within ~1 s (e.g. a wedged GUI that never drained the flag) triggers an
+     * immediate 8042 CPU reset -- safe from IRQ context, no disk flush, the
+     * classic "mash Ctrl-Alt-Del to reboot". */
     if (mod_ctrl && mod_alt && kc == KC_DELETE) {
+        static uint32_t last_cad = 0;
+        uint32_t now = timer_get_ticks();
+        if (last_cad && (now - last_cad) < TIMER_HZ) {
+            outb(0x64, 0xFE);                 /* pulse RESET line via the 8042 */
+        }
+        last_cad = now;
         __atomic_store_n(&kb_cad_pending, 1, __ATOMIC_RELEASE);
         return;
     }
@@ -1715,6 +1724,15 @@ static void kb_service_cad(void)
         __atomic_store_n(&kb_cad_pending, 0, __ATOMIC_RELEASE);
         cad_menu();
     }
+}
+
+/* Atomically test-and-clear the pending Ctrl-Alt-Del flag.  The GUI display
+ * server polls this each frame (via SYS_CAD_PENDING) to open its power menu --
+ * the text path (kb_service_cad) only fires when a root text session is active,
+ * so under the GUI the flag is the WM's to consume.  Returns 1 if it was set. */
+int kb_take_cad_pending(void)
+{
+    return __atomic_exchange_n(&kb_cad_pending, 0, __ATOMIC_ACQ_REL) ? 1 : 0;
 }
 
 unsigned char keyboard_getchar(void)

--- a/src/kernel/arch/i386/drivers/timer.c
+++ b/src/kernel/arch/i386/drivers/timer.c
@@ -31,12 +31,12 @@
 
 /* Preemptive scheduling quantum: yield every g_sched_quantum PIT ticks.
  * Runtime-tunable (slice 9 phase 3) via the `sched_quantum` shell builtin
- * or by writing the global directly.  Default 4 ticks @ 100 Hz = 40 ms
- * slice per task.  Clamped to [SCHED_QUANTUM_MIN, SCHED_QUANTUM_MAX] by
- * setters; the IRQ reads the global unsynchronised so don't bother with
- * atomics -- a torn 32-bit read is impossible on i386, and a stale read
- * just delays the new value by one tick. */
-volatile uint32_t g_sched_quantum = 4;
+ * or by writing the global directly.  Default 1 tick @ 250 Hz = a 4 ms base
+ * slice per task (scaled by task_t.sched_weight).  Clamped to
+ * [SCHED_QUANTUM_MIN, SCHED_QUANTUM_MAX] by setters; the IRQ reads the global
+ * unsynchronised so don't bother with atomics -- a torn 32-bit read is
+ * impossible on i386, and a stale read just delays the new value by one tick. */
+volatile uint32_t g_sched_quantum = 1;
 
 static volatile uint32_t tick = 0;
 
@@ -61,12 +61,25 @@ void timer_callback(registers_t *regs)
 	 * the EOI / yield so a task that gets preempted on this very tick
 	 * still gets credit for it.  task_current() returns NULL pre-
 	 * tasking_init, so guard. */
-	{
-		task_t *cur = task_current();
-		if (cur)
-			cur->kticks++;
+	task_t *cur = task_current();
+	if (cur)
+		cur->kticks++;
+
+	/* Preempt when the current task's *effective* quantum has elapsed.
+	 * Effective quantum = g_sched_quantum * sched_weight (0 ⇒ weight 1):
+	 * the GUI compositor gets a small boost so it can finish a frame
+	 * without being preempted mid-composite.  last_sched_tick is stamped
+	 * by schedule() when the task is switched in, so (tick - last_sched_tick)
+	 * is exactly how long this task has been running.  Pre-tasking
+	 * (cur == NULL) fall back to the plain modulo. */
+	int due;
+	if (cur) {
+		uint32_t w = cur->sched_weight ? cur->sched_weight : 1u;
+		due = (tick - cur->last_sched_tick) >= g_sched_quantum * w;
+	} else {
+		due = (tick % g_sched_quantum == 0);
 	}
-	if (tick % g_sched_quantum == 0) {
+	if (due) {
 		/* Send EOI to the master PIC before yielding so that the idle
 		   task's hlt can be woken by the next timer tick.  Without this
 		   the IRQ 0 in-service bit stays set, blocking all future timer
@@ -93,13 +106,16 @@ static inline uint64_t rdtsc(void)
 
 void ksleep(uint32_t ticks)
 {
-    /* 100 Hz PIT → each tick is 10 ms.  A modern CPU does ~1e9 cycles/s
-     * so 10 ms ≈ 10_000_000 cycles.  Allow 5× headroom (50 M cycles/tick)
-     * before declaring the timer stuck and panicking.  This never false-fires
-     * on real hardware; it only catches the case where the timer ISR has
-     * stopped delivering IRQ 0 entirely. */
-    uint32_t end = tick + ticks;
-    uint64_t tsc_limit = rdtsc() + (uint64_t)ticks * 50000000ULL;
+    /* `ticks` are legacy 100 Hz units (10 ms each); scale to real PIT ticks
+     * at TIMER_HZ so existing call sites keep their wall-clock duration after
+     * the rate change.  e.g. ksleep(100) = 1 s = 250 real ticks @ 250 Hz. */
+    uint32_t real = (uint32_t)(((uint64_t)ticks * TIMER_HZ) / 100u);
+
+    /* Generous tsc safety valve: ~50 M cycles per real tick before declaring
+     * the timer stuck (only false-fires above ~12 GHz, so never in practice).
+     * Catches a fully stalled IRQ 0 rather than spinning forever. */
+    uint32_t end = tick + real;
+    uint64_t tsc_limit = rdtsc() + (uint64_t)real * 50000000ULL;
     while (tick < end) {
         if (rdtsc() > tsc_limit)
             KPANIC("ksleep: timer ISR appears stuck (PIT IRQ 0 not firing)");

--- a/src/kernel/arch/i386/fs/ext2.c
+++ b/src/kernel/arch/i386/fs/ext2.c
@@ -888,22 +888,60 @@ int ext2_write_file(const char *path, const void *buf, uint32_t size)
         }
     }
 
-    /* Write the data, block by block. */
+    /* Write the data, coalescing physically-contiguous full blocks into one
+     * multi-block transfer (Linux merges adjacent blocks into a single bio).
+     * The bitmap allocator hands out consecutive blocks when it can, so this
+     * collapses the old block-at-a-time loop -- ~3k single-block DMA setups
+     * for a 12 MiB file -- into ~100 batched writes.  The ≤255-sector ABI
+     * (ide count is uint8_t) caps a run at (255 / s_spb) blocks. */
     uint32_t done = 0, lb = 0;
     const uint8_t *src = (const uint8_t *)buf;
+    uint32_t max_run = (s_spb && s_spb <= 255u) ? (255u / s_spb) : 1u;
+    if (max_run == 0u) max_run = 1u;
+    uint32_t run_start_pb = 0u, run_blocks = 0u;
+    const uint8_t *run_src = (const uint8_t *)0;
+    int werr = 0;
+
     while (done < size) {
         int grew;
         uint32_t pb = e2_bmap_alloc(&in, lb, &grew);
         if (!pb) { /* out of space: keep what we wrote */ break; }
-        uint32_t chunk = s_block_size;
-        if (chunk > size - done) chunk = size - done;
-        memset(s_blk, 0, s_block_size);
-        memcpy(s_blk, src + done, chunk);
-        if (e2_write_block(pb, s_blk) != 0) break;
         if (grew) in.i_blocks += s_block_size / SECTOR_SIZE;
+
+        uint32_t chunk = (size - done < s_block_size) ? (size - done) : s_block_size;
+
+        if (chunk == s_block_size) {
+            /* Full block: extend the contiguous run, flushing first if this
+             * block isn't physically adjacent or the run hit its size cap. */
+            if (run_blocks &&
+                (pb != run_start_pb + run_blocks || run_blocks >= max_run)) {
+                if (ide_write_sectors(s_drive, s_part_lba + run_start_pb * s_spb,
+                                      (uint8_t)(run_blocks * s_spb), run_src)) { werr = 1; break; }
+                run_blocks = 0u;
+            }
+            if (!run_blocks) { run_start_pb = pb; run_src = src + done; }
+            run_blocks++;
+        } else {
+            /* Final partial block: flush the run, then write the zero-padded
+             * tail through the per-block bounce buffer. */
+            if (run_blocks) {
+                if (ide_write_sectors(s_drive, s_part_lba + run_start_pb * s_spb,
+                                      (uint8_t)(run_blocks * s_spb), run_src)) { werr = 1; break; }
+                run_blocks = 0u;
+            }
+            memset(s_blk, 0, s_block_size);
+            memcpy(s_blk, src + done, chunk);
+            if (e2_write_block(pb, s_blk) != 0) { werr = 1; break; }
+        }
         done += chunk;
         lb++;
     }
+    /* Flush any trailing full-block run. */
+    if (!werr && run_blocks &&
+        ide_write_sectors(s_drive, s_part_lba + run_start_pb * s_spb,
+                          (uint8_t)(run_blocks * s_spb), run_src))
+        werr = 1;
+    (void)werr;
     in.i_size = done;
     e2_write_inode(ino, &in);
     e2_flush_meta();

--- a/src/kernel/arch/i386/fs/fat32.c
+++ b/src/kernel/arch/i386/fs/fat32.c
@@ -1174,24 +1174,57 @@ int fat32_write_file(const char *path, const void *buf, uint32_t size)
 
     if (fat_flush()) return -2;
 
-    /* Write file data sector by sector. */
+    /* Write file data, coalescing physically-contiguous clusters into large
+     * multi-sector transfers.  fat_alloc hands out consecutive clusters when
+     * it can, so a freshly written file is usually one or a few runs -- this
+     * turns the old one-sector-per-call loop (~24.5k DMA setups for a 12 MiB
+     * DOOM.WAD) into ~100 batched writes.  The single-sector ABI caps a call
+     * at 255 sectors (ide count is uint8_t), so each run is chunked to that. */
     const uint8_t *src       = (const uint8_t *)buf;
     uint32_t       remaining = size;
     uint32_t       cluster   = first_cluster;
 
     while (remaining > 0u && cluster >= 2u && cluster < FAT32_BAD) {
-        uint32_t lba = clus_to_lba(cluster);
+        /* Extend a run of consecutive cluster numbers (contiguous LBAs). */
+        uint32_t run_lba  = clus_to_lba(cluster);
+        uint32_t run_clus = 1u;
+        uint32_t next     = fat_read(cluster);
+        while (next == cluster + 1u && next >= 2u && next < FAT32_BAD) {
+            run_clus++;
+            cluster = next;
+            next    = fat_read(cluster);
+        }
 
-        for (uint8_t s = 0; s < vol.spc && remaining > 0u; s++) {
-            uint32_t chunk = remaining > 512u ? 512u : remaining;
+        uint32_t run_sectors = run_clus * vol.spc;
+        uint32_t run_bytes   = run_sectors * 512u;
+        uint32_t use_bytes   = remaining < run_bytes ? remaining : run_bytes;
+        uint32_t full_secs   = use_bytes / 512u;
+        uint32_t off         = 0u;
+
+        /* Whole sectors: write straight from the source buffer, ≤255 at a
+         * time (ide_write_sectors bounces through its own DMA buffer, so a
+         * non-contiguous kernel allocation is fine). */
+        while (full_secs > 0u) {
+            uint8_t batch = full_secs > 255u ? 255u : (uint8_t)full_secs;
+            if (ide_write_sectors(vol.drive, run_lba + off, batch, src))
+                return -2;
+            src       += (uint32_t)batch * 512u;
+            remaining -= (uint32_t)batch * 512u;
+            off       += batch;
+            full_secs -= batch;
+        }
+        /* Trailing partial sector (only at end-of-file): zero-pad via s_sec. */
+        if (remaining > 0u && off < run_sectors) {
+            uint32_t chunk = remaining;            /* < 512 */
             memset(s_sec, 0, 512);
             memcpy(s_sec, src, chunk);
-            if (ide_write_sectors(vol.drive, lba + s, 1, s_sec))
+            if (ide_write_sectors(vol.drive, run_lba + off, 1, s_sec))
                 return -2;
             src       += chunk;
             remaining -= chunk;
         }
-        cluster = fat_read(cluster);
+
+        cluster = next;
     }
 
     /* Update or create the directory entry. */

--- a/src/kernel/arch/i386/fs/procfs.c
+++ b/src/kernel/arch/i386/fs/procfs.c
@@ -276,7 +276,9 @@ static void render_tasks(pf_writer_t *w)
         if (t->tty < 0) pf_putc(w, '-');
         else            pf_putu(w, (uint32_t)t->tty);
         pf_putc(w, ' ');
-        pf_putu(w, t->kticks);
+        /* CPU time in USER_HZ (100 Hz) units -- stable across TIMER_HZ and
+         * unit-matched to SYS_UPTIME so maktop's CPU% ratio is correct. */
+        pf_putu(w, timer_to_user_ticks(t->kticks));
         pf_putc(w, ' ');
         /* Per-task memory (KiB): every task owns an 8 KiB kernel stack;
          * ring-3 tasks additionally have their resident user pages.  So
@@ -298,7 +300,7 @@ static void render_uname(pf_writer_t *w)
 {
     pf_puts(w, "Makar " MAKAR_VERSION " (i386) built " __DATE__ " " __TIME__ "\n");
     pf_puts(w, "uptime ticks: ");
-    pf_putu(w, timer_get_ticks());
+    pf_putu(w, timer_user_ticks());
     pf_puts(w, " (100 Hz)\n");
 }
 

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -70,8 +70,12 @@
  * installer silently truncates it (iso9660_read_file copies min(size, bufsz)),
  * which corrupts the tail — e.g. a truncated DOOM.WAD (~11.8 MiB) loses its
  * lump directory and DOOM fails with "W_GetNumForName: PNAMES not found!".
- * 16 MiB covers DOOM.WAD/DOOM2.WAD; bump if a larger asset is ever bundled. */
-#define INST_MAX_FILE_SIZE    (16u * 1024u * 1024u)
+ * 32 MiB covers the FreeDOOM WADs (freedoom1 ~21 MiB, freedoom2 ~28 MiB) as
+ * well as DOOM.WAD/DOOM2.WAD.  It's a transient kmalloc in the 40 MiB heap,
+ * live only during the copy phase (mkfs metadata is block-sized), so it fits.
+ * A larger asset would need true streaming (ISO offset-read + FS append) --
+ * noted as a follow-up; the multi-sector FS writes already make the copy fast. */
+#define INST_MAX_FILE_SIZE    (32u * 1024u * 1024u)
 #define MBR_PART_TABLE_OFF    0x1BEu
 #define MBR_SIG_OFF           0x1FEu
 #define LIMINE_STAGE2_LOC_OFF 0x1A4u          /* u64 stage-2 byte offset       */

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -1846,6 +1846,22 @@ static void test_rtc_unix_time(void)
     syscall_dispatch(&regs);
     KTEST_ASSERT_EQ((int)regs.eax, -1);
 
+    /* USER_HZ contract: the internal PIT runs at TIMER_HZ (250) but
+     * SYS_UPTIME reports in fixed 100 Hz user-ticks (timer_user_ticks).
+     * Over a ksleep(20) delay (0.2 s in legacy 100 Hz units) uptime must
+     * advance by ~20 user-ticks -- guards both the rate and the scaling so
+     * a future rate change can't silently skew wall-clock-facing apps. */
+    memset(&regs, 0, sizeof(regs));
+    regs.eax = SYS_UPTIME;
+    syscall_dispatch(&regs);
+    uint32_t up0 = regs.eax;
+    ksleep(20);
+    memset(&regs, 0, sizeof(regs));
+    regs.eax = SYS_UPTIME;
+    syscall_dispatch(&regs);
+    uint32_t dup = regs.eax - up0;
+    KTEST_ASSERT(dup >= 16u && dup <= 24u);   /* ~20 user-ticks, ±20% */
+
     ktest_summary();
 }
 

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -2365,12 +2365,22 @@ static void test_signal(void)
     KTEST_ASSERT(sig_set_handler(cur, SIGSTOP, SIG_IGN) == -1);
     KTEST_ASSERT(sig_set_handler(cur, SIGINT,  SIG_IGN) == 0);
 
-    /* SIG_IGN: sig_deliver clears the pending bit without touching state. */
+    /* SIG_IGN: sig_deliver clears the pending bit without touching state.
+     * cur is the running task, so a preempting timer IRQ between the post and
+     * the observe would let schedule()'s sig_deliver clear the (ignored) bit
+     * first -- wrap post + observe in disable_interrupts to remove the window
+     * (more likely at 250 Hz; surfaced on CI's TCG timing).  Capture state with
+     * IRQs off, assert on the snapshots. */
+    disable_interrupts();
     sig_send(cur, SIGINT);
-    KTEST_ASSERT((cur->sig_pending & SIG_BIT(SIGINT)) != 0);
+    uint32_t ign_before = cur->sig_pending;
     sig_deliver(cur);
-    KTEST_ASSERT((cur->sig_pending & SIG_BIT(SIGINT)) == 0);
-    KTEST_ASSERT(cur->state != TASK_DEAD);
+    uint32_t ign_after  = cur->sig_pending;
+    int      ign_state  = cur->state;
+    enable_interrupts();
+    KTEST_ASSERT((ign_before & SIG_BIT(SIGINT)) != 0);
+    KTEST_ASSERT((ign_after  & SIG_BIT(SIGINT)) == 0);
+    KTEST_ASSERT(ign_state != TASK_DEAD);
     sig_set_handler(cur, SIGINT, SIG_DFL);
 
     /* sig_send input validation: NULL task / bogus signo are no-ops. */

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -95,6 +95,53 @@ static int stdin_pipe_getchar(task_t *t)
     }
 }
 
+/* ---- cell-API -> ANSI bridge (GUI terminal) -----------------------------
+ * A task forked by the GUI terminal (mxterm) has no live VT slot and its
+ * stdout is a pipe, so its cell-API calls (SYS_PUTCH_AT / SET_CURSOR /
+ * TTY_CLEAR) have nowhere to land.  Translate them to ANSI escapes written to
+ * fd 1 -- mxterm's vt100 emulator renders them -- so every cell-API TUI app
+ * (maktop, vix, cfdisk, the installer, ...) works inside a terminal window
+ * unchanged.  The real text-VT path (vtty_buf_current() != NULL) is untouched;
+ * grandchildren inherit the piped fd 1 so they're covered too.
+ */
+static fd_entry_t *ansi_bridge_fd(void)
+{
+    task_t *cur = task_current();
+    if (!cur || vtty_buf_current() != NULL) return NULL;   /* has a live VT */
+    fd_entry_t *e = fd_get(cur->fd_table, 1);
+    if (e && e->kind == FD_KIND_PIPE && e->pipe_is_writer && e->pipe) return e;
+    return NULL;
+}
+static void ansi_pipe_write(fd_entry_t *e, const char *s, uint32_t n)
+{
+    pipe_ring_t *r = e->pipe;
+    uint32_t w = 0; uint32_t spins = 0;
+    while (w < n) {
+        if (r->refcount_r == 0) break;                     /* reader gone */
+        uint32_t space = PIPE_RING_CAP - (r->head - r->tail);
+        if (space == 0) { if (++spins > 200000u) break; task_yield(); continue; }
+        uint32_t chunk = n - w; if (chunk > space) chunk = space;
+        for (uint32_t i = 0; i < chunk; i++)
+            r->buf[(r->head + i) % PIPE_RING_CAP] = (uint8_t)s[w + i];
+        r->head += chunk; w += chunk; spins = 0;
+    }
+}
+static int ansi_u(char *b, unsigned v)
+{ char t[10]; int n = 0; if (!v) { b[0] = '0'; return 1; }
+  while (v) { t[n++] = (char)('0' + v % 10); v /= 10; }
+  for (int i = 0; i < n; i++) b[i] = t[n-1-i]; return n; }
+/* VGA colour index -> ANSI index (VGA swaps red/blue vs ANSI). */
+static const unsigned char s_vga2ansi[8] = {0,4,2,6,1,5,3,7};
+static int ansi_sgr(char *b, unsigned char vga)
+{   unsigned f = vga & 0x0F, g = (vga >> 4) & 0x0F;
+    unsigned fc = (f < 8) ? 30u + s_vga2ansi[f]   : 90u  + s_vga2ansi[f-8];
+    unsigned bc = (g < 8) ? 40u + s_vga2ansi[g]   : 100u + s_vga2ansi[g-8];
+    int o = 0; b[o++] = 0x1b; b[o++] = '['; b[o++] = '0'; b[o++] = ';';
+    o += ansi_u(b+o, fc); b[o++] = ';'; o += ansi_u(b+o, bc); b[o++] = 'm'; return o; }
+static int ansi_cup(char *b, unsigned row, unsigned col)
+{   int o = 0; b[o++] = 0x1b; b[o++] = '[';
+    o += ansi_u(b+o, row+1); b[o++] = ';'; o += ansi_u(b+o, col+1); b[o++] = 'H'; return o; }
+
 /* Callback + context for SYS_LS_DIR using vfs_complete. */
 typedef struct { char *buf; uint32_t cap; uint32_t off; } ls_ctx_t;
 static void ls_cb(const char *name, int is_dir, void *ctx)
@@ -782,6 +829,19 @@ void syscall_dispatch(registers_t *regs)
     case SYS_CAD_PENDING:
         regs->eax = (uint32_t)kb_take_cad_pending();
         break;
+
+    /* SYS_PTY_WINSIZE(272): a GUI terminal publishes its grid size onto a pipe
+     * so the piped child's SYS_TERM_SIZE reports it.  EBX=fd, ECX=(cols<<16)|rows. */
+    case SYS_PTY_WINSIZE: {
+        task_t *cur = task_current();
+        fd_entry_t *e = fd_get(cur ? cur->fd_table : NULL, (int)regs->ebx);
+        if (e && e->kind == FD_KIND_PIPE && e->pipe) {
+            e->pipe->cols = (uint16_t)(regs->ecx >> 16);
+            e->pipe->rows = (uint16_t)(regs->ecx & 0xFFFF);
+            regs->eax = 0;
+        } else regs->eax = (uint32_t)-1;
+        break;
+    }
 
     case SYS_GUI_CLOSE: {
         vtty_switch_root_text();
@@ -1585,6 +1645,28 @@ void syscall_dispatch(registers_t *regs)
         const tty_cell_t *cells = (const tty_cell_t *)(uintptr_t)regs->ebx;
         uint32_t n = regs->ecx;
         if (!cells || n == 0) { regs->eax = 0; break; }
+
+        /* GUI terminal: no live VT + piped stdout -> emit ANSI for mxterm. */
+        { fd_entry_t *abr = ansi_bridge_fd();
+          if (abr) {
+              char out[64]; int lr = -1, lc = -2, lclr = -1;
+              for (uint32_t i = 0; i < n; i++) {
+                  int row = cells[i].row, col = cells[i].col;
+                  int clr = cells[i].clr; char ch = (char)cells[i].ch;
+                  if (row != lr || col != lc + 1) {        /* reposition */
+                      int o = ansi_cup(out, (unsigned)row, (unsigned)col);
+                      ansi_pipe_write(abr, out, (uint32_t)o); lclr = -1;
+                  }
+                  if (clr != lclr) {
+                      int o = ansi_sgr(out, (unsigned char)clr);
+                      ansi_pipe_write(abr, out, (uint32_t)o); lclr = clr;
+                  }
+                  ansi_pipe_write(abr, &ch, 1);
+                  lr = row; lc = col;
+              }
+              { char rst[3] = { 0x1b, '[', 'm' }; ansi_pipe_write(abr, rst, 3); }
+              regs->eax = 0; break;
+          } }
         /* Mark this task as "touched the framebuffer".  shell_exec_elf
          * inspects this flag after the child dies and reissues
          * shell_clear_screen if set, so fullscreen apps that exit via
@@ -1668,6 +1750,9 @@ void syscall_dispatch(registers_t *regs)
      * EBX = col, ECX = row.
      * ------------------------------------------------------------------ */
     case SYS_SET_CURSOR: {
+        { fd_entry_t *abr = ansi_bridge_fd();
+          if (abr) { char out[24]; int o = ansi_cup(out, regs->ecx, regs->ebx);
+                     ansi_pipe_write(abr, out, (uint32_t)o); break; } }
         /* Record into the backing grid so the cursor lands correctly on
          * repaint; only move the visible hardware cursor when focused. */
         vt_buf_t *vt = vtty_buf_current();
@@ -1682,6 +1767,11 @@ void syscall_dispatch(registers_t *regs)
      * EBX = VGA colour attribute (e.g. 0x07 = white-on-black).
      * ------------------------------------------------------------------ */
     case SYS_TTY_CLEAR: {
+        { fd_entry_t *abr = ansi_bridge_fd();
+          if (abr) { char out[24]; int o = ansi_sgr(out, (unsigned char)regs->ebx);
+                     ansi_pipe_write(abr, out, (uint32_t)o);
+                     const char cl[] = { 0x1b,'[','2','J', 0x1b,'[','H' };
+                     ansi_pipe_write(abr, cl, 7); break; } }
         { task_t *cur = task_current(); if (cur) cur->fb_touched = 1; }
         /* Clear the backing grid to the requested attribute always; wipe
          * the live screen only when focused. */
@@ -1702,6 +1792,12 @@ void syscall_dispatch(registers_t *regs)
      * Returns EAX = (cols << 16) | rows.
      * ------------------------------------------------------------------ */
     case SYS_TERM_SIZE: {
+        /* GUI terminal child: report the terminal's published pty size. */
+        { fd_entry_t *abr = ansi_bridge_fd();
+          if (abr && abr->pipe->cols && abr->pipe->rows) {
+              regs->eax = ((uint32_t)abr->pipe->cols << 16) | abr->pipe->rows;
+              break;
+          } }
         /* Report the *drawable* area (vesa_tty_usable_rows), which excludes
          * the bottom status row whenever the status bar is enabled (reserved)
          * -- so shells/apps stay above it and statusbar.elf draws at row =

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -690,13 +690,14 @@ void syscall_dispatch(registers_t *regs)
         break;
 
     /* ------------------------------------------------------------------
-     * SYS_UPTIME(214): return the kernel tick counter (100 Hz).
-     * Apps that need wall-clock duration (kbtester's hold-Esc, future
-     * `clock` widget) can compute (uptime - t0) instead of counting
-     * input events whose rate depends on PS/2 typematic settings.
+     * SYS_UPTIME(214): return the kernel tick counter in USER_HZ (100 Hz)
+     * units -- stable across the internal PIT rate (see timer.h USER_HZ).
+     * Apps that need wall-clock duration (kbtester's hold-Esc, the `clock`
+     * widget) can compute (uptime - t0) instead of counting input events
+     * whose rate depends on PS/2 typematic settings.
      * ------------------------------------------------------------------ */
     case SYS_UPTIME:
-        regs->eax = timer_get_ticks();
+        regs->eax = timer_user_ticks();
         break;
 
     /* ------------------------------------------------------------------
@@ -779,7 +780,7 @@ void syscall_dispatch(registers_t *regs)
         uint32_t secs = 0;
         if (rtc_unix_time(&secs) != 0) { regs->eax = (uint32_t)-1; break; }
         tv->tv_sec  = (int32_t)secs;
-        tv->tv_usec = (int32_t)((timer_get_ticks() % 100u) * 10000u);
+        tv->tv_usec = (int32_t)((timer_get_ticks() % TIMER_HZ) * (1000000u / TIMER_HZ));
         regs->eax = 0;
         break;
     }
@@ -798,11 +799,11 @@ void syscall_dispatch(registers_t *regs)
             uint32_t secs = 0;
             if (rtc_unix_time(&secs) != 0) { regs->eax = (uint32_t)-1; break; }
             ts->tv_sec  = (int32_t)secs;
-            ts->tv_nsec = (int32_t)((timer_get_ticks() % 100u) * 10000000u);
+            ts->tv_nsec = (int32_t)((timer_get_ticks() % TIMER_HZ) * (1000000000u / TIMER_HZ));
         } else if (clk == CLOCK_MONOTONIC) {
             uint32_t ticks = timer_get_ticks();
-            ts->tv_sec  = (int32_t)(ticks / 100u);
-            ts->tv_nsec = (int32_t)((ticks % 100u) * 10000000u);
+            ts->tv_sec  = (int32_t)(ticks / TIMER_HZ);
+            ts->tv_nsec = (int32_t)((ticks % TIMER_HZ) * (1000000000u / TIMER_HZ));
         } else {
             regs->eax = (uint32_t)-1;
             break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -776,6 +776,13 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    /* SYS_CAD_PENDING(271): test-and-clear the Ctrl-Alt-Del flag.  The GUI
+     * server polls this each frame to open its power menu instantly (the text
+     * path only services CAD inside a root text session). */
+    case SYS_CAD_PENDING:
+        regs->eax = (uint32_t)kb_take_cad_pending();
+        break;
+
     case SYS_GUI_CLOSE: {
         vtty_switch_root_text();
         g_gui_session = 0;          /* Exit to Shell: this session is now CLI */

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -760,6 +760,22 @@ void syscall_dispatch(registers_t *regs)
         break;
     }
 
+    /* SYS_PASSWD(270): change the current session user's password.  Verify the
+     * old password, then write the new one.  Needs a writable (installed)
+     * rootfs -- /etc/shadow can't be rewritten on the read-only live CD.
+     * Returns 0 ok / -2 wrong current password / -1 otherwise. */
+    case SYS_PASSWD: {
+        const char *oldp = (const char *)(uintptr_t)regs->ebx;
+        const char *newp = (const char *)(uintptr_t)regs->ecx;
+        const char *user = auth_current_user();
+        if (!oldp || !newp || !user || !user[0] || !vfs_rootfs_is_disk()) {
+            regs->eax = (uint32_t)-1; break;
+        }
+        if (shadow_verify(user, oldp) != 0) { regs->eax = (uint32_t)-2; break; }
+        regs->eax = (uint32_t)(shadow_set_password(user, newp) == 0 ? 0 : -1);
+        break;
+    }
+
     case SYS_GUI_CLOSE: {
         vtty_switch_root_text();
         g_gui_session = 0;          /* Exit to Shell: this session is now CLI */

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -11,6 +11,7 @@
  */
 
 #include <kernel/task.h>
+#include <kernel/timer.h>
 #include <kernel/vtty.h>
 #include <kernel/keyboard.h>
 #include <kernel/fd.h>
@@ -537,6 +538,9 @@ static void schedule(void)
 
     current_task        = next;
     current_task->state = TASK_RUNNING;
+    /* Stamp the switch-in tick so the timer IRQ measures this task's slice
+     * from here (see timer_callback's effective-quantum preemption). */
+    current_task->last_sched_tick = timer_get_ticks();
 
     /* Update the TSS so Ring-3 → Ring-0 transitions land on this task's
        kernel stack.  Skip the idle task which uses the original boot stack. */

--- a/src/kernel/arch/i386/proc/vtty.c
+++ b/src/kernel/arch/i386/proc/vtty.c
@@ -275,6 +275,9 @@ int vtty_close_pid(int pid)
 void vtty_register_root_gui(task_t *t)
 {
     if (!t) return;
+    /* Give the compositor a larger time-slice so it can finish a frame
+     * without being preempted mid-composite (see task_t.sched_weight). */
+    t->sched_weight = 3;
     __atomic_store_n(&vtty_root_gui_task, t, __ATOMIC_RELEASE);
     /* Remember who launched the GUI so leaving it returns focus to that live
      * reader (the sh.elf the user typed `gui` in), not the login-loop. */

--- a/src/kernel/arch/i386/shell/shell_cmd_system.c
+++ b/src/kernel/arch/i386/shell/shell_cmd_system.c
@@ -390,6 +390,8 @@ const shell_cmd_entry_t system_cmds[] = {
     { "ps",       cmd_ps       },   /* richer columns: PID PPID S RING TTY NAME */
     { "tty",      cmd_tty      },   /* print controlling terminal (Linux `tty`) */
     { "shutdown", cmd_shutdown },
+    { "poweroff", cmd_shutdown },   /* alias (Linux) */
+    { "halt",     cmd_shutdown },   /* alias (Linux; ACPI soft-off) */
     { "reboot",   cmd_reboot   },
     { "panic",    cmd_panic    },
     { "ktest",    cmd_ktest    },

--- a/src/kernel/include/kernel/auth.h
+++ b/src/kernel/include/kernel/auth.h
@@ -37,6 +37,11 @@ const char *auth_current_user(void);
  * until a login sets it again. */
 void auth_clear_user(void);
 
+/* Force the session user with NO password check.  Used by the rescue boot
+ * (single-user mode): physical-console recovery is root-equivalent by design,
+ * the same trust model as Linux `init=/bin/sh`.  Do not use for normal login. */
+void auth_force_user(const char *user);
+
 /* Verify credentials and, on success, set the session user.  Returns 0 on
  * success, -1 on failure.  Backs SYS_LOGIN for the ring-3 GUI login screen. */
 int auth_login(const char *username, const char *password);

--- a/src/kernel/include/kernel/fd.h
+++ b/src/kernel/include/kernel/fd.h
@@ -46,6 +46,9 @@ typedef struct pipe_ring {
     uint32_t tail;       /* read cursor (consumer)                    */
     int      refcount_r; /* live reader fds pointing at this ring     */
     int      refcount_w; /* live writer fds pointing at this ring     */
+    uint16_t cols, rows; /* pty window size (SYS_PTY_WINSIZE); 0 = unset.
+                          * A GUI terminal (mxterm) publishes its grid size here
+                          * so its piped child's SYS_TERM_SIZE reports it. */
 } pipe_ring_t;
 
 /* Per-fd flag bits, mirrored from Linux fcntl O_NONBLOCK.  Stored in

--- a/src/kernel/include/kernel/keyboard.h
+++ b/src/kernel/include/kernel/keyboard.h
@@ -15,6 +15,10 @@ void keyboard_init(void);
 unsigned char keyboard_getchar(void);
 unsigned char keyboard_poll(void);
 
+/* Atomically test-and-clear the pending Ctrl-Alt-Del flag (1 if it was set).
+ * Backs SYS_CAD_PENDING so the GUI server can open its power menu instantly. */
+int kb_take_cad_pending(void);
+
 /* Per-task input routing (Phase 2 / split-panes). */
 void keyboard_bind_pane(int pane_id, task_t *t);
 void keyboard_focus_pane(int pane_id);

--- a/src/kernel/include/kernel/syscall.h
+++ b/src/kernel/include/kernel/syscall.h
@@ -19,11 +19,13 @@
 
 /* Maximum size of a regular file backed by an in-memory FD_KIND_FILE buffer.
  * Reads cap the eager-load here; writes may grow the buffer up to this hard
- * limit (16 MiB) before SYS_WRITE returns -1 (EFBIG).  Kernel heap is 32 MiB
- * (see HEAP_MAX in kernel/heap.h), so two simultaneously-open large files
- * still leave the kernel room to operate.  16 MiB is enough for tcc.c + its
- * emitted ELF on a self-compile attempt. */
-#define SYSCALL_FILE_MAX     (16u * 1024u * 1024u)
+ * limit before SYS_WRITE returns -1 (EFBIG).  The kernel heap is 40 MiB (see
+ * HEAP_MAX in kernel/heap.h), so a single 32 MiB file still leaves the kernel
+ * ~8 MiB to operate.  32 MiB covers a full DOOM IWAD: the FreeDOOM WADs are
+ * ~29 MiB (DOOM.WAD is 12 MiB) -- at 16 MiB they loaded truncated and DOOM
+ * died with "W_GetNumForName: PNAMES not found!".  Don't raise this past the
+ * heap's headroom, and note only one such file should be open at a time. */
+#define SYSCALL_FILE_MAX     (32u * 1024u * 1024u)
 /* Initial heap allocation for a freshly-created (O_CREAT) or O_TRUNC'd fd.
  * Subsequent SYS_WRITEs grow geometrically (doubling). */
 #define SYSCALL_FILE_INITIAL (4u * 1024u)

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -124,10 +124,20 @@ typedef struct task {
     /* --- tick accounting ---
      * Cumulative PIT ticks (100 Hz) during which this task was the
      * current_task at IRQ 0 time.  Incremented by timer_callback before
-     * the preemptive yield.  Rolls every ~497 days at 100 Hz; that's
+     * the preemptive yield.  Rolls every ~199 days at 250 Hz; that's
      * fine for diagnostics, replace with uint64_t if real uptime SLAs
      * ever appear.  Read via /proc/tasks. */
     uint32_t      kticks;
+
+    /* --- scheduling weight (250 Hz responsiveness) ---
+     * Relative time-slice multiplier: effective quantum = g_sched_quantum *
+     * sched_weight PIT ticks (0 is treated as 1).  The GUI compositor
+     * (vtty_register_root_gui) gets a small boost so it can finish a frame
+     * without being preempted mid-composite.  last_sched_tick is the tick at
+     * which this task was last switched in; the timer IRQ preempts it once its
+     * effective quantum has elapsed since then. */
+    uint8_t       sched_weight;
+    uint32_t      last_sched_tick;
 
     /* --- exec hand-off ---
      * Pointer to a heap-allocated exec_params_t set up by shell_exec_elf

--- a/src/kernel/include/kernel/timer.h
+++ b/src/kernel/include/kernel/timer.h
@@ -6,8 +6,38 @@
 #include <stdio.h>
 #include <kernel/types.h>
 
+/* PIT tick rate.  250 Hz = a 4 ms tick, giving the preemptive scheduler a
+ * fine grain so the GUI compositor runs promptly between client time-slices
+ * (the old 100 Hz / 40 ms slice made multi-window + DOOM feel laggy).  This
+ * is the single source of truth for the rate; init_timer() is called with it
+ * and all tick<->wall-clock conversions divide/multiply by it. */
+#define TIMER_HZ 250u
+
 void init_timer(uint32_t frequency);
 uint32_t timer_get_ticks(void);
+
+/* USER_HZ: the *userspace-facing* tick rate, fixed at 100 Hz regardless of the
+ * internal TIMER_HZ -- exactly like Linux's stable USER_HZ / CLOCKS_PER_SEC.
+ * SYS_UPTIME and the /proc CPU-tick counters report in these units so apps
+ * that assume 100 ticks/second (clock widget's `+100u` = 1 s, maktop's refresh
+ * cadence, CPU% ratios) stay correct after the rate change. Both the uptime
+ * and the per-task kticks are scaled by the same factor, so their ratio (used
+ * for CPU%) is preserved. */
+#define USER_HZ 100u
+static inline uint32_t timer_to_user_ticks(uint32_t real_ticks)
+{
+    return (uint32_t)(((uint64_t)real_ticks * USER_HZ) / TIMER_HZ);
+}
+static inline uint32_t timer_user_ticks(void)
+{
+    return timer_to_user_ticks(timer_get_ticks());
+}
+
+/* ksleep(): busy-wait for `ticks` *legacy 100 Hz units* (i.e. centiseconds,
+ * 10 ms each), independent of the real TIMER_HZ.  Kept HZ-independent so the
+ * many call sites that mean a wall-clock delay ("1 s pause" = ksleep(100))
+ * keep their exact duration after the rate change -- the function scales the
+ * argument to real PIT ticks internally. */
 void ksleep(uint32_t ticks);
 
 /*
@@ -23,11 +53,12 @@ void ksleep(uint32_t ticks);
 typedef void (*timer_tick_fn)(uint32_t tick);
 void timer_register_tick_hook(timer_tick_fn fn);
 
-/* Preemptive scheduling quantum in PIT ticks (100 Hz).  Read by the
+/* Preemptive scheduling quantum in PIT ticks (TIMER_HZ).  Read by the
  * timer IRQ each tick; writable at runtime via the `sched_quantum`
- * shell builtin.  Bounds-check at the setter, not here. */
+ * shell builtin.  Bounds-check at the setter, not here.  Default 1 tick
+ * @ 250 Hz = a 4 ms base slice (scaled per task by task_t.sched_weight). */
 #define SCHED_QUANTUM_MIN 1u
-#define SCHED_QUANTUM_MAX 100u
+#define SCHED_QUANTUM_MAX 250u
 extern volatile uint32_t g_sched_quantum;
 
 #endif

--- a/src/kernel/include/makar_syscalls.h
+++ b/src/kernel/include/makar_syscalls.h
@@ -109,6 +109,11 @@
 #define SYS_SURFACE_DESTROY 264 /* int surface_destroy(int id) -> 0 / -1          */
 #define SYS_SURFACE_UNMAP   268 /* int surface_unmap(int id) -> 0/-1 (resize realloc) */
 
+/* Change the *current session user's* password (graphical passwd dialog).
+ * Verifies `old` against /etc/shadow then sets `new`.  Returns 0 ok, -2 if the
+ * current password is wrong, -1 otherwise (bad args / read-only live rootfs). */
+#define SYS_PASSWD          270 /* int passwd(const char *old, const char *new)    */
+
 /*
  * Admin syscalls (219..229).
  *

--- a/src/kernel/include/makar_syscalls.h
+++ b/src/kernel/include/makar_syscalls.h
@@ -114,6 +114,8 @@
  * current password is wrong, -1 otherwise (bad args / read-only live rootfs). */
 #define SYS_PASSWD          270 /* int passwd(const char *old, const char *new)    */
 #define SYS_CAD_PENDING     271 /* int cad_pending(void) - test+clear Ctrl-Alt-Del */
+#define SYS_PTY_WINSIZE     272 /* int pty_winsize(int fd, (cols<<16)|rows) - set a
+                                 * pipe's pty window size (GUI terminal -> child) */
 
 /*
  * Admin syscalls (219..229).

--- a/src/kernel/include/makar_syscalls.h
+++ b/src/kernel/include/makar_syscalls.h
@@ -113,6 +113,7 @@
  * Verifies `old` against /etc/shadow then sets `new`.  Returns 0 ok, -2 if the
  * current password is wrong, -1 otherwise (bad args / read-only live rootfs). */
 #define SYS_PASSWD          270 /* int passwd(const char *old, const char *new)    */
+#define SYS_CAD_PENDING     271 /* int cad_pending(void) - test+clear Ctrl-Alt-Del */
 
 /*
  * Admin syscalls (219..229).

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -330,9 +330,9 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 		}
 	}
 
-	t_writestring("Starting timer (100 Hz)");
+	t_writestring("Starting timer (250 Hz)");
 	kprint_ok();
-	init_timer(100);
+	init_timer(TIMER_HZ);
 	/* Subscribe the display's periodic widgets to the timer rather than
 	 * having the timer IRQ reach into the display layer directly. */
 	timer_register_tick_hook(t_spinner_tick);

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include <kernel/tty.h>
+#include <kernel/auth.h>
 #include <kernel/vga.h>
 #include <kernel/descr_tbl.h>
 #include <kernel/fpu.h>
@@ -528,6 +529,10 @@ void kernel_main(uint32_t magic, multiboot2_info_t *mbi)
 		 * mak.sh0.  The explicit userspace `makmux` application owns
 		 * the multi-VT shell experience. */
 		if (shell_rescue) {
+			/* Single-user rescue: come up as root with no login prompt
+			 * (physical-console recovery is root-equivalent, like Linux
+			 * `init=/bin/sh`).  See auth_force_user / docs. */
+			auth_force_user("root");
 			task_create("rescu.sh", shell_run);
 		} else {
 			task_create("net", net_lwip_task);

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -89,7 +89,7 @@ gui.elf: crt0.o wm.o gui_gfx.o gui_ui.o gui_browser.o makx.o
 # makx clients: each links the gui_gfx/gui_ui/gui_browser helpers it uses plus
 # the makx client library (makx.o).  Applications are independent processes that
 # talk to gui.elf (the display server) over IPC + a shared surface; see makx.h.
-mxterm.elf: crt0.o mxterm.o gui_gfx.o makx.o
+mxterm.elf: crt0.o mxterm.o vt100.o gui_gfx.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxfiles.elf: crt0.o mxfiles.o gui_gfx.o gui_ui.o gui_browser.o makx.o

--- a/src/userspace/doomgeneric_makar.c
+++ b/src/userspace/doomgeneric_makar.c
@@ -227,9 +227,12 @@ int main(int argc, char **argv)
 
     static char *na[16];
     if (!has_iwad(argc, argv)) {
-        /* With -m 64 + a 40 MiB backed heap the full 12 MiB DOOM.WAD loads, so
-         * prefer it; DOOM1.WAD (shareware) and /tmp fetches are fallbacks. */
+        /* Prefer the BSD-licensed FreeDOOM IWADs (shipped by default, see
+         * getfreedoom.sh) so DOOM Just Works without the copyrighted DOOM.WAD;
+         * fall back to DOOM.WAD / DOOM1.WAD (shareware) and /tmp fetches if
+         * someone supplies them. */
         static const char *cand[] = {
+            "/apps/freedoom1.wad", "/apps/freedoom2.wad",
             "/apps/DOOM.WAD",  "/tmp/DOOM.WAD",   "/apps/DOOM2.WAD",
             "/apps/DOOM1.WAD", "/apps/doom1.wad", "/tmp/DOOM1.WAD", 0
         };

--- a/src/userspace/doomgeneric_makar.c
+++ b/src/userspace/doomgeneric_makar.c
@@ -197,9 +197,15 @@ int DG_GetKey(int *pressed, unsigned char *doomKey)
 
 void DG_SetWindowTitle(const char *title) { (void)title; }
 
-/* If the caller didn't pass -iwad, look for a WAD next to doom.elf (/apps) or
- * in /tmp (where getwad.sh saves) and inject it.  Lets `doom` and the gui Doom
- * icon Just Work with a bundled/fetched WAD. */
+/* Flag handling (passed straight through to doomgeneric's d_main.c):
+ *   doom -iwad /apps/DOOM.WAD            pick a specific IWAD
+ *   doom -file /tmp/mymap.wad …          load one or more PWADs (mods/maps)
+ *   doom -iwad <iwad> -file <pwad> …     both together
+ * If no -iwad is given we auto-pick a bundled/fetched IWAD (cand[] below).
+ * `-makx <pid>` (display-server handle) is stripped before doomgeneric sees it.
+ *
+ * If the caller didn't pass -iwad, look for a WAD in /apps (bundled) or /tmp
+ * (where getwad.sh saves) and inject it. */
 static int has_iwad(int argc, char **argv)
 {
     for (int i = 1; i < argc; i++)
@@ -216,16 +222,16 @@ int main(int argc, char **argv)
     if (mx_connect(&s_mc, argc, argv, DOOMGENERIC_RESX, DOOMGENERIC_RESY, 0) == 0)
         s_windowed = 1;
 
-    static char *fa[18];
+    static char *fa[34];
     int fc = 0;
-    for (int i = 0; i < argc && fc < 17; i++) {
+    for (int i = 0; i < argc && fc < 33; i++) {
         if (i >= 1 && !strcmp(argv[i], "-makx") && i + 1 < argc) { i++; continue; }
         fa[fc++] = argv[i];
     }
     fa[fc] = 0;
     argv = fa; argc = fc;
 
-    static char *na[16];
+    static char *na[36];
     if (!has_iwad(argc, argv)) {
         /* Prefer the BSD-licensed FreeDOOM IWADs (shipped by default, see
          * getfreedoom.sh) so DOOM Just Works without the copyrighted DOOM.WAD;
@@ -242,7 +248,7 @@ int main(int argc, char **argv)
                 sys_close(fd);
                 int n = 0;
                 na[n++] = argv[0]; na[n++] = "-iwad"; na[n++] = (char *)cand[i];
-                for (int j = 1; j < argc && n < 14; j++) na[n++] = argv[j];
+                for (int j = 1; j < argc && n < 34; j++) na[n++] = argv[j];
                 na[n] = 0;
                 argv = na; argc = n;
                 break;

--- a/src/userspace/mxterm.c
+++ b/src/userspace/mxterm.c
@@ -48,6 +48,9 @@ static void term_spawn(void){
     sys_close(ip[0]);sys_close(op[1]);
     sys_fcntl(term_out,F_SETFL,O_NONBLOCK);
     sys_fcntl(term_in,F_SETFL,O_NONBLOCK);
+    /* Publish our grid size so the child's SYS_TERM_SIZE (and any TUI app it
+     * runs) reports the terminal window's real dimensions, not the VT's. */
+    sys_pty_winsize(term_out, vt.cols, vt.rows);
 }
 static void term_kill(void){
     if(term_pid>0){sys_kill(term_pid,SIGKILL);int st;sys_wait4(term_pid,&st,0);}
@@ -68,7 +71,10 @@ static void term_key(int k){ if(term_in<0)return; unsigned char b=(unsigned char
 static void term_fit(gfx_surface *s){
     int cols=(s->w-8)/8, rows=(s->h-8)/8;
     if(cols<1)cols=1; if(rows<1)rows=1;
-    if(cols!=vt.cols||rows!=vt.rows) vt_resize(&vt,cols,rows);
+    if(cols!=vt.cols||rows!=vt.rows){
+        vt_resize(&vt,cols,rows);
+        if(term_out>=0) sys_pty_winsize(term_out, vt.cols, vt.rows);
+    }
 }
 static void term_draw(gfx_surface *s, int focused){
     gfx_fill(s,0,0,s->w,s->h,PAL[0]);

--- a/src/userspace/mxterm.c
+++ b/src/userspace/mxterm.c
@@ -1,42 +1,40 @@
 /*
- * mxterm.elf -- terminal, as a makx client.  Forks /apps/sh.elf over a pair of
- * pipes, renders the byte stream as a character grid into its makx surface, and
- * forwards keys the display server delivers (over IPC) to the shell's stdin.
- * Was the W_TERMINAL window kind built into the old monolithic wm.c; now an
- * ordinary client process talking the makx protocol (makx.h).
+ * mxterm.elf -- a real ANSI/VT100+ terminal, as a makx client.  Forks
+ * /apps/sh.elf over a pair of pipes, feeds the child's byte stream through the
+ * vt100 emulator core (vt100.c), and renders its colour cell grid into the makx
+ * surface; forwards keys the display server delivers to the shell's stdin.
+ *
+ * Was a single-colour glass-TTY; now parses CSI/SGR/scroll-region/alt-screen so
+ * TUI programs (maktop, vix, ls --color, ...) render correctly in the window.
  */
 #include "syscall.h"
 #include "gui_gfx.h"
 #include "makx.h"
+#include "vt100.h"
 
 #define RGB GFX_RGB
-#define COL_TEXT RGB(0xd3,0xd7,0xcf)
 
 static void scpy(char *d,const char *s,int max){int i=0;while(s[i]&&i<max-1){d[i]=s[i];i++;}d[i]=0;}
 static char *scat(char *d,const char *s){while(*d)d++;while(*s)*d++=*s++;*d=0;return d;}
 
-#define TCOLS 80
-#define TROWS 50
-static char term[TROWS][TCOLS];
-static int  t_cols, t_rows, t_cr, t_cc;
-static int  term_pid=-1, term_in=-1, term_out=-1;
+/* Standard 16-colour ANSI palette (0-7 normal, 8-15 bright). */
+static const gfx_u32 PAL[16] = {
+    RGB(0x00,0x00,0x00), RGB(0xaa,0x00,0x00), RGB(0x00,0xaa,0x00), RGB(0xaa,0x55,0x00),
+    RGB(0x00,0x00,0xaa), RGB(0xaa,0x00,0xaa), RGB(0x00,0xaa,0xaa), RGB(0xc0,0xc4,0xbe),
+    RGB(0x55,0x55,0x55), RGB(0xff,0x55,0x55), RGB(0x55,0xff,0x55), RGB(0xff,0xff,0x55),
+    RGB(0x55,0x55,0xff), RGB(0xff,0x55,0xff), RGB(0x55,0xff,0xff), RGB(0xff,0xff,0xff) };
 
-static void term_clear(void){ for(int r=0;r<TROWS;r++)for(int c=0;c<TCOLS;c++)term[r][c]=' '; t_cr=t_cc=0; }
-static void term_newline(void){ t_cc=0; if(++t_cr>=t_rows){ for(int r=0;r<t_rows-1;r++)for(int c=0;c<TCOLS;c++)term[r][c]=term[r+1][c]; for(int c=0;c<TCOLS;c++)term[t_rows-1][c]=' '; t_cr=t_rows-1; } }
-static void term_putc(char ch){
-    if(ch=='\n'){term_newline();return;}
-    if(ch=='\r'){t_cc=0;return;}
-    if(ch==8||ch==127){if(t_cc>0){t_cc--;term[t_cr][t_cc]=' ';}return;}
-    if(ch<32)return;
-    if(t_cc>=t_cols)term_newline();
-    if(t_cr<TROWS&&t_cc<TCOLS)term[t_cr][t_cc++]=ch;
-}
+static vt_term vt;
+static int term_pid=-1, term_in=-1, term_out=-1;
+
+static void feed(const char *s){ while(*s) vt_putc(&vt,(unsigned char)*s++); }
+
 static void term_spawn(void){
     if(term_pid>0)return;
     int ip[2],op[2];
-    if(sys_pipe(ip)<0||sys_pipe(op)<0){const char*m="terminal: pipe failed\n";for(int i=0;m[i];i++)term_putc(m[i]);return;}
+    if(sys_pipe(ip)<0||sys_pipe(op)<0){ feed("terminal: pipe failed\r\n"); return; }
     int pid=sys_fork();
-    if(pid<0){const char*m="terminal: fork failed\n";for(int i=0;m[i];i++)term_putc(m[i]);return;}
+    if(pid<0){ feed("terminal: fork failed\r\n"); return; }
     if(pid==0){
         sys_close(ip[1]);sys_close(op[0]);
         sys_dup2(ip[0],0);sys_dup2(op[1],1);sys_dup2(op[1],2);
@@ -59,36 +57,40 @@ static void term_kill(void){
 }
 static int term_pump(void){
     if(term_out<0)return 0;
-    unsigned char b[128];int dirty=0;
-    for(;;){long n=sys_read(term_out,b,sizeof b);if(n<=0)break;for(long i=0;i<n;i++)term_putc((char)b[i]);dirty=1;if(n<(long)sizeof b)break;}
-    if(term_pid>0){int st;if(sys_wait4(term_pid,&st,WNOHANG)==term_pid){term_pid=-1;const char*m="\n[shell exited]\n";for(int i=0;m[i];i++)term_putc(m[i]);dirty=1;}}
+    unsigned char b[256];int dirty=0;
+    for(;;){long n=sys_read(term_out,b,sizeof b);if(n<=0)break;for(long i=0;i<n;i++)vt_putc(&vt,b[i]);dirty=1;if(n<(long)sizeof b)break;}
+    if(term_pid>0){int st;if(sys_wait4(term_pid,&st,WNOHANG)==term_pid){term_pid=-1;feed("\r\n[shell exited]\r\n");dirty=1;}}
     return dirty;
 }
 static void term_key(int k){ if(term_in<0)return; unsigned char b=(unsigned char)k; if(b=='\r')b='\n'; sys_write(term_in,&b,1); }
 
+/* Grid geometry: 8x8 glyphs with a 4px margin. */
+static void term_fit(gfx_surface *s){
+    int cols=(s->w-8)/8, rows=(s->h-8)/8;
+    if(cols<1)cols=1; if(rows<1)rows=1;
+    if(cols!=vt.cols||rows!=vt.rows) vt_resize(&vt,cols,rows);
+}
 static void term_draw(gfx_surface *s, int focused){
-    gfx_fill(s,0,0,s->w,s->h,RGB(0x0e,0x12,0x18));
-    t_cols=(s->w-8)/8; if(t_cols>TCOLS)t_cols=TCOLS;
-    t_rows=(s->h-8)/8; if(t_rows>TROWS)t_rows=TROWS;
-    for(int r=0;r<t_rows;r++)for(int c=0;c<t_cols;c++)
-        if(term[r][c]!=' ')gfx_char(s,4+c*8,4+r*8,(unsigned char)term[r][c],COL_TEXT);
-    if(focused && t_cr<t_rows && t_cc<t_cols)
-        gfx_fill(s,4+t_cc*8,4+t_cr*8,8,8,RGB(0x8a,0xe2,0x34));
+    gfx_fill(s,0,0,s->w,s->h,PAL[0]);
+    for(int r=0;r<vt.rows;r++)for(int c=0;c<vt.cols;c++){
+        vt_cell *cl=&vt.cell[r][c];
+        int x=4+c*8, y=4+r*8;
+        if(cl->bg) gfx_fill(s,x,y,8,8,PAL[cl->bg&15]);
+        if(cl->ch!=' ') gfx_char(s,x,y,cl->ch,PAL[cl->fg&15]);
+    }
+    if(focused && vt.cursor_visible && vt.cx<vt.cols && vt.cy<vt.rows)
+        gfx_fill(s,4+vt.cx*8,4+vt.cy*8,8,8,RGB(0x8a,0xe2,0x34));
 }
 
 int main(int argc,char**argv){
     mx_conn c;
     if(mx_connect(&c,argc,argv,640,400,MX_F_RESIZABLE)!=0) return 1;
-    /* Size the grid up front: term_putc wraps/scrolls using t_cols/t_rows, and
-     * the shell can emit its banner+prompt before the first term_draw runs --
-     * leaving these 0 would scroll the first output off into a negative row. */
-    t_cols=(c.surf.w-8)/8; if(t_cols>TCOLS)t_cols=TCOLS; if(t_cols<1)t_cols=1;
-    t_rows=(c.surf.h-8)/8; if(t_rows>TROWS)t_rows=TROWS; if(t_rows<1)t_rows=1;
-    term_clear();
+    { int cols=(c.surf.w-8)/8, rows=(c.surf.h-8)/8; vt_init(&vt,cols,rows); }
     term_spawn();
     int first=1;
     while(!c.closed){
         mx_pump(&c);
+        if(c.resized) term_fit(&c.surf);
         int k,keyed=0; while((k=mx_key(&c))>=0){ term_key(k); keyed=1; }
         int dirty=term_pump();
         if(dirty||keyed||first||c.resized){ term_draw(&c.surf,c.focused); mx_present(&c); first=0; }

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -620,6 +620,12 @@ static inline int sys_login(const char *user, const char *pass)
 {
     return (int)syscall2(SYS_LOGIN, (long)user, (long)pass);
 }
+/* Change the current session user's password.  0 = ok, -2 = wrong current
+ * password, -1 = otherwise (bad args / read-only live rootfs). */
+static inline int sys_passwd(const char *oldp, const char *newp)
+{
+    return (int)syscall2(SYS_PASSWD, (long)oldp, (long)newp);
+}
 static inline int sys_gui_close(void)
 {
     return (int)syscall1(SYS_GUI_CLOSE, 0);

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -626,6 +626,11 @@ static inline int sys_passwd(const char *oldp, const char *newp)
 {
     return (int)syscall2(SYS_PASSWD, (long)oldp, (long)newp);
 }
+/* Test-and-clear the pending Ctrl-Alt-Del flag (1 if it was pressed). */
+static inline int sys_cad_pending(void)
+{
+    return (int)syscall1(SYS_CAD_PENDING, 0);
+}
 static inline int sys_gui_close(void)
 {
     return (int)syscall1(SYS_GUI_CLOSE, 0);

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -631,6 +631,13 @@ static inline int sys_cad_pending(void)
 {
     return (int)syscall1(SYS_CAD_PENDING, 0);
 }
+/* Publish a pty window size onto a pipe fd so a piped child's SYS_TERM_SIZE
+ * reports it (GUI terminal -> shell).  0 ok, -1 if fd isn't a pipe. */
+static inline int sys_pty_winsize(int fd, int cols, int rows)
+{
+    return (int)syscall2(SYS_PTY_WINSIZE, fd,
+                         ((long)(cols & 0xFFFF) << 16) | (rows & 0xFFFF));
+}
 static inline int sys_gui_close(void)
 {
     return (int)syscall1(SYS_GUI_CLOSE, 0);

--- a/src/userspace/vt100.c
+++ b/src/userspace/vt100.c
@@ -267,7 +267,11 @@ void vt_putc(vt_term *t, unsigned char b)
     if (b == 0x1B) { t->state = VT_ESC; return; }
     if (b < 0x20) {                                            /* C0 controls */
         switch (b) {
-        case '\n': line_feed(t); break;
+        /* Makar convention (matches the kernel VGA console, t_putchar): a bare
+         * '\n' is a *newline* -- carriage-return + line-feed -- since apps emit
+         * '\n' between lines rather than "\r\n".  (A strict VT would move down
+         * only; that left prompts cascading diagonally.) */
+        case '\n': t->cx = 0; line_feed(t); break;
         case '\r': t->cx = 0; break;
         case '\b': if (t->cx > 0) t->cx--; break;
         case '\t': t->cx = (t->cx + 8) & ~7; if (t->cx > t->cols-1) t->cx = t->cols-1; break;

--- a/src/userspace/vt100.c
+++ b/src/userspace/vt100.c
@@ -1,0 +1,291 @@
+/* vt100.c -- ANSI/VT100+ terminal emulator core.  See vt100.h. */
+#include "vt100.h"
+
+/* Local mem helpers so the emulator stays freestanding (mxterm links without
+ * libc.a, like the other makx clients). */
+static void *memset(void *d, int v, unsigned long n)
+{ unsigned char *p = d; while (n--) *p++ = (unsigned char)v; return d; }
+static void *memcpy(void *d, const void *s, unsigned long n)
+{ unsigned char *a = d; const unsigned char *b = s; while (n--) *a++ = *b++; return d; }
+
+enum { VT_GROUND=0, VT_ESC, VT_CSI, VT_OSC };
+
+/* ---- cell helpers -------------------------------------------------------- */
+
+/* Final fg/bg for a write, applying bold (brightens 0-7) then reverse-video. */
+static void cur_colours(vt_term *t, unsigned char *fg, unsigned char *bg)
+{
+    unsigned char f = t->cur_fg, b = t->cur_bg;
+    if (t->bold && f < 8) f += 8;
+    if (t->reverse) { unsigned char x = f; f = b; b = x; }
+    *fg = f; *bg = b;
+}
+static vt_cell blank_cell(vt_term *t)
+{
+    vt_cell c; unsigned char f, b; cur_colours(t, &f, &b);
+    c.ch = ' '; c.fg = f; c.bg = b; return c;
+}
+static void clear_region(vt_term *t, int r0, int c0, int r1, int c1)
+{
+    vt_cell bl = blank_cell(t);
+    for (int r = r0; r <= r1 && r < t->rows; r++)
+        for (int c = (r==r0?c0:0); c <= (r==r1?c1:t->cols-1) && c < t->cols; c++)
+            t->cell[r][c] = bl;
+}
+
+/* ---- scrolling within the current region --------------------------------- */
+static void scroll_up(vt_term *t, int n)
+{
+    if (n < 1) return;
+    vt_cell bl = blank_cell(t);
+    for (int r = t->s_top; r <= t->s_bot; r++) {
+        int src = r + n;
+        for (int c = 0; c < t->cols; c++)
+            t->cell[r][c] = (src <= t->s_bot) ? t->cell[src][c] : bl;
+    }
+}
+static void scroll_down(vt_term *t, int n)
+{
+    if (n < 1) return;
+    vt_cell bl = blank_cell(t);
+    for (int r = t->s_bot; r >= t->s_top; r--) {
+        int src = r - n;
+        for (int c = 0; c < t->cols; c++)
+            t->cell[r][c] = (src >= t->s_top) ? t->cell[src][c] : bl;
+    }
+}
+
+/* ---- cursor / output ----------------------------------------------------- */
+static void clampc(vt_term *t)
+{
+    if (t->cx < 0) t->cx = 0; if (t->cx >= t->cols) t->cx = t->cols-1;
+    if (t->cy < 0) t->cy = 0; if (t->cy >= t->rows) t->cy = t->rows-1;
+}
+static void line_feed(vt_term *t)
+{
+    if (t->cy == t->s_bot) scroll_up(t, 1);
+    else if (t->cy < t->rows-1) t->cy++;
+}
+static void put_glyph(vt_term *t, unsigned int cp)
+{
+    if (t->cx >= t->cols) { t->cx = 0; line_feed(t); }
+    unsigned char f, b; cur_colours(t, &f, &b);
+    vt_cell *c = &t->cell[t->cy][t->cx];
+    c->ch = (cp < 128u) ? (unsigned char)cp : '?';
+    c->fg = f; c->bg = b;
+    t->cx++;
+}
+
+/* ---- init / resize ------------------------------------------------------- */
+void vt_init(vt_term *t, int cols, int rows)
+{
+    memset(t, 0, sizeof(*t));
+    if (cols < 1) cols = 1; if (cols > VT_MAXCOLS) cols = VT_MAXCOLS;
+    if (rows < 1) rows = 1; if (rows > VT_MAXROWS) rows = VT_MAXROWS;
+    t->cols = cols; t->rows = rows;
+    t->cur_fg = 7; t->cur_bg = 0;
+    t->s_top = 0; t->s_bot = rows-1;
+    t->cursor_visible = 1;
+    vt_cell bl = blank_cell(t);
+    for (int r = 0; r < rows; r++) for (int c = 0; c < cols; c++) t->cell[r][c] = bl;
+}
+void vt_resize(vt_term *t, int cols, int rows)
+{
+    if (cols < 1) cols = 1; if (cols > VT_MAXCOLS) cols = VT_MAXCOLS;
+    if (rows < 1) rows = 1; if (rows > VT_MAXROWS) rows = VT_MAXROWS;
+    /* Blank any newly-exposed cells; keep existing content in place. */
+    vt_cell bl = blank_cell(t);
+    for (int r = 0; r < rows; r++)
+        for (int c = 0; c < cols; c++)
+            if (r >= t->rows || c >= t->cols) t->cell[r][c] = bl;
+    t->cols = cols; t->rows = rows;
+    t->s_top = 0; t->s_bot = rows-1;        /* reset scroll region on resize */
+    clampc(t);
+}
+
+/* ---- CSI dispatch -------------------------------------------------------- */
+static int pget(vt_term *t, int i, int def)       /* param i, 0/absent -> def */
+{
+    int v = (i < t->nparam) ? t->params[i] : 0;
+    return v ? v : def;
+}
+static void csi_dispatch(vt_term *t, unsigned char f)
+{
+    int n;
+    switch (f) {
+    case 'A': t->cy -= pget(t,0,1); if (t->cy < t->s_top) t->cy = t->s_top; break;
+    case 'B': t->cy += pget(t,0,1); if (t->cy > t->s_bot) t->cy = t->s_bot; break;
+    case 'C': t->cx += pget(t,0,1); if (t->cx > t->cols-1) t->cx = t->cols-1; break;
+    case 'D': t->cx -= pget(t,0,1); if (t->cx < 0) t->cx = 0; break;
+    case 'E': t->cy += pget(t,0,1); t->cx = 0; clampc(t); break;
+    case 'F': t->cy -= pget(t,0,1); t->cx = 0; clampc(t); break;
+    case 'G': case '`': t->cx = pget(t,0,1)-1; clampc(t); break;
+    case 'd': t->cy = pget(t,0,1)-1; clampc(t); break;
+    case 'H': case 'f':
+        t->cy = pget(t,0,1)-1; t->cx = pget(t,1,1)-1; clampc(t); break;
+    case 'J': {                                   /* ED */
+        int m = (0 < t->nparam) ? t->params[0] : 0;
+        if (m == 0)      clear_region(t, t->cy, t->cx, t->rows-1, t->cols-1);
+        else if (m == 1) clear_region(t, 0, 0, t->cy, t->cx);
+        else             clear_region(t, 0, 0, t->rows-1, t->cols-1);
+        break; }
+    case 'K': {                                   /* EL */
+        int m = (0 < t->nparam) ? t->params[0] : 0;
+        if (m == 0)      clear_region(t, t->cy, t->cx, t->cy, t->cols-1);
+        else if (m == 1) clear_region(t, t->cy, 0, t->cy, t->cx);
+        else             clear_region(t, t->cy, 0, t->cy, t->cols-1);
+        break; }
+    case 'S': scroll_up(t, pget(t,0,1)); break;
+    case 'T': scroll_down(t, pget(t,0,1)); break;
+    case 'L': {                                   /* IL: insert lines at cy */
+        if (t->cy < t->s_top || t->cy > t->s_bot) break;
+        n = pget(t,0,1);
+        for (int i = 0; i < n; i++) {
+            for (int r = t->s_bot; r > t->cy; r--)
+                memcpy(t->cell[r], t->cell[r-1], sizeof(vt_cell)*t->cols);
+            vt_cell bl = blank_cell(t);
+            for (int c = 0; c < t->cols; c++) t->cell[t->cy][c] = bl;
+        }
+        break; }
+    case 'M': {                                   /* DL: delete lines at cy */
+        if (t->cy < t->s_top || t->cy > t->s_bot) break;
+        n = pget(t,0,1);
+        for (int i = 0; i < n; i++) {
+            for (int r = t->cy; r < t->s_bot; r++)
+                memcpy(t->cell[r], t->cell[r+1], sizeof(vt_cell)*t->cols);
+            vt_cell bl = blank_cell(t);
+            for (int c = 0; c < t->cols; c++) t->cell[t->s_bot][c] = bl;
+        }
+        break; }
+    case '@': {                                   /* ICH: insert blanks */
+        n = pget(t,0,1); vt_cell bl = blank_cell(t);
+        for (int c = t->cols-1; c >= t->cx; c--)
+            t->cell[t->cy][c] = (c-n >= t->cx) ? t->cell[t->cy][c-n] : bl;
+        break; }
+    case 'P': {                                   /* DCH: delete chars */
+        n = pget(t,0,1); vt_cell bl = blank_cell(t);
+        for (int c = t->cx; c < t->cols; c++)
+            t->cell[t->cy][c] = (c+n < t->cols) ? t->cell[t->cy][c+n] : bl;
+        break; }
+    case 'X': {                                   /* ECH: erase chars */
+        n = pget(t,0,1);
+        clear_region(t, t->cy, t->cx, t->cy, t->cx+n-1 < t->cols ? t->cx+n-1 : t->cols-1);
+        break; }
+    case 'r':                                     /* DECSTBM scroll region */
+        t->s_top = pget(t,0,1)-1;
+        t->s_bot = pget(t,1,t->rows)-1;
+        if (t->s_top < 0) t->s_top = 0;
+        if (t->s_bot > t->rows-1) t->s_bot = t->rows-1;
+        if (t->s_top >= t->s_bot) { t->s_top = 0; t->s_bot = t->rows-1; }
+        t->cx = 0; t->cy = t->s_top;
+        break;
+    case 'h': case 'l': {                          /* DECSET/RST (private) */
+        int set = (f == 'h');
+        if (t->priv) {
+            int m = (0 < t->nparam) ? t->params[0] : 0;
+            if (m == 25) t->cursor_visible = set;
+            else if (m == 1049) {                  /* alt-screen */
+                if (set && !t->alt_active) {
+                    memcpy(t->alt_save, t->cell, sizeof(t->cell));
+                    t->alt_cx = t->cx; t->alt_cy = t->cy;
+                    t->alt_active = 1;
+                    clear_region(t, 0, 0, t->rows-1, t->cols-1);
+                    t->cx = t->cy = 0;
+                } else if (!set && t->alt_active) {
+                    memcpy(t->cell, t->alt_save, sizeof(t->cell));
+                    t->cx = t->alt_cx; t->cy = t->alt_cy;
+                    t->alt_active = 0;
+                }
+            }
+        }
+        break; }
+    case 'm': {                                    /* SGR */
+        if (t->nparam == 0) { t->cur_fg = 7; t->cur_bg = 0; t->bold = t->reverse = 0; break; }
+        for (int i = 0; i < t->nparam; i++) {
+            int p = t->params[i];
+            if (p == 0)              { t->cur_fg = 7; t->cur_bg = 0; t->bold = t->reverse = 0; }
+            else if (p == 1)         t->bold = 1;
+            else if (p == 22)        t->bold = 0;
+            else if (p == 7)         t->reverse = 1;
+            else if (p == 27)        t->reverse = 0;
+            else if (p >= 30 && p <= 37)   t->cur_fg = (unsigned char)(p-30);
+            else if (p == 39)        t->cur_fg = 7;
+            else if (p >= 40 && p <= 47)   t->cur_bg = (unsigned char)(p-40);
+            else if (p == 49)        t->cur_bg = 0;
+            else if (p >= 90 && p <= 97)   t->cur_fg = (unsigned char)(p-90+8);
+            else if (p >= 100 && p <= 107) t->cur_bg = (unsigned char)(p-100+8);
+        }
+        break; }
+    default: break;                                /* swallow unknown */
+    }
+}
+
+/* ---- byte feed ----------------------------------------------------------- */
+void vt_putc(vt_term *t, unsigned char b)
+{
+    switch (t->state) {
+    case VT_ESC:
+        switch (b) {
+        case '[': t->state = VT_CSI; t->nparam = 0; t->priv = 0;
+                  for (int i = 0; i < VT_MAXPARAM; i++) t->params[i] = 0; return;
+        case ']': t->state = VT_OSC; return;
+        case '7': t->saved_cx = t->cx; t->saved_cy = t->cy; t->state = VT_GROUND; return;
+        case '8': t->cx = t->saved_cx; t->cy = t->saved_cy; clampc(t); t->state = VT_GROUND; return;
+        case 'M': if (t->cy == t->s_top) scroll_down(t,1); else if (t->cy>0) t->cy--;
+                  t->state = VT_GROUND; return;
+        case 'c': vt_init(t, t->cols, t->rows); return;        /* RIS */
+        case '(': case ')': case '*': case '+':                /* charset: eat next */
+                  t->state = VT_ESC + 100; return;             /* one-byte swallow */
+        default:  t->state = VT_GROUND; return;
+        }
+    case VT_ESC + 100: t->state = VT_GROUND; return;           /* swallowed charset byte */
+    case VT_CSI:
+        if (b == '?') { t->priv = 1; return; }
+        if (b >= '0' && b <= '9') {
+            int i = t->nparam ? t->nparam-1 : 0;
+            t->params[i] = t->params[i]*10 + (b-'0');
+            if (!t->nparam) t->nparam = 1;
+            return;
+        }
+        if (b == ';') {
+            if (!t->nparam) t->nparam = 1;
+            if (t->nparam < VT_MAXPARAM) t->nparam++;
+            return;
+        }
+        if (b >= 0x40 && b <= 0x7E) { csi_dispatch(t, b); t->state = VT_GROUND; return; }
+        return;                                                /* intermediates: ignore */
+    case VT_OSC:
+        if (b == 0x07) t->state = VT_GROUND;                   /* BEL terminates */
+        else if (b == 0x1B) t->state = VT_ESC + 200;           /* maybe ST (ESC \) */
+        return;
+    case VT_ESC + 200:
+        t->state = VT_GROUND; return;                          /* ST or abort OSC */
+    default: break;                                            /* VT_GROUND below */
+    }
+
+    /* GROUND */
+    if (b == 0x1B) { t->state = VT_ESC; return; }
+    if (b < 0x20) {                                            /* C0 controls */
+        switch (b) {
+        case '\n': line_feed(t); break;
+        case '\r': t->cx = 0; break;
+        case '\b': if (t->cx > 0) t->cx--; break;
+        case '\t': t->cx = (t->cx + 8) & ~7; if (t->cx > t->cols-1) t->cx = t->cols-1; break;
+        case 0x07: break;                                      /* BEL: no-op */
+        default: break;
+        }
+        return;
+    }
+
+    /* UTF-8 decode -> one cell per codepoint (ASCII renders, else '?'). */
+    if (b < 0x80) { t->u8_left = 0; put_glyph(t, b); return; }
+    if ((b & 0xC0) == 0x80) {                                  /* continuation */
+        if (t->u8_left) { t->u8_cp = (t->u8_cp << 6) | (b & 0x3F);
+                          if (--t->u8_left == 0) put_glyph(t, t->u8_cp); }
+        return;
+    }
+    if ((b & 0xE0) == 0xC0) { t->u8_cp = b & 0x1F; t->u8_left = 1; return; }
+    if ((b & 0xF0) == 0xE0) { t->u8_cp = b & 0x0F; t->u8_left = 2; return; }
+    if ((b & 0xF8) == 0xF0) { t->u8_cp = b & 0x07; t->u8_left = 3; return; }
+    t->u8_left = 0;                                            /* invalid lead */
+}

--- a/src/userspace/vt100.h
+++ b/src/userspace/vt100.h
@@ -1,0 +1,60 @@
+/*
+ * vt100.h -- a small ANSI/VT100+ terminal emulator core (parser + cell grid).
+ *
+ * Freestanding/userspace: no libc beyond memcpy/memset.  Feed it the byte
+ * stream from a child program with vt_putc(); it maintains a colour cell grid
+ * that a front-end (mxterm) renders.  Reusable by any terminal surface (a
+ * future serial console can share it).
+ *
+ * Coverage: C0 controls; CSI cursor moves (CUU/CUD/CUF/CUB/CNL/CPL/CHA/VPA/
+ * CUP/HVP), ED/EL erase, SGR colours (30-37/40-47 + bright 90-97/100-107 +
+ * bold/reset/reverse), DECSTBM scroll region + SU/SD, IL/DL/ICH/DCH/ECH,
+ * DECTCEM cursor show/hide, DECSET/RST 1049 alt-screen, ESC 7/8 save/restore,
+ * ESC M reverse-index, ESC c reset.  OSC is consumed (title ignored).  Unknown
+ * sequences are swallowed, never printed as garbage.  UTF-8 is decoded so a
+ * multibyte codepoint occupies one cell (rendered as ASCII if <128, else '?').
+ */
+#ifndef VT100_H
+#define VT100_H
+
+#define VT_MAXCOLS  200
+#define VT_MAXROWS  100
+#define VT_MAXPARAM 16
+
+/* Colour indices 0-7 normal, 8-15 bright (bold brightens 0-7).  Defaults:
+ * fg 7 (light grey), bg 0 (black).  A front-end maps these to RGB. */
+typedef struct { unsigned char ch, fg, bg; } vt_cell;
+
+typedef struct {
+    int cols, rows;
+    vt_cell cell[VT_MAXROWS][VT_MAXCOLS];
+
+    int cx, cy;                 /* cursor (0-based) */
+    int s_top, s_bot;           /* scroll region, 0-based inclusive */
+
+    unsigned char cur_fg, cur_bg;
+    int bold, reverse;
+
+    int saved_cx, saved_cy;     /* ESC 7 / ESC 8 */
+    int cursor_visible;
+
+    /* alt-screen (?1049): saved primary grid + cursor */
+    int alt_active;
+    vt_cell alt_save[VT_MAXROWS][VT_MAXCOLS];
+    int alt_cx, alt_cy;
+
+    /* parser */
+    int state;                  /* VT_GROUND / VT_ESC / VT_CSI / VT_OSC */
+    int params[VT_MAXPARAM];
+    int nparam, priv;
+
+    /* UTF-8 decode */
+    int u8_left;
+    unsigned int u8_cp;
+} vt_term;
+
+void vt_init(vt_term *t, int cols, int rows);
+void vt_resize(vt_term *t, int cols, int rows);
+void vt_putc(vt_term *t, unsigned char b);
+
+#endif /* VT100_H */

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -546,23 +546,36 @@ static int dock_hit(int px,int py,int *out_win)
 }
 
 /* top menu bar -------------------------------------------------------------- */
-#define LOGOFF_W 70
-#define EXIT_W   54
+/* IEC 5009 "standby" power glyph (11x11): a broken ring with a vertical bar. */
+#define POWER_W 30
+static const char *PWR_ICON[11]={
+ "    XX     ",
+ "  X XX X   ",
+ " X  XX  X  ",
+ "X   XX   X ",
+ "X        X ",
+ "X        X ",
+ "X        X ",
+ " X      X  ",
+ "  X    X   ",
+ "   XXXX    ",
+ "           " };
+static void draw_power_icon(int bx,int by,gfx_u32 col)
+{
+    for(int r=0;r<11;r++) for(int c=0;PWR_ICON[r][c];c++)
+        if(PWR_ICON[r][c]=='X') gfx_px(&scr,bx+c,by+r,col);
+}
 static void draw_menubar(void)
 {
     gfx_fill(&scr,0,0,(int)FBW,MENU_H,COL_MENU);
     gfx_fill(&scr,0,MENU_H-1,(int)FBW,1,RGB(0x28,0x32,0x44));
     gfx_str(&scr,8,(MENU_H-8)/2,"Makar",RGB(0x8a,0xe2,0x34));
     gfx_str(&scr,64,(MENU_H-8)/2, (focus>=0&&W[focus].in_use)?W[focus].title:"Desktop", RGB(0x90,0xa0,0xb5));
-    int lx=(int)FBW-LOGOFF_W-4;
-    gfx_fill(&scr,lx,2,LOGOFF_W,MENU_H-4,COL_CLOSE);
-    gfx_str(&scr,lx+(LOGOFF_W-gfx_text_w("Log Off"))/2,(MENU_H-8)/2,"Log Off",0xFFFFFF);
-    int ex=lx-EXIT_W-4;
-    gfx_fill(&scr,ex,2,EXIT_W,MENU_H-4,UI_COL_BTN);
-    gfx_str(&scr,ex+(EXIT_W-gfx_text_w("Exit"))/2,(MENU_H-8)/2,"Exit",0xFFFFFF);
+    int px0=(int)FBW-POWER_W-4;
+    gfx_fill(&scr,px0,2,POWER_W,MENU_H-4,UI_COL_BTN);
+    draw_power_icon(px0+(POWER_W-11)/2,(MENU_H-11)/2,0xFFFFFF);
 }
-static int exit_hit(int px,int py){ int ex=(int)FBW-LOGOFF_W-4-EXIT_W-4; return in_rect(px,py,ex,2,EXIT_W,MENU_H-4); }
-static int logoff_hit(int px,int py){ int lx=(int)FBW-LOGOFF_W-4; return in_rect(px,py,lx,2,LOGOFF_W,MENU_H-4); }
+static int power_hit(int px,int py){ int x0=(int)FBW-POWER_W-4; return in_rect(px,py,x0,2,POWER_W,MENU_H-4); }
 
 /* ---- mouse cursor ------------------------------------------------------- */
 static const char *CURSOR[16]={
@@ -700,6 +713,64 @@ static void do_login(const char *prefill_user)
     }
 }
 
+/* ============================ power menu ================================ */
+enum { PWR_NONE=0, PWR_CANCEL, PWR_LOGOUT_GUI, PWR_LOGOUT_SHELL,
+       PWR_SHUTDOWN, PWR_REBOOT, PWR_PASSWD };
+
+/* Centred modal power menu (clones do_login's input/render loop).  Returns one
+ * of the PWR_* actions; Cancel / Esc dismisses it.  The caller (main, or the
+ * Ctrl-Alt-Del path) repaints the desktop afterwards. */
+static int show_power_menu(int cx, int cy)
+{
+    int prev_left=0, dirty=1;
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
+
+    static const char *labels[6]={
+        "Log out (graphical)","Log out to shell","Shut down",
+        "Reboot","Change password...","Cancel" };
+    static const int acts[6]={ PWR_LOGOUT_GUI,PWR_LOGOUT_SHELL,PWR_SHUTDOWN,
+                               PWR_REBOOT,PWR_PASSWD,PWR_CANCEL };
+
+    for(;;){
+        int mpressed=0,mreleased=0; unsigned int ev;
+        while((ev=sys_mouse_read())!=0){
+            cx+=(int)(signed char)((ev>>8)&0xFF); cy+=(int)(signed char)((ev>>16)&0xFF);
+            if(cx<0)cx=0; if(cx>=(int)FBW)cx=(int)FBW-1;
+            if(cy<0)cy=0; if(cy>=(int)FBH)cy=(int)FBH-1;
+            int left=ev&1; if(left&&!prev_left)mpressed=1; if(!left&&prev_left)mreleased=1;
+            prev_left=left; dirty=1;
+        }
+        int mdown=prev_left, key=-1;
+        { unsigned char b; if(sys_read(0,&b,1)==1){ key=b; dirty=1; } }
+        if(key==27) return PWR_CANCEL;                 /* Esc */
+        if(!dirty){ sys_yield(); continue; }
+
+        gfx_fill(&scr,0,0,(int)FBW,(int)FBH,COL_DESK);
+        int pw=300, ph=44+6*40+12, px=(int)FBW/2-pw/2, py=(int)FBH/2-ph/2;
+        gfx_round(&scr,px,py,pw,ph,COL_WIN,COL_BORDER);
+        gfx_fill(&scr,px,py,pw,26,COL_TITLE);
+        gfx_str(&scr,px+(pw-gfx_text_w("Power"))/2,py+9,"Power",0xFFFFFF);
+
+        ui_begin(&u,cx,cy,mdown,mpressed,mreleased,-1);
+        int ret=PWR_NONE;
+        for(int i=0;i<6;i++)
+            if(ui_button(&u,&scr,px+24,py+40+i*40,pw-48,30,labels[i])) ret=acts[i];
+
+        draw_cursor(cx,cy);
+        sys_fb_present(scr.px);
+        dirty=0;
+        if(ret!=PWR_NONE) return ret;
+        sys_yield();
+    }
+}
+
+/* Graphical change-password dialog.  Phase 7 implements it (SYS_PASSWD over
+ * the shadow file); this stub keeps the power-menu commit self-contained. */
+static void show_passwd_dialog(int start_cx, int start_cy)
+{
+    (void)start_cx; (void)start_cy;
+}
+
 /* =============================== main =================================== */
 int main(int argc, char **argv, char **envp)
 {
@@ -729,7 +800,7 @@ int main(int argc, char **argv, char **envp)
 
     int cx=(int)FBW/2, cy=(int)FBH/2, prev_left=0;
     int dragging=0, resizing=0, drag_win=-1, drag_dx=0, drag_dy=0;
-    int announced=0, exit_to_shell=0;
+    int announced=0, exit_to_shell=0, power_action=0;
     unsigned stat_up=0;
 
     for(;;){
@@ -760,8 +831,16 @@ int main(int argc, char **argv, char **envp)
         /* ---- window-management click handling ---- */
         if (mpressed){
             int dk;
-            if (logoff_hit(cx,cy)) break;
-            else if (exit_hit(cx,cy)){ exit_to_shell=1; break; }
+            if (power_hit(cx,cy)){
+                int act=show_power_menu(cx,cy);
+                g_dirty=1; damage_full();           /* repaint desktop after modal */
+                if      (act==PWR_SHUTDOWN)    { power_action=PWR_SHUTDOWN;    break; }
+                else if (act==PWR_REBOOT)      { power_action=PWR_REBOOT;      break; }
+                else if (act==PWR_LOGOUT_GUI)  { power_action=PWR_LOGOUT_GUI;  break; }
+                else if (act==PWR_LOGOUT_SHELL){ exit_to_shell=1; break; }
+                else if (act==PWR_PASSWD)      { show_passwd_dialog(cx,cy); g_dirty=1; damage_full(); }
+                /* CANCEL: stay on the desktop */
+            }
             else if (dock_hit(cx,cy,&dk)){ W[dk].minimized=0; z_raise(dk); set_focus(dk); g_dirty=1; damage_full(); }
             else {
                 int hk=hit_window(cx,cy);
@@ -892,7 +971,11 @@ int main(int argc, char **argv, char **envp)
     }
     sys_fcntl(0,F_SETFL,0);
     sys_statusbar_set(saved_status);
-    if (exit_to_shell) sys_gui_close();
-    else               sys_logout();
+    /* Power actions (clients already torn down above): shut down / reboot are
+     * noreturn on success; fall through to the session exit if they fail. */
+    if (power_action==PWR_SHUTDOWN) sys_shutdown();
+    if (power_action==PWR_REBOOT)   sys_reboot();
+    if (exit_to_shell) sys_gui_close();   /* "Log out to shell" -> CLI shell   */
+    else               sys_logout();      /* "Log out (graphical)" -> login    */
     return 0;
 }

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -883,18 +883,13 @@ int main(int argc, char **argv, char **envp)
         int cmoved = (cx!=cur_sx || cy!=cur_sy);  /* cursor moved this frame? */
 
         /* ---- window-management click handling ---- */
+        /* The power menu opens from the menubar icon OR from Ctrl-Alt-Del
+         * (polled below) -- both set this so the action dispatch lives once. */
+        int want_power_menu = 0;
+
         if (mpressed){
             int dk;
-            if (power_hit(cx,cy)){
-                int act=show_power_menu(cx,cy);
-                g_dirty=1; damage_full();           /* repaint desktop after modal */
-                if      (act==PWR_SHUTDOWN)    { power_action=PWR_SHUTDOWN;    break; }
-                else if (act==PWR_REBOOT)      { power_action=PWR_REBOOT;      break; }
-                else if (act==PWR_LOGOUT_GUI)  { power_action=PWR_LOGOUT_GUI;  break; }
-                else if (act==PWR_LOGOUT_SHELL){ exit_to_shell=1; break; }
-                else if (act==PWR_PASSWD)      { show_passwd_dialog(cx,cy); g_dirty=1; damage_full(); }
-                /* CANCEL: stay on the desktop */
-            }
+            if (power_hit(cx,cy)) want_power_menu=1;
             else if (dock_hit(cx,cy,&dk)){ W[dk].minimized=0; z_raise(dk); set_focus(dk); g_dirty=1; damage_full(); }
             else {
                 int hk=hit_window(cx,cy);
@@ -931,6 +926,22 @@ int main(int argc, char **argv, char **envp)
             if(w->x+w->w>(int)FBW)w->w=(int)FBW-w->x;
             if(w->y+w->h>(int)FBH-DOCK_H)w->h=(int)FBH-DOCK_H-w->y;
             g_dirty=1; damage_win(drag_win);     /* new size */
+        }
+
+        /* ---- Ctrl-Alt-Del opens the power menu instantly (kernel sets the
+         * flag from the IRQ; we test-and-clear it every frame) ---- */
+        if (sys_cad_pending()) want_power_menu=1;
+
+        if (want_power_menu){
+            int act=show_power_menu(cx,cy);
+            g_dirty=1; damage_full();                 /* repaint desktop after modal */
+            if      (act==PWR_SHUTDOWN)    { power_action=PWR_SHUTDOWN;    break; }
+            else if (act==PWR_REBOOT)      { power_action=PWR_REBOOT;      break; }
+            else if (act==PWR_LOGOUT_GUI)  { power_action=PWR_LOGOUT_GUI;  break; }
+            else if (act==PWR_LOGOUT_SHELL){ exit_to_shell=1; break; }
+            else if (act==PWR_PASSWD)      { show_passwd_dialog(cx,cy); g_dirty=1; damage_full(); }
+            /* CANCEL: stay on the desktop */
+            prev_left=0;                               /* swallow the click that opened it */
         }
 
         /* ---- forward input to the focused client over IPC ---- */

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -764,11 +764,65 @@ static int show_power_menu(int cx, int cy)
     }
 }
 
-/* Graphical change-password dialog.  Phase 7 implements it (SYS_PASSWD over
- * the shadow file); this stub keeps the power-menu commit self-contained. */
-static void show_passwd_dialog(int start_cx, int start_cy)
+/* Graphical change-password dialog: Current / New / Confirm via masked fields,
+ * OK calls sys_passwd (verify old + set new over /etc/shadow).  Tab cycles
+ * fields; Esc/Cancel dismisses.  Mirrors do_login's input/render loop. */
+static void show_passwd_dialog(int cx, int cy)
 {
-    (void)start_cx; (void)start_cy;
+    char oldp[64]={0}, newp[64]={0}, conf[64]={0}, err[48]={0};
+    int prev_left=0, dirty=1;
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
+    u.focus=1;
+
+    for(;;){
+        int mpressed=0,mreleased=0; unsigned int ev;
+        while((ev=sys_mouse_read())!=0){
+            cx+=(int)(signed char)((ev>>8)&0xFF); cy+=(int)(signed char)((ev>>16)&0xFF);
+            if(cx<0)cx=0; if(cx>=(int)FBW)cx=(int)FBW-1;
+            if(cy<0)cy=0; if(cy>=(int)FBH)cy=(int)FBH-1;
+            int left=ev&1; if(left&&!prev_left)mpressed=1; if(!left&&prev_left)mreleased=1;
+            prev_left=left; dirty=1;
+        }
+        int mdown=prev_left, key=-1;
+        { unsigned char b; if(sys_read(0,&b,1)==1){ key=b; dirty=1; } }
+        if(key==27) return;                                /* Esc cancels */
+        if(!dirty){ sys_yield(); continue; }
+
+        gfx_fill(&scr,0,0,(int)FBW,(int)FBH,COL_DESK);
+        int pw=340, ph=232, px=(int)FBW/2-pw/2, py=(int)FBH/2-ph/2;
+        gfx_round(&scr,px,py,pw,ph,COL_WIN,COL_BORDER);
+        gfx_fill(&scr,px,py,pw,26,COL_TITLE);
+        gfx_str(&scr,px+(pw-gfx_text_w("Change password"))/2,py+9,"Change password",0xFFFFFF);
+        gfx_str(&scr,px+24,py+50,"Current:",COL_TEXT);
+        gfx_str(&scr,px+24,py+86,"New:",COL_TEXT);
+        gfx_str(&scr,px+24,py+122,"Confirm:",COL_TEXT);
+
+        ui_begin(&u,cx,cy,mdown,mpressed,mreleased,
+                 (key=='\t'||key=='\n'||key=='\r')?-1:key);
+        ui_password(&u,&scr,px+110,py+44, pw-134,22,oldp,(int)sizeof oldp);
+        ui_password(&u,&scr,px+110,py+80, pw-134,22,newp,(int)sizeof newp);
+        ui_password(&u,&scr,px+110,py+116,pw-134,22,conf,(int)sizeof conf);
+        int okc =ui_button(&u,&scr,px+pw/2-92,py+162,88,28,"OK");
+        int cnc =ui_button(&u,&scr,px+pw/2+4, py+162,88,28,"Cancel");
+        if(err[0]) gfx_str(&scr,px+24,py+ph-22,err,COL_CLOSE);
+
+        if(key=='\t') u.focus = (u.focus>=3)?1:(u.focus+1);
+        if(cnc) return;
+        if(okc || key=='\n' || key=='\r'){
+            int match=1; for(int i=0;;i++){ if(newp[i]!=conf[i]){match=0;break;} if(!newp[i])break; }
+            if(!newp[0])      { scpy(err,"New password is empty",sizeof err); u.focus=2; }
+            else if(!match)   { scpy(err,"New passwords do not match",sizeof err); conf[0]=0; u.focus=3; }
+            else {
+                int rc=sys_passwd(oldp,newp);
+                if(rc==0) return;                          /* changed -> close */
+                else if(rc==-2){ scpy(err,"Current password incorrect",sizeof err); oldp[0]=0; u.focus=1; }
+                else           { scpy(err,"Could not change (read-only?)",sizeof err); }
+            }
+        }
+        draw_cursor(cx,cy);
+        sys_fb_present(scr.px);
+        dirty=0; sys_yield();
+    }
 }
 
 /* =============================== main =================================== */


### PR DESCRIPTION
## Summary

GUI/session + **terminal** + OS-polish pass. Makes the desktop feel like a
proper OS: smoother multitasking, a real terminal emulator that runs the
text-mode apps in a window, a power/shutdown menu, a graphical password dialog,
working Ctrl-Alt-Del, a much faster installer, FreeDOOM instead of a copyrighted
WAD, and a root-by-default rescue shell.

This is **PR #1 of a split** — the original effort grew too large for one PR.
Follow-ups (tracked in `CLAUDE.roadmap.md`): **#2** hypervisor GPU drivers
(VBE/VMware-SVGA-II/Hyper-V-synthvid), **#3** modern hardware (AHCI / USB HID /
UEFI), **#4** GUI apps (clock/calc/disk/net + image viewer + web browser),
**#5** memory management + GC (on-demand file I/O / page cache + reclaim).

All gates green: `./run.sh ktest` (875/0), `./run.sh iso test` (shell-smoke +
incore + in-OS libc-tcc — ALL GROUPS PASSED), `./run.sh guitest` (`GUI: READY`).

> Note: the branch name `feat/gpu-drivers-and-os-polish` is a historical
> misnomer — the GPU drivers moved to PR #2. This PR is the GUI/terminal/OS-polish
> slice.

## 1. Scheduler — 250 Hz + per-task quantum (snappier GUI)

The 100 Hz / 40 ms time-slice made multi-window + DOOM laggy (a busy client held
the CPU while the compositor waited). Raise the PIT to **250 Hz** (4 ms slice)
and give each task an effective quantum of `g_sched_quantum × sched_weight`
ticks; the GUI compositor gets weight 3 so it finishes a frame without being
preempted mid-composite. Wall-clock stays correct across the rate change:
`ksleep` takes legacy-100 Hz units and scales internally, and a fixed
**USER_HZ = 100** ABI (like Linux) keeps `SYS_UPTIME` + `/proc` CPU ticks stable
(clock widget, maktop CPU%, etc. unchanged).

## 2. Fast install — multi-sector FS writes

`fat32_write_file` wrote **one 512-byte sector per `ide_write_sectors` call**
(~24,500 DMA setups for a 12 MiB WAD); `ext2_write_file` was block-at-a-time.
Both now coalesce physically-contiguous clusters/blocks into large multi-sector
writes (≤255 sectors/call, the ABI cap) straight from the source buffer — the
Linux "merge adjacent blocks into one bio" idea. ~24,500 calls → ~100. Installer
per-file ceiling raised 16 → 32 MiB.

## 3. FreeDOOM instead of DOOM.WAD

`getfreedoom.sh` fetches the BSD-licensed FreeDOOM IWADs into the gitignored
`wads/` at build (idempotent, best-effort, skipped in CI); `doomgeneric_makar.c`
prefers `freedoom1.wad`. DOOM.WAD stays gitignored and is only a fallback.
Licence in `LICENSES/freedoom.md` + `THIRD-PARTY-NOTICES.md`. `doom -iwad <wad>
-file <pwad…>` flags documented + widened to stack several PWADs.

## 4. GUI power menu + graphical passwd + Ctrl-Alt-Del

- Menubar **power icon** → centred modal: Log out (graphical/shell), Shut down,
  Reboot, Change password…, Cancel/Esc (replaces the old Exit/Log Off buttons).
- **`SYS_PASSWD`(270)** + a masked Current/New/Confirm dialog (reuses
  `ui_password`); verifies via `shadow_verify`, writes via `shadow_set_password`,
  gated to a writable rootfs.
- **Ctrl-Alt-Del** now works in the GUI: the kernel sets the flag from the IRQ;
  the WM polls **`SYS_CAD_PENDING`(271)** each frame and opens the power menu
  instantly. A second CAD within ~1 s pulses an 8042 reset (wedged-GUI escape).

## 5. Rescue → root; reliable live-CD autologin

- `shell=rescue` boots straight to a `root@makar:/#` shell with no prompt
  (single-user-mode trust model, like Linux `init=/bin/sh`).
- The live CD now autologins `user`/`user` reliably — the autologin retries the
  `/etc/shadow` lookup (it was transiently missed during early boot).

## 6. Real ANSI/VT100 terminal + run TUI apps in the window

- **`mxterm`** is now a real **ANSI/VT100+** emulator (new freestanding
  `vt100.c`): colour (SGR), cursor addressing, scroll regions, IL/DL/ICH/DCH/ECH,
  alt-screen, cursor show/hide, UTF-8 → one cell, unknown sequences swallowed.
- **Cell-API → ANSI bridge:** a process forked by `mxterm` has no live VT slot
  and a piped stdout, so its cell-API calls (`SYS_PUTCH_AT`/`SET_CURSOR`/
  `TTY_CLEAR`) are translated to ANSI on fd 1 and rendered by the emulator —
  so **every TUI app (maktop, vix, cfdisk, the installer) runs inside a terminal
  window unchanged**. `SYS_PTY_WINSIZE`(272) publishes the grid size; the real
  text-VT path is untouched.

## 7. Tooling / docs

- `.claude/skills/makar-conventions/SKILL.md` — house rules + style for any agent
  (WWLD, commit discipline, headless testing, single-source ABI, fallback-gating,
  docs-as-you-go). Pointer added to `CLAUDE.md`.
- `halt`/`poweroff` shell aliases. Docs updated per-phase: `gui.md`,
  `syscalls.md` (270/271/272), `glossary.md`, `using-makar.md` (rescue),
  `THIRD-PARTY-NOTICES.md`, `CLAUDE.roadmap.md` (the PR split).

## Testing notes

- ktest 875/0 (adds a USER_HZ rate-contract assertion); iso test ALL PASS;
  guitest `GUI: READY`.
- The terminal's `\n` handling matches Makar's TTY convention (CR+LF), fixed
  after a manual-test catch.
- FreeDOOM (~29 MiB) currently relies on an **interim** band-aid
  (`SYSCALL_FILE_MAX`→32 MiB + interactive `-m 256`) because the kernel eager-
  loads whole files into the heap; the proper fix (on-demand file I/O / page
  cache) is PR #5, which reverts the band-aid (FreeDOOM runs on DOS in <16 MiB).
- Hardware/hypervisor-specific work is deferred to PRs #2/#3 behind capability/
  boot-mode gates so the tested QEMU path is unaffected.
