### PR TITLE
GUI apps: clock / calc / net / disk + Install icon + image viewer (BMP/GIF)

### DIFF
--- a/SURVEY.md
+++ b/SURVEY.md
@@ -155,6 +155,9 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 - **mxfiles** (mxfiles.c) — file browser on the shared `gui_browser` model (Up/Open/Refresh/Go).
 - **mxedit** (mxedit.c) — multi-line text editor with the shared open/save dialog (`br_dialog`).
 - **mxtasks** (mxtasks.c) — task manager: `/proc/tasks` list, Kill, refresh-interval slider.
+- **mxclock / mxcalc / mxnet / mxdisk** (mx*.c) — GUI peers of `clock` / `calc` / `maknetcfg` / `diskinfo`.
+- **mximg** (mximg.c) — image viewer (BMP + GIF; PNG/JPEG pending), Open dialog or path arg.
+- **mxinstall** (mxinstall.c) — graphical OS installer; drives the shared install engine via `SYS_INSTALL_EXEC` (see Installer section + `docs/gui.md`).
 - **doom.elf** (doomgeneric_makar.c) — windowed makx client with `-makx`; unchanged fullscreen path without it.
 - Shared client libs: `gui_gfx` (drawing), `gui_ui` (immediate-mode widgets), `gui_browser` (FS model + file dialog), `makx` (protocol client).
 
@@ -250,33 +253,28 @@ All apps in `/Users/arawn/Makar/src/userspace/` compile to `.elf` files and are 
 ### Tab Completion
 - `fat32_complete(dir_path, prefix, cb, ctx)` - callback per entry
 
-## Installer (`src/kernel/arch/i386/proc/installer.c`, lines 137–466)
+## Installer (`src/kernel/arch/i386/proc/installer.c`)
 
-Fully interactive OS installer. Steps:
+Interactive OS installer, structured as **one shared execution engine** with two
+front-ends — see [docs/gui.md](docs/gui.md) ("Installer") and
+[docs/syscalls.md](docs/syscalls.md) (`SYS_INSTALL_EXEC`).
 
-1. **Probe ISO9660** (lines 146–167) - Find ATAPI CD-ROM with ISO
-2. **List ATA drives** (lines 172–192) - Prompt user to select target HDD
-3. **Confirm destructive write** (lines 216–231) - Type "yes" to proceed
-4. **Install GRUB bootloader** (lines 242–352):
-   - Read `boot.img` and `core.img` from ISO
-   - Patch `boot.img` with `core.img` LBA (sector 1)
-   - Build MBR at sector 0 (GRUB code + partition table + 0x55AA signature)
-   - Write `core.img` to sectors 1..N (embedding area before first partition)
-5. **Format FAT32** (lines 357–364) - `fat32_mkfs()` at LBA 2048
-6. **Mount volume** (lines 369–376) - `fat32_mount()` for directory creation
-7. **Create directory tree** (lines 381–384):
-   - `/boot`
-   - `/boot/grub`
-   - `/boot/grub/i386-pc`
-8. **Copy kernel** (lines 389–394) - `/boot/makar.kernel` from ISO
-9. **Copy GRUB modules** (lines 399–428):
-   - `normal.mod`, `part_msdos.mod`, `fat.mod`, `multiboot2.mod`, `linux.mod`
-   - Non-fatal if missing
-10. **Write grub.cfg** (lines 433–455):
-    - Sets `timeout=0` (no user prompt; boots immediately)
-    - Multiboot2 path: `/boot/makar.kernel`
-    - Includes explicit `boot` command
-11. **Unmount & success** (lines 460–465) - Report success; user removes CD-ROM and reboots
+- **Front-ends.** `installer_run()` is the text (TUI) wizard, rendered as an
+  ANSI/VT100 byte stream to its stdout (so it works on a shell VT and inside an
+  `mxterm` window with one path). `mxinstall.elf` is the graphical wizard. Both
+  collect an `install_params_t` and drive the same engine.
+- **Engine** (`install_exec_begin` / `install_exec_step` / `install_exec_finish`,
+  `install_exec_drives`; `kernel/installer.h`). `begin` partitions
+  (34 MiB FAT32 boot + a data partition), runs `fat32_mkfs`/`ext2_mkfs`, installs
+  **Limine** to the MBR (boot sector + post-MBR stage 2, stage-2 offset patched at
+  0x1a4), copies the kernel + `limine-bios.sys` + a generated `limine.conf`, writes
+  `/etc/{hostname,shadow,autologin}` + home dirs, then mounts the data partition
+  and pre-counts the files to copy. `step` copies one file per call (across
+  `/apps`, `/docs`, `/src`, `/usr`) reporting `{files, total, current}`. `finish`
+  makes `/bin` and unmounts.
+- **Preemptible**: the engine runs with interrupts enabled so the compositor
+  keeps running during the copy; per-file progress also goes to the serial log
+  (`INSTALL>copy <n>/<total> (<pct>%) <name>`). No auto-reboot on the GUI path.
 
 ## iso.sh Script (`iso.sh`, lines 1–79)
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -185,6 +185,8 @@ Clients (each an independent process, `src/userspace/mx*.c`):
 - **mxtasks** parses `/proc/tasks`, Kill via `SYS_KILL`, refresh-interval slider.
 - **mxclock** draws a large digital time + date from `/proc/rtc` (GUI peer of the
   fullscreen `clock.elf`; reuses the same parse, scaled-glyph rendering).
+- **mxcalc** is a button-grid calculator over the same integer expression
+  evaluator as `calc.elf` (`+ - * / %`, parens, unary); mouse or keyboard input.
 - **doom** is the windowed makx client (see below).
 
 An always-on **top menu bar** (drawn after the windows, never occluded) carries

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -187,7 +187,16 @@ Clients (each an independent process, `src/userspace/mx*.c`):
   fullscreen `clock.elf`; reuses the same parse, scaled-glyph rendering).
 - **mxcalc** is a button-grid calculator over the same integer expression
   evaluator as `calc.elf` (`+ - * / %`, parens, unary); mouse or keyboard input.
+- **mxnet** shows the eth0/DHCP/DNS state (`SYS_NET_INFO`) with Renew / Release /
+  Flush-DNS buttons (`SYS_NET_CTL`) — the GUI peer of `maknetcfg.elf`.
+- **mxdisk** is a read-only view of the drives + partition table + FAT32 BPB
+  (`SYS_DISK_INFO`), GUI peer of `diskinfo.elf` (destructive partitioning stays
+  in `cfdisk`/`fdisk`).
 - **doom** is the windowed makx client (see below).
+
+The **Install** desktop icon launches `mxterm` with a one-shot command
+(`mxterm.elf -makx <pid> install` → it runs `sh.elf -c install`), so the in-OS
+installer's TUI renders inside a terminal window via the cell-API→ANSI bridge.
 
 An always-on **top menu bar** (drawn after the windows, never occluded) carries
 the Makar brand, the focused window's title, and a **power icon** at the

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -192,6 +192,10 @@ Clients (each an independent process, `src/userspace/mx*.c`):
 - **mxdisk** is a read-only view of the drives + partition table + FAT32 BPB
   (`SYS_DISK_INFO`), GUI peer of `diskinfo.elf` (destructive partitioning stays
   in `cfdisk`/`fdisk`).
+- **mximg** is an image viewer: an Open dialog (shared `gui_browser`) or a path
+  argument, decode, and aspect-fit-to-window via `gfx_blit_scaled`. Decodes BMP
+  (24/32-bpp uncompressed) today; GIF/PNG/JPEG are the next slice. mmap-backed
+  file + pixel buffers (no libc).
 - **doom** is the windowed makx client (see below).
 
 The **Install** desktop icon launches `mxterm` with a one-shot command

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -194,8 +194,8 @@ Clients (each an independent process, `src/userspace/mx*.c`):
   in `cfdisk`/`fdisk`).
 - **mximg** is an image viewer: an Open dialog (shared `gui_browser`) or a path
   argument, decode, and aspect-fit-to-window via `gfx_blit_scaled`. Decodes BMP
-  (24/32-bpp uncompressed) today; GIF/PNG/JPEG are the next slice. mmap-backed
-  file + pixel buffers (no libc).
+  (24/32-bpp uncompressed) and GIF (87a/89a first frame, LZW + interlace);
+  PNG/JPEG are the next slice. mmap-backed file + pixel buffers (no libc).
 - **doom** is the windowed makx client (see below).
 
 The **Install** desktop icon launches `mxterm` with a one-shot command

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -196,11 +196,32 @@ Clients (each an independent process, `src/userspace/mx*.c`):
   argument, decode, and aspect-fit-to-window via `gfx_blit_scaled`. Decodes BMP
   (24/32-bpp uncompressed) and GIF (87a/89a first frame, LZW + interlace);
   PNG/JPEG are the next slice. mmap-backed file + pixel buffers (no libc).
+- **mxinstall** is the graphical OS installer (see "Installer" below).
 - **doom** is the windowed makx client (see below).
 
-The **Install** desktop icon launches `mxterm` with a one-shot command
-(`mxterm.elf -makx <pid> install` → it runs `sh.elf -c install`), so the in-OS
-installer's TUI renders inside a terminal window via the cell-API→ANSI bridge.
+`ui_password` fields render a small round dot per character (not `*`).
+
+### Installer (`mxinstall.elf`)
+
+The **Install** desktop icon launches `mxinstall.elf`, a graphical makx wizard:
+Welcome → target drive → filesystem + optional components → hostname → accounts
+(root + optional user) → confirm → progress → done. It collects an
+`install_params_t` and drives the kernel's **shared, stepped install engine**
+(`SYS_INSTALL_EXEC`: `install_exec_begin` / `install_exec_step` / `_finish`,
+declared in `kernel/installer.h`) — one file copied per `step` over a
+pre-counted total, so the client repaints a live percentage bar between files.
+The same engine backs the text installer (`installer_run`, shell mode), so the
+two front-ends are functionally identical; only the presentation differs.
+
+The engine runs **preemptibly** (interrupts enabled), so the compositor keeps
+running at full frame rate while files copy — the install never freezes the
+desktop. Per-file progress is also written to the serial log
+(`INSTALL>copy <n>/<total> (<pct>%) <name>`). Unlike a server install there is
+**no auto-reboot**: the completion screen offers *Continue (live)* or *Reboot
+now*, so on a live CD the operator stays in control (Ubuntu-style).
+
+The text installer renders as a real ANSI/VT100 byte stream to its stdout, so it
+also works from a shell VT and inside an `mxterm` window with one code path.
 
 An always-on **top menu bar** (drawn after the windows, never occluded) carries
 the Makar brand, the focused window's title, and a **power icon** at the

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -183,6 +183,8 @@ Clients (each an independent process, `src/userspace/mx*.c`):
   parent). (Cross-client "open in editor" is a follow-up; each client is
   self-contained for now.)
 - **mxtasks** parses `/proc/tasks`, Kill via `SYS_KILL`, refresh-interval slider.
+- **mxclock** draws a large digital time + date from `/proc/rtc` (GUI peer of the
+  fullscreen `clock.elf`; reuses the same parse, scaled-glyph rendering).
 - **doom** is the windowed makx client (see below).
 
 An always-on **top menu bar** (drawn after the windows, never occluded) carries

--- a/docs/kernel/heap.md
+++ b/docs/kernel/heap.md
@@ -13,6 +13,13 @@ Implements a simple first-fit linked-list allocator for the kernel heap.
 The heap occupies the virtual address range **8 MiB – 24 MiB** (16 MiB
 total), immediately above the identity-mapped boot window.
 
+`kmalloc`/`kfree` briefly disable interrupts (`irq_save`/`restore`) around the
+freelist critical sections (the list walk / split / coalesce). This keeps the
+freelist consistent when a long syscall runs **preemptibly** (interrupts
+enabled) — e.g. the installer — and the timer preempts it to another task that
+also allocates. The masked regions are short, so interrupt latency is
+negligible.
+
 ---
 
 ## Constants

--- a/docs/kernel/ide.md
+++ b/docs/kernel/ide.md
@@ -13,9 +13,24 @@ kernel.  It supports 28-bit LBA sector reads and writes over two ATA channels
 (primary and secondary), giving access to up to four drives (primary master,
 primary slave, secondary master, secondary slave).
 
-All transfers are polling-based - no DMA, no IRQ-driven I/O.  ATAPI (CD-ROM)
-devices are detected and read via the SCSI PACKET command set (READ(12),
-READ CAPACITY(10), START/STOP UNIT for eject); ATAPI writing is not supported.
+Bus-master (BMIDE) DMA is used when a drive advertises it, with a PIO fallback
+on any failure; completion is detected by polling (no IRQ-driven I/O).  ATAPI
+(CD-ROM) devices are detected and read via the SCSI PACKET command set
+(READ(12), READ CAPACITY(10), START/STOP UNIT for eject); ATAPI writing is not
+supported.
+
+### Concurrency
+
+The single controller / shared bus-master bounce buffer means only one transfer
+may be in flight at a time.  `ide_read_sectors` / `ide_write_sectors` /
+`ide_read_atapi_sectors` therefore take an irq-guarded controller lock
+(`ide_lock`/`ide_unlock`): the test-and-set briefly masks interrupts so it is
+correct from both interrupts-off syscalls and interrupts-on (preemptible)
+kernel tasks; a task that finds the controller busy yields until it frees.
+`io_spin_pump()` animates the boot/status spinner during a wait but does **not**
+yield — responsiveness during a long disk operation comes from the timer
+preempting the (interrupts-enabled) caller, e.g. the installer, rather than
+cooperative yields inside the poll loop.
 
 ---
 

--- a/docs/kernel/vt.md
+++ b/docs/kernel/vt.md
@@ -18,6 +18,22 @@ Modelled on Linux's `vc_data.vc_screenbuf` and the ELKS / xv6 console
 backing-buffer pattern. Lets background TTYs accumulate output silently and
 have it surface atomically when the user switches focus.
 
+## ANSI/VT100 escape parsing
+
+`vt_putchar` is also a small terminal emulator: it carries a CSI/SGR parser
+state machine (`esc_state`/`esc_param[]` in `vt_buf_t`) and interprets escape
+sequences in the byte stream rather than printing them as glyphs — modelled on
+Linux's in-kernel VT layer (`drivers/tty/vt/vt.c`). Supported: `CUP`/`HVP`,
+`CUU`/`CUD`/`CUF`/`CUB`, `CHA`/`VPA`, `ED`(0/1/2), `EL`(0/1/2), `SGR` (16-colour
+fg/bg via a built-in palette, plus reset), `ESC 7`/`ESC 8` and `CSI s`/`CSI u`
+(cursor save/restore), and `ESC c` (reset). Plain text and `\n`/`\r`/`\b`
+behave exactly as before; unknown finals are swallowed.
+
+Because the framebuffer console funnels through `vt_putchar`
+(`t_putchar → vesa_tty_putchar → vt_putchar`), this makes the kernel console a
+real ANSI terminal, not just `/dev/ttyN` — userspace TUIs (e.g. the installer)
+drive it with escape bytes. Covered by `test_vt_ansi` in `ktest`.
+
 ## Data layout
 
 ```c

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -229,10 +229,13 @@ than user/credential based.
 | 270 `SYS_PASSWD` | `old, new` | change the current session user's password (`shadow_verify` old + `shadow_set_password` new); `0` ok, `-2` wrong current password, `-1` otherwise (bad args / read-only live rootfs) |
 | 271 `SYS_CAD_PENDING` | — | test-and-clear the Ctrl-Alt-Del flag; `1` if it was pressed. The GUI server polls it each frame to open its power menu |
 | 272 `SYS_PTY_WINSIZE` | `fd, (cols<<16)\|rows` | publish a pty window size onto a pipe fd so a piped child's `SYS_TERM_SIZE` reports it (GUI terminal → shell); `0` ok, `-1` if not a pipe |
+| 273 `SYS_INSTALL_EXEC` | `cmd, ptr` | stepped headless installer for the GUI front-end (`mxinstall.elf`). `cmd`: `0` begin(`install_params_t*`), `1` step(`install_progress_t*`, copies one file), `2` finish(`install_params_t*`), `3` list-drives(`install_drive_t[4]`). Returns the engine result (see `kernel/installer.h`). Runs preemptibly so the compositor stays live during the copy |
 
 `SYS_LOGIN` backs the GUI graphical login (`gui.elf`'s `do_login`); `SYS_PASSWD`
 backs its change-password dialog (the power menu's "Change password..."). Both
-are documented in `docs/gui.md`.
+are documented in `docs/gui.md`.  `SYS_INSTALL_EXEC` backs the graphical
+installer `mxinstall.elf`; the text installer (`install` builtin →
+`SYS_INSTALL`) and the GUI share one execution engine (see `docs/gui.md`).
 
 ### Virtual Terminals and makmux
 

--- a/src/kernel/arch/i386/display/vt.c
+++ b/src/kernel/arch/i386/display/vt.c
@@ -25,6 +25,15 @@ bool vt_init(vt_buf_t *vt, uint32_t cols, uint32_t rows,
     vt->fg      = default_fg;
     vt->bg      = default_bg;
 
+    vt->esc_state  = 0;
+    vt->esc_nparam = 0;
+    vt->esc_priv   = 0;
+    for (uint32_t i = 0; i < VT_NPARAM; i++) vt->esc_param[i] = 0;
+    vt->saved_col = 0;
+    vt->saved_row = 0;
+    vt->def_fg    = default_fg;
+    vt->def_bg    = default_bg;
+
     size_t n = (size_t)cols * (size_t)rows;
     vt->cells = (vt_cell_t *)kmalloc(n * sizeof(vt_cell_t));
     if (!vt->cells) return false;
@@ -102,11 +111,161 @@ void vt_put_at(vt_buf_t *vt, char c, uint32_t col, uint32_t row)
                  (uint8_t)c, vt->fg, vt->bg);
 }
 
+/* Standard 16-colour ANSI palette, framebuffer-pixel encoded (0x00RRGGBB).
+ * Index order is ANSI (0 black .. 7 white, 8-15 bright), matching the SGR
+ * codes 30-37/90-97 and the mxterm client palette. */
+static const uint32_t s_ansi_pal[16] = {
+    0x00000000, 0x00AA0000, 0x0000AA00, 0x00AA5500,
+    0x000000AA, 0x00AA00AA, 0x0000AAAA, 0x00AAAAAA,
+    0x00555555, 0x00FF5555, 0x0055FF55, 0x00FFFF55,
+    0x005555FF, 0x00FF55FF, 0x0055FFFF, 0x00FFFFFF,
+};
+
+/* Fill an inclusive cell region [r0,c0]..[r1,c1] with the current bg (used by
+ * ED / EL).  Clamped to the usable area. */
+static void vt_fill_region(vt_buf_t *vt, uint32_t r0, uint32_t c0,
+                           uint32_t r1, uint32_t c1)
+{
+    uint32_t rows = vt_limit_rows(vt);
+    if (!vt->cells) return;
+    for (uint32_t r = r0; r <= r1 && r < rows; r++) {
+        uint32_t cs = (r == r0) ? c0 : 0;
+        uint32_t ce = (r == r1) ? c1 : (vt->cols - 1);
+        for (uint32_t c = cs; c <= ce && c < vt->cols; c++)
+            vt_fill_cell(&vt->cells[(size_t)r * vt->cols + c], ' ', vt->fg, vt->bg);
+    }
+}
+
+/* CSI param i, treating 0/absent as the given default. */
+static int vt_pget(const vt_buf_t *vt, int i, int def)
+{
+    int v = (i < vt->esc_nparam) ? vt->esc_param[i] : 0;
+    return v ? v : def;
+}
+
+/* SGR (Select Graphic Rendition): map colour codes to grid fg/bg.  Bold and
+ * reverse aren't tracked as flags here -- bright colours arrive as their own
+ * 90-97/100-107 codes (which is exactly what the cell-API->ANSI bridge and
+ * mxterm emit), so the rendered result is identical. */
+static void vt_sgr(vt_buf_t *vt)
+{
+    if (vt->esc_nparam == 0) { vt->fg = vt->def_fg; vt->bg = vt->def_bg; return; }
+    for (int i = 0; i < vt->esc_nparam; i++) {
+        int p = vt->esc_param[i];
+        if      (p == 0)                 { vt->fg = vt->def_fg; vt->bg = vt->def_bg; }
+        else if (p >= 30 && p <= 37)     vt->fg = s_ansi_pal[p - 30];
+        else if (p == 39)                vt->fg = vt->def_fg;
+        else if (p >= 40 && p <= 47)     vt->bg = s_ansi_pal[p - 40];
+        else if (p == 49)                vt->bg = vt->def_bg;
+        else if (p >= 90 && p <= 97)     vt->fg = s_ansi_pal[p - 90 + 8];
+        else if (p >= 100 && p <= 107)   vt->bg = s_ansi_pal[p - 100 + 8];
+    }
+}
+
+/* Dispatch a completed CSI sequence (final byte f).  Returns 1 if grid
+ * *content* changed (ED/EL), so the caller forces a full repaint; pure cursor
+ * moves return 0. */
+static int vt_csi_dispatch(vt_buf_t *vt, unsigned char f)
+{
+    uint32_t rows = vt_limit_rows(vt);
+    int n;
+    switch (f) {
+    case 'A': n = vt_pget(vt,0,1); vt->cur_row = (vt->cur_row > (uint32_t)n) ? vt->cur_row - n : 0; break;
+    case 'B': n = vt_pget(vt,0,1); vt->cur_row += n; if (vt->cur_row >= rows) vt->cur_row = rows - 1; break;
+    case 'C': n = vt_pget(vt,0,1); vt->cur_col += n; if (vt->cur_col >= vt->cols) vt->cur_col = vt->cols - 1; break;
+    case 'D': n = vt_pget(vt,0,1); vt->cur_col = (vt->cur_col > (uint32_t)n) ? vt->cur_col - n : 0; break;
+    case 'E': n = vt_pget(vt,0,1); vt->cur_row += n; if (vt->cur_row >= rows) vt->cur_row = rows - 1; vt->cur_col = 0; break;
+    case 'F': n = vt_pget(vt,0,1); vt->cur_row = (vt->cur_row > (uint32_t)n) ? vt->cur_row - n : 0; vt->cur_col = 0; break;
+    case 'G': case '`': { int c = vt_pget(vt,0,1) - 1; if (c < 0) c = 0; vt->cur_col = (uint32_t)c;
+                          if (vt->cur_col >= vt->cols) vt->cur_col = vt->cols - 1; break; }
+    case 'd': { int r = vt_pget(vt,0,1) - 1; if (r < 0) r = 0; vt->cur_row = (uint32_t)r;
+                if (vt->cur_row >= rows) vt->cur_row = rows - 1; break; }
+    case 'H': case 'f': {
+        int r = vt_pget(vt,0,1) - 1, c = vt_pget(vt,1,1) - 1;
+        if (r < 0) r = 0; if (c < 0) c = 0;
+        vt->cur_row = (uint32_t)r; vt->cur_col = (uint32_t)c;
+        if (vt->cur_row >= rows) vt->cur_row = rows - 1;
+        if (vt->cur_col >= vt->cols) vt->cur_col = vt->cols - 1;
+        break; }
+    case 'J': {  /* ED: erase in display */
+        int m = (vt->esc_nparam > 0) ? vt->esc_param[0] : 0;
+        if      (m == 0) vt_fill_region(vt, vt->cur_row, vt->cur_col, rows - 1, vt->cols - 1);
+        else if (m == 1) vt_fill_region(vt, 0, 0, vt->cur_row, vt->cur_col);
+        else             vt_fill_region(vt, 0, 0, rows - 1, vt->cols - 1);
+        return 1; }
+    case 'K': {  /* EL: erase in line */
+        int m = (vt->esc_nparam > 0) ? vt->esc_param[0] : 0;
+        if      (m == 0) vt_fill_region(vt, vt->cur_row, vt->cur_col, vt->cur_row, vt->cols - 1);
+        else if (m == 1) vt_fill_region(vt, vt->cur_row, 0, vt->cur_row, vt->cur_col);
+        else             vt_fill_region(vt, vt->cur_row, 0, vt->cur_row, vt->cols - 1);
+        return 1; }
+    case 'm': vt_sgr(vt); break;
+    case 's': vt->saved_col = vt->cur_col; vt->saved_row = vt->cur_row; break;
+    case 'u': vt->cur_col = vt->saved_col; vt->cur_row = vt->saved_row;
+              if (vt->cur_row >= rows) vt->cur_row = rows - 1;
+              if (vt->cur_col >= vt->cols) vt->cur_col = vt->cols - 1; break;
+    default: break;   /* swallow unimplemented finals */
+    }
+    return 0;
+}
+
 vt_dirty_t vt_putchar(vt_buf_t *vt, char c)
 {
     vt_dirty_t d = { 0, 0, 0, 0 };
     uint32_t rows = vt_limit_rows(vt);
     if (!vt->cells || vt->cols == 0 || rows == 0) return d;
+
+    /* ---- ANSI/VT100 escape-sequence state machine ----------------------
+     * Non-ground states consume the byte and return; GROUND falls through to
+     * the plain \n/\r/\b + glyph path that follows (unchanged). */
+    unsigned char b = (unsigned char)c;
+    if (vt->esc_state == 1) {               /* after ESC */
+        switch (b) {
+        case '[': vt->esc_state = 2; vt->esc_nparam = 0; vt->esc_priv = 0;
+                  for (uint32_t i = 0; i < VT_NPARAM; i++) vt->esc_param[i] = 0; return d;
+        case ']': vt->esc_state = 3; return d;                       /* OSC */
+        case '7': vt->saved_col = vt->cur_col; vt->saved_row = vt->cur_row; vt->esc_state = 0; return d;
+        case '8': vt->cur_col = vt->saved_col; vt->cur_row = vt->saved_row;
+                  if (vt->cur_row >= rows) vt->cur_row = rows - 1;
+                  if (vt->cur_col >= vt->cols) vt->cur_col = vt->cols - 1;
+                  vt->esc_state = 0; return d;
+        case 'c': vt->fg = vt->def_fg; vt->bg = vt->def_bg;          /* RIS */
+                  vt_clear(vt); vt->esc_state = 0; d.scrolled = 1; return d;
+        case '(': case ')': case '*': case '+':                      /* charset: eat next */
+                  vt->esc_state = 4; return d;
+        default:  vt->esc_state = 0; return d;
+        }
+    }
+    if (vt->esc_state == 4) { vt->esc_state = 0; return d; }         /* swallowed charset byte */
+    if (vt->esc_state == 2) {                /* CSI */
+        if (b == '?') { vt->esc_priv = 1; return d; }
+        if (b >= '0' && b <= '9') {
+            int i = vt->esc_nparam ? vt->esc_nparam - 1 : 0;
+            vt->esc_param[i] = (uint16_t)(vt->esc_param[i] * 10 + (b - '0'));
+            if (!vt->esc_nparam) vt->esc_nparam = 1;
+            return d;
+        }
+        if (b == ';') {
+            if (!vt->esc_nparam) vt->esc_nparam = 1;
+            if (vt->esc_nparam < VT_NPARAM) vt->esc_nparam++;
+            return d;
+        }
+        if (b >= 0x40 && b <= 0x7E) {        /* final byte: dispatch */
+            if (vt_csi_dispatch(vt, b)) d.scrolled = 1;
+            vt->esc_state = 0;
+            return d;
+        }
+        return d;                            /* intermediates: ignore */
+    }
+    if (vt->esc_state == 3) {                /* OSC: swallow to BEL or ESC \ */
+        if (b == 0x07) vt->esc_state = 0;
+        else if (b == 0x1B) vt->esc_state = 5;
+        return d;
+    }
+    if (vt->esc_state == 5) { vt->esc_state = 0; return d; }         /* ST / abort */
+
+    /* GROUND: ESC starts a sequence; everything else is text/control. */
+    if (b == 0x1B) { vt->esc_state = 1; return d; }
 
     /* Clamp transient out-of-range cursor (preemption between increment
      * and bounds check elsewhere). */

--- a/src/kernel/arch/i386/drivers/ide.c
+++ b/src/kernel/arch/i386/drivers/ide.c
@@ -18,6 +18,7 @@
 #include <kernel/serial.h>
 #include <kernel/debug.h>
 #include <kernel/pci.h>
+#include <kernel/task.h>   /* task_yield() -- cooperative I/O waits */
 
 #include <stddef.h>
 #include <string.h>
@@ -204,13 +205,41 @@ static int dma_atapi_usable(uint8_t drive_num)
  * with interrupts masked in syscall context), so the boot/status spinner
  * freezes and a slow read/write looks like a hang.  Pump it directly from the
  * I/O path: animation then tracks actual disk progress.  `t_spinner_tick`
- * advances one frame per 12 counts, so step the counter by 12 each pump. */
+ * advances one frame per 12 counts, so step the counter by 12 each pump.
+ *
+ * Pure animation, no CPU hand-off: responsiveness during long disk operations
+ * now comes from the timer preempting the (interrupts-enabled) install syscalls
+ * directly, rather than cooperative yields from inside the poll loop -- which,
+ * count- or time-gated, were always either too rare (frozen) or too frequent
+ * (livelocked the copy and starved other tasks). */
 static uint32_t s_io_spin = 0;
 static inline void io_spin_pump(void)
 {
     s_io_spin += 12u;
     t_spinner_tick(s_io_spin);
 }
+
+/* Cooperative controller lock.  Now that the I/O wait paths yield, two tasks
+ * could otherwise interleave on the single IDE controller mid-transfer.  The
+ * test-and-set is made atomic with irq_save_disable so it is correct whether
+ * called from an interrupts-off syscall or an interrupts-on kernel task; a task
+ * that finds the controller busy yields (interrupts restored) until it frees. */
+static inline uint32_t ide_irq_save(void)
+{ uint32_t f; asm volatile("pushfl; popl %0; cli" : "=r"(f) :: "memory"); return f; }
+static inline void ide_irq_restore(uint32_t f)
+{ asm volatile("pushl %0; popfl" :: "r"(f) : "memory", "cc"); }
+
+static volatile int s_ide_busy = 0;
+static void ide_lock(void)
+{
+    for (;;) {
+        uint32_t fl = ide_irq_save();
+        if (!s_ide_busy) { s_ide_busy = 1; ide_irq_restore(fl); return; }
+        ide_irq_restore(fl);
+        task_yield();
+    }
+}
+static void ide_unlock(void) { s_ide_busy = 0; }
 
 /* Program the BMIDE engine for one transfer and clear stale status bits.
  * to_mem != 0 selects device->memory (a read). */
@@ -245,7 +274,7 @@ static int bm_run_and_wait(uint8_t ch, int to_mem)
     uint8_t  sr;
     do {
         sr = inb(bm + BM_REG_STATUS);
-        if ((limit & 0x3FFFFu) == 0)        /* keep the spinner alive on long DMA */
+        if ((limit & 0x3FFFFu) == 0)        /* long DMA in flight: hand off the CPU */
             io_spin_pump();
         if (--limit == 0)
             break;
@@ -311,7 +340,7 @@ static int ide_poll(uint8_t ch, int check_drq)
     uint32_t limit = 5000000;
     do {
         status = ide_read_altstatus(ch);
-        if ((limit & 0x3FFFFu) == 0)        /* keep moving during a long wait */
+        if ((limit & 0x3FFFFu) == 0)        /* long BSY wait: hand off the CPU */
             io_spin_pump();
         if (--limit == 0)
             KPANIC("ide_poll: ATA drive BSY never cleared (drive hung or absent)");
@@ -601,23 +630,29 @@ static int ide_dma_ata(uint8_t direction, uint8_t drive_num,
 int ide_read_sectors(uint8_t drive_num, uint32_t lba, uint8_t count,
                      void *buf)
 {
+    ide_lock();
     int r = ide_dma_ata(0, drive_num, lba, count, buf);
-    if (r == 0)
-        return 0;
-    if (r != -3)                        /* DMA tried but errored: reset + retry */
-        dma_note_failure(drives[drive_num].channel);
-    return ide_access(0, drive_num, lba, count, buf);   /* PIO fallback/retry */
+    if (r != 0) {
+        if (r != -3)                    /* DMA tried but errored: reset + retry */
+            dma_note_failure(drives[drive_num].channel);
+        r = ide_access(0, drive_num, lba, count, buf);   /* PIO fallback/retry */
+    }
+    ide_unlock();
+    return r;
 }
 
 int ide_write_sectors(uint8_t drive_num, uint32_t lba, uint8_t count,
                       const void *buf)
 {
+    ide_lock();
     int r = ide_dma_ata(1, drive_num, lba, count, (void *)buf);
-    if (r == 0)
-        return 0;
-    if (r != -3)
-        dma_note_failure(drives[drive_num].channel);
-    return ide_access(1, drive_num, lba, count, (void *)buf);   /* PIO */
+    if (r != 0) {
+        if (r != -3)
+            dma_note_failure(drives[drive_num].channel);
+        r = ide_access(1, drive_num, lba, count, (void *)buf);   /* PIO */
+    }
+    ide_unlock();
+    return r;
 }
 
 const ide_drive_t *ide_get_drive(uint8_t drive_num)
@@ -755,6 +790,7 @@ int ide_read_atapi_sectors(uint8_t drive_num, uint32_t lba,
     if (count == 0)
         return 0;
 
+    ide_lock();   /* released at every controller-path return below */
     uint8_t  ch = drives[drive_num].channel;
     uint8_t  dr = drives[drive_num].drive;
     uint8_t *p  = (uint8_t *)buf;
@@ -778,6 +814,7 @@ int ide_read_atapi_sectors(uint8_t drive_num, uint32_t lba,
         }
         if (ok) {
             dma_note_success();
+            ide_unlock();
             return 0;
         }
         dma_note_failure(ch);
@@ -785,11 +822,14 @@ int ide_read_atapi_sectors(uint8_t drive_num, uint32_t lba,
 
     for (uint16_t i = 0; i < count; i++) {
         int err = atapi_read_one(ch, dr, lba + (uint32_t)i, p);
-        if (err)
+        if (err) {
+            ide_unlock();
             return err;
+        }
         p += ATAPI_CD_SECTOR_SIZE;
     }
 
+    ide_unlock();
     return 0;
 }
 

--- a/src/kernel/arch/i386/mm/heap.c
+++ b/src/kernel/arch/i386/mm/heap.c
@@ -23,6 +23,17 @@ typedef struct block_hdr {
 
 #define BLOCK_HDR_SIZE  sizeof(block_hdr_t)
 
+/* The freelist is shared mutable state.  Once syscalls run with interrupts
+ * enabled (preemptible) a timer preempt mid-allocation could let another task
+ * re-enter the allocator and corrupt the list, so the freelist critical
+ * sections briefly disable interrupts (the regions are short -- a list walk /
+ * a couple of pointer writes).  irq_save/restore preserve the caller's IF so
+ * this is safe from both interrupts-off and interrupts-on contexts. */
+static inline uint32_t heap_irq_save(void)
+{ uint32_t f; __asm__ volatile("pushfl; popl %0; cli" : "=r"(f) :: "memory"); return f; }
+static inline void heap_irq_restore(uint32_t f)
+{ __asm__ volatile("pushl %0; popfl" :: "r"(f) : "memory", "cc"); }
+
 /* Minimum user-data size kept when splitting a block.  Splitting a block that
    would leave a remainder smaller than this wastes less memory by not splitting
    at all. */
@@ -65,6 +76,7 @@ void *kmalloc(size_t size)
      * subsequent block in the freelist, eventually corrupting it. */
     size = (size + 3u) & ~3u;
 
+    uint32_t fl = heap_irq_save();
     block_hdr_t *blk = heap_head;
 
     while (blk) {
@@ -82,11 +94,13 @@ void *kmalloc(size_t size)
             }
 
             blk->is_free = 0;
+            heap_irq_restore(fl);
             return (void *)((uint8_t *)blk + BLOCK_HDR_SIZE);
         }
         blk = blk->next;
     }
 
+    heap_irq_restore(fl);
     return NULL; /* heap exhausted */
 }
 
@@ -112,6 +126,7 @@ void kfree(void *ptr)
         return;
     }
 
+    uint32_t fl = heap_irq_save();
     block_hdr_t *blk = (block_hdr_t *)((uint8_t *)ptr - BLOCK_HDR_SIZE);
     blk->is_free = 1;
 
@@ -140,6 +155,7 @@ void kfree(void *ptr)
         blk->size += BLOCK_HDR_SIZE + blk->next->size;
         blk->next  = blk->next->next;
     }
+    heap_irq_restore(fl);
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/kernel/arch/i386/proc/installer.c
+++ b/src/kernel/arch/i386/proc/installer.c
@@ -15,10 +15,13 @@
  * At runtime the FAT32 boot partition mounts as /mnt/boot and the data
  * partition mounts as /mnt/root (auto-detected by vfs_auto_mount).
  *
- * Rendering uses the VESA TTY paint primitives (vesa_tty_*), reserving the
- * bottom makmux status row.  In VGA-text fallback it degrades to a plain
- * numbered-prompt flow.  The shell repaints the screen (shell_restore_screen)
- * after installer_run() returns.
+ * Rendering is a real ANSI/VT100 terminal byte stream written to the invoking
+ * task's stdout (kfd_stdout_write): on a live text VT the bytes reach the
+ * framebuffer console's ANSI parser (vt_putchar); inside an mxterm window they
+ * reach the client's vt100 emulator over a pipe -- so the installer runs both
+ * from a shell and in a GUI window with one code path.  With no terminal at all
+ * (no VESA, not piped) it degrades to a plain numbered-prompt flow.  The shell
+ * repaints the screen (shell_restore_screen) after installer_run() returns.
  *
  * The host build still boots via GRUB; this deploys limine at runtime, reading
  * the vendored limine-bios.sys off the CD (staged at /limine/limine-bios.sys
@@ -37,6 +40,7 @@
 #include <kernel/fat32.h>
 #include <kernel/ext2.h>
 #include <kernel/vfs.h>
+#include <kernel/fd.h>
 #include <kernel/logfs.h>
 #include <kernel/heap.h>
 #include <kernel/tty.h>
@@ -119,13 +123,6 @@ static int  s_q_head, s_q_tail;
 static struct { char name[64]; int is_dir; } s_ents[ENTS_MAX];
 static int s_nents;
 
-/* Installed target info, set during do_install so the account-creation
- * wizard can remount the data partition without re-discovering it. */
-static uint8_t  s_inst_drive;
-static uint32_t s_inst_boot_lba;
-static uint32_t s_inst_data_lba;
-static int      s_inst_fs;
-
 /* Optional component trees, chosen in the wizard (default: install both). */
 static int      s_inst_docs = 1;   /* copy /docs to the target rootfs */
 static int      s_inst_src  = 1;   /* copy /src  to the target rootfs */
@@ -134,15 +131,22 @@ static int      s_inst_src  = 1;   /* copy /src  to the target rootfs */
 /* Geometry                                                                  */
 /* ------------------------------------------------------------------------- */
 
-static int g_gui;        /* 1 = VESA TUI, 0 = VGA text fallback */
+/* The installer renders as a real ANSI/VT100 terminal application.  Output is
+ * a byte stream of escape sequences written to the calling task's stdout via
+ * kfd_stdout_write(): on a live text VT those bytes reach the framebuffer
+ * console's ANSI parser (vt_putchar); inside an mxterm window they reach the
+ * client's vt100 emulator over a pipe.  Pure-VGA-text with no terminal at all
+ * (no VESA, not piped) degrades to a plain numbered-prompt flow via t_write. */
+static int g_ansi;       /* 1 = ANSI terminal available, 0 = VGA-text fallback */
 static uint32_t g_cols, g_rows;   /* usable area (status row excluded)       */
 
 static void tui_geometry(void)
 {
-    g_gui = vesa_tty_is_ready();
-    if (g_gui) {
-        g_cols = vesa_tty_get_cols();
-        g_rows = vesa_tty_usable_rows();
+    g_ansi = kfd_stdout_is_pipe() || vesa_tty_is_ready();
+    if (g_ansi) {
+        kfd_term_size(&g_cols, &g_rows);
+        if (g_cols == 0) g_cols = 80;
+        if (g_rows < 2)  g_rows = 25;
     } else {
         g_cols = 80;
         g_rows = 49;   /* 80x50 VGA text, minus status row */
@@ -150,24 +154,88 @@ static void tui_geometry(void)
 }
 
 /* ------------------------------------------------------------------------- */
-/* Low-level paint helpers (GUI mode only)                                   */
+/* ANSI output primitives                                                     */
 /* ------------------------------------------------------------------------- */
 
-static void paint_fill(uint32_t bg)
+/* Write to the invoking task's terminal; fall back to the kernel console when
+ * it has no usable stdout (in-kernel rescue shell). */
+static void out(const char *s)
 {
-    char blank[256];
-    uint32_t n = (g_cols < 255) ? g_cols : 255;
-    for (uint32_t i = 0; i < n; i++) blank[i] = ' ';
-    blank[n] = '\0';
-    for (uint32_t r = 0; r < g_rows; r++)
-        vesa_tty_paint_string_at(0, r, blank, C_FG, bg);
+    unsigned n = 0; while (s[n]) n++;
+    if (kfd_stdout_write(s, n) < 0) t_write(s, n);
+}
+static void outn(const char *s, unsigned n)
+{
+    if (kfd_stdout_write(s, n) < 0) t_write(s, n);
 }
 
+/* uint -> decimal text, returns length written (no NUL). */
+static int u2d(char *b, unsigned v)
+{
+    char t[10]; int n = 0;
+    if (!v) { b[0] = '0'; return 1; }
+    while (v) { t[n++] = (char)('0' + v % 10); v /= 10; }
+    for (int i = 0; i < n; i++) b[i] = t[n - 1 - i];
+    return n;
+}
+
+/* Emit SGR for an (fg,bg) pair drawn from the installer's RGB palette.  The
+ * console / mxterm map these 16-colour codes back to pixels; bright codes
+ * (9x/10x) carry the vivid title/warn/ok hues. */
+static void ansi_color(uint32_t fg, uint32_t bg)
+{
+    if (!g_ansi) return;
+    unsigned fc, bc;
+    if      (fg == C_TITLE) fc = 96;        /* bright cyan */
+    else if (fg == C_DIM)   fc = 37;        /* grey        */
+    else if (fg == C_SELFG) fc = 30;        /* dark (on cyan selection) */
+    else if (fg == C_WARN)  fc = 91;        /* bright red  */
+    else if (fg == C_OK)    fc = 92;        /* bright green */
+    else                    fc = 97;        /* C_FG bright white */
+    if      (bg == C_SELBG) bc = 106;       /* bright cyan (== C_TITLE) */
+    else if (bg == C_WARN)  bc = 101;
+    else                    bc = 44;        /* C_BG deep blue / default */
+    char b[24]; int o = 0;
+    b[o++] = 0x1b; b[o++] = '['; b[o++] = '0'; b[o++] = ';';
+    o += u2d(b + o, fc); b[o++] = ';'; o += u2d(b + o, bc); b[o++] = 'm';
+    outn(b, (unsigned)o);
+}
+static void ansi_goto(uint32_t col, uint32_t row)
+{
+    if (!g_ansi) return;
+    char b[24]; int o = 0;
+    b[o++] = 0x1b; b[o++] = '[';
+    o += u2d(b + o, row + 1); b[o++] = ';'; o += u2d(b + o, col + 1); b[o++] = 'H';
+    outn(b, (unsigned)o);
+}
+
+/* Clear the whole screen to bg, cursor home. */
+static void tui_clear(uint32_t bg)
+{
+    if (!g_ansi) return;
+    ansi_color(C_FG, bg);
+    out("\x1b[2J\x1b[H");
+}
+
+/* Paint a positioned, coloured string (no-op in VGA-text fallback).  Embedded
+ * '\n' starts a new line re-anchored at the same start column (some menu
+ * descriptions are multi-line) rather than wrapping to column 0. */
 static void tui_at(uint32_t col, uint32_t row, const char *s,
                    uint32_t fg, uint32_t bg)
 {
-    if (g_gui)
-        vesa_tty_paint_string_at(col, row, s, fg, bg);
+    if (!g_ansi) return;
+    ansi_color(fg, bg);
+    uint32_t line = 0;
+    const char *p = s;
+    for (;;) {
+        ansi_goto(col, row + line);
+        char buf[256]; int o = 0;
+        while (*p && *p != '\n' && o < (int)sizeof(buf) - 1) buf[o++] = *p++;
+        buf[o] = '\0';
+        out(buf);
+        if (*p != '\n') break;   /* hit end of string */
+        p++; line++;             /* consume newline, continue one row down */
+    }
 }
 
 /* Centre a string on 'row'. */
@@ -181,12 +249,12 @@ static void tui_center(uint32_t row, const char *s, uint32_t fg, uint32_t bg)
 /* Common header (title bar + footer hint) for every wizard screen. */
 static void tui_frame(const char *title, const char *hint)
 {
-    paint_fill(C_BG);
+    tui_clear(C_BG);
     char bar[256];
     uint32_t n = (g_cols < 255) ? g_cols : 255;
     for (uint32_t i = 0; i < n; i++) bar[i] = ' ';
     bar[n] = '\0';
-    vesa_tty_paint_string_at(0, 0, bar, C_SELFG, C_TITLE);
+    tui_at(0, 0, bar, C_SELFG, C_TITLE);
     tui_center(0, title, C_SELFG, C_TITLE);
     if (hint)
         tui_at(2, g_rows - 1, hint, C_DIM, C_BG);
@@ -196,66 +264,69 @@ static void tui_frame(const char *title, const char *hint)
 /* Keyboard helpers                                                          */
 /* ------------------------------------------------------------------------- */
 
-static unsigned char getkey(void) { return keyboard_getchar(); }
+/* One key.  Source is the mxterm stdin pipe when piped, else the raw keyboard;
+ * arrow bytes (0x80-0x83), Esc (0x1B) and ASCII match either way.  EOF (pipe
+ * writer gone) returns Esc so menus cancel rather than spin. */
+static unsigned char getkey(void)
+{
+    int b = kfd_stdin_getbyte();
+    return (b < 0) ? 0x1B : (unsigned char)b;
+}
 
-/* Read a line (VGA fallback prompts / "type yes" confirm). Echoes to VGA. */
+/* Read a line (VGA fallback prompts / "type yes" confirm) with echo. */
 static void readline(char *buf, size_t max)
 {
     size_t len = 0;
     while (1) {
         unsigned char c = getkey();
-        if (c == '\n' || c == '\r') { t_putchar('\n'); break; }
-        if (c == '\b') { if (len) { len--; t_backspace(); } continue; }
+        if (c == '\n' || c == '\r') { out("\r\n"); break; }
+        if (c == '\b' || c == 127) { if (len) { len--; out("\b \b"); } continue; }
         if (c < 0x20 || c > 0x7E) continue;
-        if (len < max - 1) { buf[len++] = (char)c; t_putchar((char)c); }
+        if (len < max - 1) { buf[len++] = (char)c; { char e[2]={(char)c,0}; out(e); } }
     }
     buf[len] = '\0';
 }
 
-/* Masked password readline: echoes '*' per character with a '_' cursor.
- * GUI mode paints at (field_col, row); VGA mode echoes to terminal cursor. */
+/* Masked password readline: echoes '*' per character with a '_' cursor at
+ * (field_col, row) in ANSI mode; plain '*' echo in VGA-text fallback. */
 static void readline_masked(char *buf, size_t max,
                             uint32_t field_col, uint32_t row)
 {
     size_t len = 0;
 
-    /* Draw initial cursor */
-    if (g_gui)
-        vesa_tty_paint_string_at(field_col, row, "_", C_TITLE, C_BG);
+    if (g_ansi)
+        tui_at(field_col, row, "_", C_TITLE, C_BG);
 
     while (1) {
         unsigned char c = getkey();
         if (c == '\n' || c == '\r') {
-            /* Clear cursor on commit */
-            if (g_gui)
-                vesa_tty_paint_string_at(field_col + (uint32_t)len, row, " ", C_FG, C_BG);
+            if (g_ansi)
+                tui_at(field_col + (uint32_t)len, row, " ", C_FG, C_BG);
+            else
+                out("\r\n");
             break;
         }
         if (c == '\b' || c == 127) {
             if (len) {
-                /* Erase cursor at current pos */
-                if (g_gui)
-                    vesa_tty_paint_string_at(field_col + (uint32_t)len, row, " ", C_FG, C_BG);
-                len--;
-                /* Erase the star that was at len */
-                if (g_gui)
-                    vesa_tty_paint_string_at(field_col + (uint32_t)len, row, "_", C_TITLE, C_BG);
-                else
-                    t_backspace();
+                if (g_ansi) {
+                    tui_at(field_col + (uint32_t)len, row, " ", C_FG, C_BG);
+                    len--;
+                    tui_at(field_col + (uint32_t)len, row, "_", C_TITLE, C_BG);
+                } else {
+                    len--; out("\b \b");
+                }
             }
             continue;
         }
         if (c < 0x20 || c > 0x7E) continue;
         if (len < max - 1) {
-            /* Overwrite cursor with star, advance cursor */
-            if (g_gui) {
-                vesa_tty_paint_string_at(field_col + (uint32_t)len, row, "*", C_FG, C_BG);
-            } else {
-                t_putchar('*');
-            }
+            if (g_ansi)
+                tui_at(field_col + (uint32_t)len, row, "*", C_FG, C_BG);
+            else
+                out("*");
             buf[len++] = (char)c;
-            if (g_gui)
-                vesa_tty_paint_string_at(field_col + (uint32_t)len, row, "_", C_TITLE, C_BG);
+            if (g_ansi)
+                tui_at(field_col + (uint32_t)len, row, "_", C_TITLE, C_BG);
         }
     }
     buf[len] = '\0';
@@ -270,7 +341,7 @@ static int tui_menu(const char *title, const char *hint,
                     const char *const *items, int n,
                     const char *const *descs)
 {
-    if (!g_gui) {
+    if (!g_ansi) {
         /* VGA fallback: numbered list + readline. */
         t_writestring("\n=== ");
         t_writestring(title);
@@ -293,12 +364,25 @@ static int tui_menu(const char *title, const char *hint,
         }
     }
 
+    /* Vertical step per item: 1 label row + the tallest description + a blank
+     * separator row, so multi-line descriptions never collide with the next
+     * item (the bug that made the filesystem page look cramped). */
+    int desc_lines = 0;
+    if (descs)
+        for (int i = 0; i < n; i++) {
+            if (!descs[i]) continue;
+            int ln = 1;
+            for (const char *p = descs[i]; *p; p++) if (*p == '\n') ln++;
+            if (ln > desc_lines) desc_lines = ln;
+        }
+    uint32_t step = desc_lines ? (uint32_t)(desc_lines + 2) : 2;
+
     int sel = 0;
     uint32_t top = 4;
     while (1) {
         tui_frame(title, hint ? hint : "Up/Down to move  Enter to select  Esc to cancel");
         for (int i = 0; i < n; i++) {
-            uint32_t row = top + (uint32_t)i * 2;
+            uint32_t row = top + (uint32_t)i * step;
             char line[128];
             /* "  > label" with left padding; pad the rest with spaces so the
              * selected highlight spans a fixed width. */
@@ -315,7 +399,7 @@ static int tui_menu(const char *title, const char *hint,
             else
                 tui_at(4, row, line, C_FG, C_BG);
             if (descs && descs[i])
-                tui_at(8, row + 1, descs[i], C_DIM, C_BG);
+                tui_at(12, row + 1, descs[i], C_DIM, C_BG);   /* indent under the label */
         }
         unsigned char c = getkey();
         if (c == KEY_ARROW_UP)        sel = (sel == 0) ? n - 1 : sel - 1;
@@ -329,7 +413,7 @@ static int tui_menu(const char *title, const char *hint,
  * against dropped keystrokes and the standard TUI idiom.  VGA: type "yes". */
 static int tui_confirm(const char *title, const char *l1, const char *l2)
 {
-    if (g_gui) {
+    if (g_ansi) {
         /* Paint the warning lines, then present the choice as a menu so the
          * (highlighted, reliable) arrow/Enter path drives it.  Default is
          * Cancel - the operator must move down to Install. */
@@ -380,7 +464,7 @@ static void box_border(void)
 /* Repaint the visible tail of the log inside the box. */
 static void box_repaint(void)
 {
-    if (!g_gui) return;
+    if (!g_ansi) return;
     int start = (s_log_n > (int)s_box_vis) ? s_log_n - (int)s_box_vis : 0;
     char blank[LOG_W];
     for (uint32_t i = 0; i < s_box_w - 2 && i < LOG_W - 1; i++) blank[i] = ' ';
@@ -397,8 +481,8 @@ static void box_repaint(void)
 static void exec_screen(const char *title)
 {
     s_log_n = 0;
-    if (g_gui) {
-        vesa_tty_clear();
+    if (g_ansi) {
+        tui_clear(C_BG);
         tui_frame(title, "Installing - please wait...");
         s_box_top   = 2;
         s_box_bot   = (g_rows > 4) ? g_rows - 3 : g_rows - 1;
@@ -424,7 +508,7 @@ static void tui_log(const char *s)
      * stopped. */
     logfs_append_line("install.log", s);
 
-    if (g_gui) {
+    if (g_ansi) {
         char *dst = s_log[s_log_n % LOG_LINES];
         uint32_t i = 0;
         while (s[i] && i < LOG_W - 1) { dst[i] = s[i]; i++; }
@@ -440,7 +524,7 @@ static void tui_log(const char *s)
 /* Overwrite the transient status line (running counts during long copies). */
 static void tui_status(const char *s)
 {
-    if (g_gui) {
+    if (g_ansi) {
         char blank[256];
         uint32_t w = (g_cols < 255) ? g_cols : 255;
         for (uint32_t i = 0; i < w; i++) blank[i] = ' ';
@@ -560,73 +644,6 @@ static const char *q_pop(void)
     return p;
 }
 
-/* Recursively mirror an ISO directory tree onto the rootfs (BFS).  Paths are
- * identical on both sides (same layout), so one path serves source + dest.
- * Logs one step line, then updates a running file count on the status line so
- * the box doesn't fill with hundreds of per-file lines. */
-static void copy_tree(const char *root)
-{
-    char line[LOG_W];
-    str_u(line, "Copying ", 0);   /* placeholder, rebuild below */
-    int o = 0; const char *p = "Copying "; while (*p) line[o++] = *p++;
-    p = root; while (*p) line[o++] = *p++;
-    const char *t = " ..."; while (*t) line[o++] = *t++; line[o] = '\0';
-    tui_log(line);
-
-    uint32_t files = 0;
-    rfs_mkdir(root);
-    q_reset();
-    q_push(root);
-    while (!q_empty()) {
-        char dir[PATH_MAX_];
-        strncpy(dir, q_pop(), PATH_MAX_ - 1);
-        dir[PATH_MAX_ - 1] = '\0';
-
-        s_nents = 0;
-        iso9660_complete(g_cd, dir, "", enum_cb, NULL);
-
-        for (int i = 0; i < s_nents; i++) {
-            char child[PATH_MAX_];
-            int co = 0;
-            const char *d = dir;
-            while (*d && co < PATH_MAX_ - 1) child[co++] = *d++;
-            if (!(co == 1 && child[0] == '/') && co < PATH_MAX_ - 1)
-                child[co++] = '/';
-            const char *nm = s_ents[i].name;
-            while (*nm && co < PATH_MAX_ - 1) child[co++] = *nm++;
-            child[co] = '\0';
-
-            if (s_ents[i].is_dir) {
-                rfs_mkdir(child);
-                q_push(child);
-            } else {
-                /* Name the current file on the status line *before* copying it.
-                 * rfs_write is whole-file (no progress callback), so a large
-                 * file (e.g. the 12 MB DOOM.WAD) otherwise sits on a stale
-                 * "copied N files" line and looks frozen.  Showing the name
-                 * makes it visibly alive: the operator sees which file is in
-                 * flight even when one copy takes a while under emulation. */
-                {
-                    char st[64];
-                    int so = 0;
-                    const char *pre = "  copying "; while (*pre) st[so++] = *pre++;
-                    const char *nm = s_ents[i].name;
-                    while (*nm && so < (int)sizeof(st) - 6) st[so++] = *nm++;
-                    const char *e = " ..."; while (*e) st[so++] = *e++; st[so] = '\0';
-                    tui_status(st);
-                }
-                copy_file(child, child);
-                files++;
-            }
-        }
-    }
-    char done[64];
-    str_u(done, "  done - ", files);
-    int do_ = (int)strlen(done);
-    const char *f = " files"; while (*f) done[do_++] = *f++; done[do_] = '\0';
-    tui_log(done);
-    tui_status("");
-}
 
 /* ------------------------------------------------------------------------- */
 /* limine MBR install (mirrors host/limine.c::bios_install, MBR path, v12.x) */
@@ -803,115 +820,7 @@ static uint32_t build_limine_conf(char *buf, uint32_t cap, const char *autologin
     return o;
 }
 
-/* Append "<prefix> (rc=<n>)" to the installer log -- detailed failure
- * context so a post-mortem `cat /log/install.log` records exactly which
- * step failed and the backend return code.  Buf is generous (`tui_log`
- * truncates at LOG_W). */
-static void tui_log_rc(const char *prefix, int rc)
-{
-    char buf[160];
-    int  i = 0;
-    while (prefix[i] && i < 120) { buf[i] = prefix[i]; i++; }
-    /* " (rc=<int>)" */
-    const char *suf = " (rc=";
-    for (int j = 0; suf[j] && i < 154; j++) buf[i++] = suf[j];
-    int n = rc;
-    if (n < 0) { buf[i++] = '-'; n = -n; }
-    char dig[12]; int dn = 0;
-    if (n == 0) dig[dn++] = '0';
-    while (n) { dig[dn++] = (char)('0' + (n % 10)); n /= 10; }
-    while (dn--) buf[i++] = dig[dn];
-    buf[i++] = ')';
-    buf[i]   = '\0';
-    tui_log(buf);
-}
 
-static int do_install(uint8_t drive, uint32_t disk_sectors, int fs)
-{
-    uint32_t boot_lba = 0, boot_count = 0;
-    uint32_t data_lba = 0, data_count = 0;
-
-    exec_screen("Installing Makar");
-
-    tui_log("Partitioning drive...");
-    int prc = partition_whole_disk(drive, disk_sectors, fs,
-                                   &boot_lba, &boot_count,
-                                   &data_lba, &data_count);
-    if (prc != 0) {
-        tui_log_rc("  ERROR: failed to write partition table.", prc);
-        return -1;
-    }
-
-    /* ---- Partition 1: FAT32 boot (kernel + limine stage 3) ---- */
-
-    tui_log("Formatting boot partition (FAT32, 34 MiB)...");
-    int rc;
-    if ((rc = fat32_mkfs(drive, boot_lba, boot_count)) != 0) {
-        tui_log_rc("  ERROR: boot mkfs failed (need >= 33 MiB for FAT32).", rc);
-        return -2;
-    }
-
-    /* Boot files are copied after the remaining wizard inputs have been
-     * collected.  This phase only prepares the filesystem. */
-
-    /* ---- Partition 2: data (apps / docs / src) ---- */
-
-    tui_log(fs == ROOTFS_EXT2 ? "Formatting data partition (ext2)..."
-                               : "Formatting data partition (FAT32)...");
-    int mk = (fs == ROOTFS_EXT2) ? ext2_mkfs(drive, data_lba, data_count)
-                                  : fat32_mkfs(drive, data_lba, data_count);
-    if (mk != 0) {
-        tui_log_rc(fs == ROOTFS_EXT2
-                       ? "  ERROR: data mkfs (ext2) failed."
-                       : "  ERROR: data mkfs (FAT32) failed.", mk);
-        return -4;
-    }
-
-    tui_log("Mounting data partition...");
-    if (fat32_mounted()) fat32_unmount();
-    int mnt = (fs == ROOTFS_EXT2) ? ext2_mount(drive, data_lba)
-                                   : fat32_mount(drive, data_lba);
-    if (mnt != 0) {
-        tui_log_rc(fs == ROOTFS_EXT2 ? "  ERROR: data mount (ext2) failed."
-                                      : "  ERROR: data mount (FAT32) failed.", mnt);
-        return -5;
-    }
-    g_root_fs = fs;
-    /* Record for the post-install account-creation step. */
-    s_inst_drive    = drive;
-    s_inst_boot_lba = boot_lba;
-    s_inst_data_lba = data_lba;
-    s_inst_fs       = fs;
-
-    /* Data partition contents are copied after the remaining wizard inputs
-     * have been collected, so the installer does not spend time mirroring
-     * large trees before hostname/account prompts. */
-    if (fs == ROOTFS_EXT2) ext2_unmount(); else fat32_unmount();
-
-    /* ---- limine MBR install ---- */
-
-    tui_log("Installing limine bootloader...");
-    /* The MBR boot code + stage2 come from limine-hdd.bin (mirrors the host
-     * bios-install, which embeds binary_limine_hdd_bin_data); limine-bios.sys
-     * is stage3 and lives on the FAT32 /mnt/boot partition (/limine, above). */
-    uint32_t sys_sz = 0;
-    if (iso9660_read_file(g_cd, LIMINE_HDD_ISO_PATH, s_filebuf,
-                          INST_MAX_FILE_SIZE, &sys_sz) != 0 || sys_sz <= 512) {
-        tui_log("  ERROR: cannot read limine-hdd.bin from CD.");
-        return -6;
-    }
-    int li = limine_install_mbr(drive, s_filebuf, sys_sz);
-    if (li != 0) {
-        char e[48];
-        str_u(e, "  ERROR: limine install failed (", (uint32_t)(-li));
-        int eo = (int)strlen(e); e[eo++] = ')'; e[eo] = '\0';
-        tui_log(e);
-        return -7;
-    }
-
-    tui_log("Done.");
-    return 0;
-}
 
 /* ------------------------------------------------------------------------- */
 /* Drive picker                                                              */
@@ -953,6 +862,313 @@ static int build_drive_list(void)
 }
 
 /* ------------------------------------------------------------------------- */
+/* Shared headless execution engine (kernel/installer.h)                     */
+/*                                                                           */
+/* Drives the same disk work the TUI wizard performs, but parameterised and  */
+/* *stepped* so a GUI front-end (mxinstall.elf) can render a live progress   */
+/* bar and yield between files instead of freezing behind one blocking call. */
+/* ------------------------------------------------------------------------- */
+
+/* Build a shadow line "user:$mh$<salt16>$<hash16>:::::::\n" into out (>=128).
+ * Returns its length.  Salt seeded from the timer + RTC like the TUI path. */
+static uint32_t make_shadow_line(const char *user, const char *pw, char *out)
+{
+    char salt[17], hash[17];
+    uint32_t ticks = timer_get_ticks();
+    uint32_t rtcsec = 0; rtc_unix_time(&rtcsec);
+    uint8_t seed[8];
+    seed[0]=(uint8_t)ticks;        seed[1]=(uint8_t)(ticks>>8);
+    seed[2]=(uint8_t)(ticks>>16);  seed[3]=(uint8_t)(ticks>>24);
+    seed[4]=(uint8_t)rtcsec;       seed[5]=(uint8_t)(rtcsec>>8);
+    seed[6]=(uint8_t)(rtcsec>>16); seed[7]=(uint8_t)(rtcsec>>24);
+    microhash_hex16(seed, 8, salt);
+    {
+        size_t plen = strlen(pw); if (plen > 256) plen = 256;
+        uint8_t combined[16 + 256];
+        for (int i = 0; i < 16; i++) combined[i] = (uint8_t)salt[i];
+        for (size_t i = 0; i < plen; i++) combined[16+i] = (uint8_t)pw[i];
+        microhash_hex16(combined, 16 + plen, hash);
+    }
+    uint32_t pos = 0;
+    for (const char *u = user; *u && pos < 64; u++) out[pos++] = *u;
+    out[pos++]=':'; out[pos++]='$'; out[pos++]='m'; out[pos++]='h'; out[pos++]='$';
+    for (int i=0;i<16;i++) out[pos++]=salt[i];
+    out[pos++]='$';
+    for (int i=0;i<16;i++) out[pos++]=hash[i];
+    const char *tail = ":::::::\n"; for (int i=0;tail[i];i++) out[pos++]=tail[i];
+    out[pos]='\0';
+    return pos;
+}
+
+/* Default per-account rc files (mirrors the TUI installer's). */
+static const char s_makrc[]  = "# ~/.makshrc -- sourced by sh.elf on login\nPATH=/apps:/bin\n";
+static const char s_vixrc[]  = "\" ~/.vixrc -- read by vix on startup\nset linenumbers\n";
+static const char s_sbrc[]   =
+    "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
+    "left command\ncenter tabs\nright cpu mem rootfs time\n";
+
+/* Write the home dir + .makshrc/.vixrc/.sbrc for one account. */
+static void write_home(const char *home)
+{
+    rfs_mkdir(home);
+    char path[96];
+    const char *files[3] = { "/.makshrc", "/.vixrc", "/.sbrc" };
+    const char *body[3]  = { s_makrc, s_vixrc, s_sbrc };
+    for (int f = 0; f < 3; f++) {
+        int o = 0; const char *h = home;
+        while (*h && o < (int)sizeof(path)-12) path[o++] = *h++;
+        const char *s = files[f]; while (*s) path[o++] = *s++; path[o] = '\0';
+        rfs_write(path, body[f], (uint32_t)strlen(body[f]));
+    }
+}
+
+/* Write /etc/{hostname,shadow,autologin} + home dirs from the params.  The data
+ * partition must already be mounted (g_root_fs set). */
+static void install_write_meta(const install_params_t *p)
+{
+    rfs_mkdir("/etc");
+
+    const char *host = (p->hostname[0]) ? p->hostname : "makar";
+    { char hf[66]; int n=0; for (const char *h=host; *h && n<64; h++) hf[n++]=*h;
+      hf[n++]='\n'; hf[n]='\0'; rfs_write("/etc/hostname", hf, (uint32_t)n); }
+
+    /* /etc/shadow: root (if a password was set) + optional user. */
+    {
+        char shadow[512]; uint32_t sp = 0;
+        if (p->root_pw[0]) {
+            char ln[160]; uint32_t l = make_shadow_line("root", p->root_pw, ln);
+            for (uint32_t i=0;i<l && sp<sizeof(shadow);i++) shadow[sp++]=ln[i];
+        }
+        if (p->user_name[0] && p->user_pw[0]) {
+            char ln[160]; uint32_t l = make_shadow_line(p->user_name, p->user_pw, ln);
+            for (uint32_t i=0;i<l && sp<sizeof(shadow);i++) shadow[sp++]=ln[i];
+        }
+        if (sp) rfs_write("/etc/shadow", shadow, sp);
+    }
+
+    if (p->autologin[0]) {
+        char al[66]; int n=0; for (const char *a=p->autologin; *a && n<64; a++) al[n++]=*a;
+        al[n++]='\n'; al[n]='\0'; rfs_write("/etc/autologin", al, (uint32_t)n);
+    }
+
+    /* Home directories. */
+    rfs_mkdir("/root"); rfs_mkdir("/home");
+    if (p->root_pw[0]) write_home("/root");
+    if (p->user_name[0] && p->user_pw[0]) {
+        char home[80]; int o=0; const char *pre="/home/";
+        while (*pre) home[o++]=*pre++;
+        for (const char *u=p->user_name; *u && o<(int)sizeof(home)-1; u++) home[o++]=*u;
+        home[o]='\0';
+        write_home(home);
+    }
+}
+
+/* Copy-iterator state (BFS across the selected trees, one file per step). */
+static const char *s_gui_trees[4];
+static int         s_gui_ntrees, s_gui_tree_i, s_gui_ent_i;
+static uint32_t    s_gui_files, s_gui_total;
+static char        s_gui_dir[PATH_MAX_];
+
+/* Count files across all selected trees up-front, so the copy phase can report
+ * an accurate percentage.  A pure directory walk (no file reads), so it's cheap
+ * relative to the copy itself; uses the shared BFS scratch (s_copyq/s_ents). */
+static uint32_t install_count_files(void)
+{
+    uint32_t total = 0;
+    for (int t = 0; t < s_gui_ntrees; t++) {
+        q_reset();
+        q_push(s_gui_trees[t]);
+        while (!q_empty()) {
+            char dir[PATH_MAX_];
+            strncpy(dir, q_pop(), PATH_MAX_ - 1);
+            dir[PATH_MAX_ - 1] = '\0';
+            s_nents = 0;
+            iso9660_complete(g_cd, dir, "", enum_cb, NULL);
+            for (int i = 0; i < s_nents; i++) {
+                if (!s_ents[i].is_dir) { total++; continue; }
+                char child[PATH_MAX_]; int co = 0;
+                for (const char *d = dir; *d && co < PATH_MAX_ - 1; d++) child[co++] = *d;
+                if (!(co == 1 && child[0] == '/') && co < PATH_MAX_ - 1) child[co++] = '/';
+                for (const char *nm = s_ents[i].name; *nm && co < PATH_MAX_ - 1; nm++) child[co++] = *nm;
+                child[co] = '\0';
+                q_push(child);
+            }
+        }
+    }
+    return total;
+}
+
+/* Run the install engine preemptibly: syscalls normally execute with
+ * interrupts masked (non-preemptible), which froze the whole machine -- mouse
+ * included -- for the duration of a disk-bound install.  Enabling interrupts
+ * here lets the timer preempt on its fixed schedule, so the compositor and
+ * other tasks keep running at full frame rate while files copy in the
+ * background.  The shared state this path touches is made safe for that: the
+ * heap is irq-guarded and the IDE controller is behind a lock.  (The FS
+ * scratch buffers are only safe because the engine is the sole disk-FS user
+ * during an install; concurrent FS from another task is the remaining gap,
+ * tracked for the full preemptive-kernel pass.) */
+static inline void inst_preempt_on(void) { __asm__ volatile("sti"); }
+
+int install_exec_begin(const install_params_t *p)
+{
+    inst_preempt_on();
+    if (!p) return -1;
+    int cd = find_cdrom(); if (cd < 0) return -2;
+    g_cd = (uint8_t)cd;
+    if (!s_filebuf) { s_filebuf = (uint8_t *)kmalloc(INST_MAX_FILE_SIZE); if (!s_filebuf) return -3; }
+
+    const ide_drive_t *hdd = ide_get_drive(p->drive);
+    if (!hdd) return -4;
+    int fs = (p->fs == INSTALL_FS_FAT32) ? ROOTFS_FAT32 : ROOTFS_EXT2;
+
+    uint32_t b_lba=0,b_cnt=0,d_lba=0,d_cnt=0;
+    if (partition_whole_disk(p->drive, hdd->size, fs, &b_lba,&b_cnt,&d_lba,&d_cnt) != 0) return -5;
+    if (fat32_mkfs(p->drive, b_lba, b_cnt) != 0) return -6;
+    int mk = (fs == ROOTFS_EXT2) ? ext2_mkfs(p->drive, d_lba, d_cnt)
+                                  : fat32_mkfs(p->drive, d_lba, d_cnt);
+    if (mk != 0) return -7;
+
+    /* limine MBR. */
+    uint32_t sys_sz = 0;
+    if (iso9660_read_file(g_cd, LIMINE_HDD_ISO_PATH, s_filebuf, INST_MAX_FILE_SIZE, &sys_sz) != 0
+        || sys_sz <= 512) return -8;
+    if (limine_install_mbr(p->drive, s_filebuf, sys_sz) != 0) return -9;
+
+    /* Boot partition files. */
+    if (fat32_mounted()) fat32_unmount();
+    if (fat32_mount(p->drive, b_lba) != 0) return -10;
+    g_root_fs = ROOTFS_FAT32;
+    fat32_mkdir("/boot"); fat32_mkdir("/limine");
+    copy_one("/boot/makar.kernel", "/boot/makar.kernel");
+    copy_one(LIMINE_SYS_ISO_PATH, "/limine/limine-bios.sys");
+    { static char lbuf[1024]; uint32_t ln = build_limine_conf(lbuf, sizeof lbuf, p->autologin);
+      rfs_write("/limine/limine.conf", lbuf, ln); }
+    fat32_unmount();
+
+    /* Data partition: mount + metadata, leave mounted for the copy steps. */
+    int mnt = (fs == ROOTFS_EXT2) ? ext2_mount(p->drive, d_lba) : fat32_mount(p->drive, d_lba);
+    if (mnt != 0) return -11;
+    g_root_fs = fs;
+    install_write_meta(p);
+
+    /* Build the tree list, count files for the progress %, then seed the
+     * copy iterator. */
+    s_gui_ntrees = 0;
+    s_gui_trees[s_gui_ntrees++] = "/apps";
+    if (p->install_docs) s_gui_trees[s_gui_ntrees++] = "/docs";
+    if (p->install_src)  s_gui_trees[s_gui_ntrees++] = "/src";
+    s_gui_trees[s_gui_ntrees++] = "/usr";
+    s_gui_total = install_count_files();
+    s_gui_tree_i = 0; s_gui_files = 0;
+    s_nents = 0; s_gui_ent_i = 0;
+    q_reset();
+    rfs_mkdir(s_gui_trees[0]); q_push(s_gui_trees[0]);
+    { char b[48]; str_u(b, "INSTALL>exec begin ok, files=", s_gui_total);
+      Serial_WriteString(b); Serial_WriteString("\n"); }
+    return 0;
+}
+
+int install_exec_step(install_progress_t *prog)
+{
+    inst_preempt_on();
+    if (prog) { prog->done = 0; prog->files = s_gui_files; prog->total = s_gui_total; prog->current[0] = '\0'; }
+    for (;;) {
+        if (s_gui_ent_i >= s_nents) {
+            /* Current directory drained: take the next dir, else next tree. */
+            if (!q_empty()) {
+                strncpy(s_gui_dir, q_pop(), PATH_MAX_ - 1);
+                s_gui_dir[PATH_MAX_ - 1] = '\0';
+                s_nents = 0;
+                iso9660_complete(g_cd, s_gui_dir, "", enum_cb, NULL);
+                s_gui_ent_i = 0;
+                continue;
+            }
+            s_gui_tree_i++;
+            if (s_gui_tree_i >= s_gui_ntrees) {
+                if (prog) { prog->done = 1; prog->files = s_gui_files; prog->total = s_gui_total; }
+                Serial_WriteString("INSTALL>copy done\n");
+                return 0;   /* all trees copied */
+            }
+            q_reset();
+            rfs_mkdir(s_gui_trees[s_gui_tree_i]);
+            q_push(s_gui_trees[s_gui_tree_i]);
+            s_nents = 0; s_gui_ent_i = 0;
+            continue;
+        }
+
+        int idx = s_gui_ent_i++;
+        /* Build "<dir>/<name>". */
+        char child[PATH_MAX_]; int co = 0;
+        for (const char *d = s_gui_dir; *d && co < PATH_MAX_ - 1; d++) child[co++] = *d;
+        if (!(co == 1 && child[0] == '/') && co < PATH_MAX_ - 1) child[co++] = '/';
+        for (const char *nm = s_ents[idx].name; *nm && co < PATH_MAX_ - 1; nm++) child[co++] = *nm;
+        child[co] = '\0';
+
+        if (s_ents[idx].is_dir) {
+            rfs_mkdir(child);
+            q_push(child);
+            continue;   /* directories are quick: keep going within this step */
+        }
+        copy_file(child, child);
+        s_gui_files++;
+        if (prog) {
+            prog->files = s_gui_files;
+            prog->total = s_gui_total;
+            int o = 0; for (const char *nm = s_ents[idx].name; *nm && o < (int)sizeof(prog->current)-1; nm++)
+                prog->current[o++] = *nm;
+            prog->current[o] = '\0';
+        }
+        /* Per-file serial breadcrumb with running count + percentage. */
+        {
+            unsigned pct = s_gui_total ? (s_gui_files * 100u) / s_gui_total : 100u;
+            char b[160]; int o = 0;
+            const char *t = "INSTALL>copy ";       while (*t) b[o++] = *t++;
+            { char n[12]; int ni=0; uint32_t v=s_gui_files; if(!v)n[ni++]='0'; while(v){n[ni++]=(char)('0'+v%10);v/=10;} while(ni)b[o++]=n[--ni]; }
+            b[o++]='/';
+            { char n[12]; int ni=0; uint32_t v=s_gui_total; if(!v)n[ni++]='0'; while(v){n[ni++]=(char)('0'+v%10);v/=10;} while(ni)b[o++]=n[--ni]; }
+            b[o++]=' '; b[o++]='(';
+            { char n[12]; int ni=0; uint32_t v=pct; if(!v)n[ni++]='0'; while(v){n[ni++]=(char)('0'+v%10);v/=10;} while(ni)b[o++]=n[--ni]; }
+            b[o++]='%'; b[o++]=')'; b[o++]=' ';
+            for (const char *nm = s_ents[idx].name; *nm && o < (int)sizeof(b)-2; nm++) b[o++]=*nm;
+            b[o++]='\n'; b[o]='\0';
+            Serial_WriteString(b);
+        }
+        return 1;   /* one file copied; more work remains */
+    }
+}
+
+int install_exec_drives(install_drive_t *out)
+{
+    if (!out) return 0;
+    int n = 0;
+    for (int i = 0; i < IDE_MAX_DRIVES && n < INSTALL_MAX_DRIVES; i++) {
+        const ide_drive_t *d = ide_get_drive((uint8_t)i);
+        if (!d || !d->present || d->type != IDE_TYPE_ATA) continue;
+        out[n].index    = (unsigned char)i;
+        out[n].size_mib = d->size / 2048u;
+        int o = 0;
+        for (const char *m = d->model; *m && o < (int)sizeof(out[n].model)-1; m++)
+            out[n].model[o++] = *m;
+        out[n].model[o] = '\0';
+        n++;
+    }
+    return n;
+}
+
+int install_exec_finish(const install_params_t *p)
+{
+    inst_preempt_on();
+    int fs = (p && p->fs == INSTALL_FS_FAT32) ? ROOTFS_FAT32 : ROOTFS_EXT2;
+    if (rfs_mkdir("/bin") != 0)
+        Serial_WriteString("[install] WARNING: mkdir /bin failed\n");
+    if (fs == ROOTFS_EXT2) ext2_unmount(); else fat32_unmount();
+    if (s_filebuf) { kfree(s_filebuf); s_filebuf = NULL; }
+    Serial_WriteString("INSTALL>exec finish ok\n");
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
 /* installer_run                                                             */
 /* ------------------------------------------------------------------------- */
 
@@ -983,7 +1199,7 @@ static void installer_run_inner(void)
     tui_log("Installer started.");
 
     /* Welcome. */
-    if (g_gui) {
+    if (g_ansi) {
         tui_frame("Makar OS Installer", "Press Enter to begin, Esc to cancel");
         tui_center(6,  "Install Makar to a hard disk.", C_FG, C_BG);
         tui_center(8,  "This will ERASE the drive you choose.", C_WARN, C_BG);
@@ -996,7 +1212,7 @@ static void installer_run_inner(void)
 
     int cd = find_cdrom();
     if (cd < 0) {
-        if (g_gui) { tui_frame("Installer", "Press a key"); tui_center(6, "No ISO9660 CD-ROM source found.", C_WARN, C_BG); getkey(); }
+        if (g_ansi) { tui_frame("Installer", "Press a key"); tui_center(6, "No ISO9660 CD-ROM source found.", C_WARN, C_BG); getkey(); }
         else t_writestring("Error: no ISO9660 CD-ROM source found.\n");
         return;
     }
@@ -1004,7 +1220,7 @@ static void installer_run_inner(void)
 
     int n = build_drive_list();
     if (n == 0) {
-        if (g_gui) { tui_frame("Installer", "Press a key"); tui_center(6, "No ATA target drives found.", C_WARN, C_BG); getkey(); }
+        if (g_ansi) { tui_frame("Installer", "Press a key"); tui_center(6, "No ATA target drives found.", C_WARN, C_BG); getkey(); }
         else t_writestring("Error: no ATA target drives found.\n");
         return;
     }
@@ -1020,12 +1236,10 @@ static void installer_run_inner(void)
     /* Filesystem choice for the data partition. */
     static const char *fs_items[] = { "ext2  (Unix-style, recommended)", "FAT32 (EFI-style)" };
     static const char *fs_descs[] = {
-        "Apps / docs / src land on an ext2 data partition.\n"
-        "  A separate FAT32 boot partition (34 MiB) holds the\n"
-        "  kernel and Limine stage 3 (limine-bios.sys).",
-        "Apps / docs / src land on a FAT32 data partition.\n"
-        "  A separate FAT32 boot partition (34 MiB) holds the\n"
-        "  kernel and Limine stage 3 (limine-bios.sys)." };
+        "/apps, /docs and /src land on an ext2 data partition.\n"
+        "A separate 34 MiB FAT32 partition holds the kernel + Limine.",
+        "/apps, /docs and /src land on a FAT32 data partition.\n"
+        "A separate 34 MiB FAT32 partition holds the kernel + Limine." };
     Serial_WriteString("INSTALL>fs\n");
     int fs_pick = tui_menu("Root filesystem", NULL, fs_items, 2, fs_descs);
     if (fs_pick < 0) return;
@@ -1044,7 +1258,7 @@ static void installer_run_inner(void)
         /* Advanced: defer to cfdisk.  We don't drive it here; instruct the
          * user and bail (re-running install with a partitioned disk picks up
          * the existing layout in a future revision). */
-        if (g_gui) {
+        if (g_ansi) {
             tui_frame("Advanced partitioning", "Press a key to exit the installer");
             tui_center(6, "Run 'cfdisk' to lay out partitions,", C_FG, C_BG);
             tui_center(7, "then re-run 'install' and choose 'Use entire disk'", C_DIM, C_BG);
@@ -1069,7 +1283,7 @@ static void installer_run_inner(void)
         w1[o] = '\0';
     }
     if (!tui_confirm("Confirm install", w1, NULL)) {
-        if (!g_gui) t_writestring("Installation cancelled.\n");
+        if (!g_ansi) t_writestring("Installation cancelled.\n");
         return;
     }
 
@@ -1077,7 +1291,7 @@ static void installer_run_inner(void)
     Serial_WriteString("INSTALL>components\n");
     {
         unsigned char a1 = 0, a2 = 0;
-        if (g_gui) {
+        if (g_ansi) {
             tui_frame("Components", "Choose which optional trees to install.");
             uint32_t mid  = g_rows / 2;
             uint32_t lcol = (g_cols / 2) > 20 ? (g_cols / 2) - 20 : 2;
@@ -1108,7 +1322,7 @@ static void installer_run_inner(void)
     char w_hostname[64];
     w_hostname[0] = '\0';
     {
-        if (g_gui) {
+        if (g_ansi) {
             tui_frame("Set hostname", "Enter a name for this machine (letters, digits, hyphens)");
             uint32_t mid  = g_rows / 2;
             uint32_t lcol = (g_cols / 2) > 20 ? (g_cols / 2) - 20 : 2;
@@ -1116,32 +1330,32 @@ static void installer_run_inner(void)
             tui_at(lcol, mid, "Hostname:   ", C_FG, C_BG);
             {
                 char blank[32]; for (int i=0;i<20;i++) blank[i]=' '; blank[20]='\0';
-                vesa_tty_paint_string_at(fcol, mid, blank, C_FG, C_BG);
+                tui_at(fcol, mid, blank, C_FG, C_BG);
             }
             tui_at(lcol, mid + 2, "Press Enter to accept (default: makar)", C_DIM, C_BG);
             {
                 size_t len = 0;
-                vesa_tty_paint_string_at(fcol, mid, "_", C_TITLE, C_BG);
+                tui_at(fcol, mid, "_", C_TITLE, C_BG);
                 while (1) {
                     unsigned char c = getkey();
                     if (c == '\n' || c == '\r') {
-                        vesa_tty_paint_string_at(fcol+(uint32_t)len, mid, " ", C_FG, C_BG);
+                        tui_at(fcol+(uint32_t)len, mid, " ", C_FG, C_BG);
                         break;
                     }
                     if (c == '\b' || c == 127) {
                         if (len) {
-                            vesa_tty_paint_string_at(fcol+(uint32_t)len, mid, " ", C_FG, C_BG);
+                            tui_at(fcol+(uint32_t)len, mid, " ", C_FG, C_BG);
                             len--;
-                            vesa_tty_paint_string_at(fcol+(uint32_t)len, mid, "_", C_TITLE, C_BG);
+                            tui_at(fcol+(uint32_t)len, mid, "_", C_TITLE, C_BG);
                         }
                         continue;
                     }
                     if (c < 0x20 || c > 0x7E) continue;
                     if (len < sizeof(w_hostname)-1) {
                         char ch[2] = {(char)c, '\0'};
-                        vesa_tty_paint_string_at(fcol+(uint32_t)len, mid, ch, C_FG, C_BG);
+                        tui_at(fcol+(uint32_t)len, mid, ch, C_FG, C_BG);
                         w_hostname[len++] = (char)c;
-                        vesa_tty_paint_string_at(fcol+(uint32_t)len, mid, "_", C_TITLE, C_BG);
+                        tui_at(fcol+(uint32_t)len, mid, "_", C_TITLE, C_BG);
                     }
                 }
                 w_hostname[len] = '\0';
@@ -1159,15 +1373,17 @@ static void installer_run_inner(void)
     /* --- Accounts --- */
     Serial_WriteString("INSTALL>accounts\n");
 
-    /* Per-account wizard state; shadow lines built in memory. */
-    struct {
-        char username[64];
-        char shadow_line[256];
-        size_t shadow_len;
-    } w_accts[2];
-    int w_naccts = 0;
-    char w_autologin[64];   /* username to auto-log-in, or "" for none */
-    w_autologin[0] = '\0';
+    /* Every wizard choice lands in one install_params_t; the TUI then drives the
+     * SAME shared engine (install_exec_*) the GUI installer uses, so the two
+     * installers are functionally identical -- only the front-end differs. */
+    install_params_t ip;
+    for (unsigned _i = 0; _i < sizeof ip; _i++) ((unsigned char *)&ip)[_i] = 0;
+    ip.drive        = (unsigned char)drive;
+    ip.fs           = (fs == ROOTFS_FAT32) ? INSTALL_FS_FAT32 : INSTALL_FS_EXT2;
+    ip.install_docs = (unsigned char)s_inst_docs;
+    ip.install_src  = (unsigned char)s_inst_src;
+    { int _h = 0; for (; w_hostname[_h] && _h < (int)sizeof(ip.hostname)-1; _h++)
+          ip.hostname[_h] = w_hostname[_h]; ip.hostname[_h] = '\0'; }
 
     static const struct { const char *user; const char *prompt; int required; }
     acct_steps[] = {
@@ -1183,7 +1399,7 @@ static void installer_run_inner(void)
         char username[64];
         char pass1[256], pass2[256];
 
-        if (g_gui) {
+        if (g_ansi) {
             tui_frame(title,
                       required ? "Enter a password for root  (Enter to skip)"
                                : "Y = create user   N / Enter = skip");
@@ -1201,45 +1417,46 @@ static void installer_run_inner(void)
                 tui_at(lcol, mid - 4, "Username:     ", C_FG, C_BG);
                 {
                     char blank[32]; for (int i=0;i<20;i++) blank[i]=' '; blank[20]='\0';
-                    vesa_tty_paint_string_at(fcol, mid - 4, blank, C_FG, C_BG);
+                    tui_at(fcol, mid - 4, blank, C_FG, C_BG);
                 }
                 {
                     char blank[40]; for (int i=0;i<36;i++) blank[i]=' '; blank[36]='\0';
-                    vesa_tty_paint_string_at(lcol, mid - 2, blank, C_FG, C_BG);
+                    tui_at(lcol, mid - 2, blank, C_FG, C_BG);
                 }
                 {
                     size_t len = 0;
-                    vesa_tty_paint_string_at(fcol, mid-4, "_", C_TITLE, C_BG);
+                    tui_at(fcol, mid-4, "_", C_TITLE, C_BG);
                     while (1) {
                         unsigned char c = getkey();
                         if (c == '\n' || c == '\r') {
-                            vesa_tty_paint_string_at(fcol+(uint32_t)len, mid-4, " ", C_FG, C_BG);
+                            tui_at(fcol+(uint32_t)len, mid-4, " ", C_FG, C_BG);
                             break;
                         }
                         if (c == 0x1B) { username[0]='\0'; break; }
                         if (c == '\b' || c == 127) {
                             if (len) {
-                                vesa_tty_paint_string_at(fcol+(uint32_t)len, mid-4, " ", C_FG, C_BG);
+                                tui_at(fcol+(uint32_t)len, mid-4, " ", C_FG, C_BG);
                                 len--;
-                                vesa_tty_paint_string_at(fcol+(uint32_t)len, mid-4, "_", C_TITLE, C_BG);
+                                tui_at(fcol+(uint32_t)len, mid-4, "_", C_TITLE, C_BG);
                             }
                             continue;
                         }
                         if (c < 0x20 || c > 0x7E) continue;
                         if (len < sizeof(username)-1) {
                             char ch[2]={(char)c,'\0'};
-                            vesa_tty_paint_string_at(fcol+(uint32_t)len, mid-4, ch, C_FG, C_BG);
+                            tui_at(fcol+(uint32_t)len, mid-4, ch, C_FG, C_BG);
                             username[len++]=(char)c;
-                            vesa_tty_paint_string_at(fcol+(uint32_t)len, mid-4, "_", C_TITLE, C_BG);
+                            tui_at(fcol+(uint32_t)len, mid-4, "_", C_TITLE, C_BG);
                         }
                     }
                     username[len]='\0';
                 }
                 if (!username[0]) goto next_acct;
             } else {
-                for (int i=0; fixed_user[i] && i<(int)sizeof(username)-1; i++)
-                    username[i] = fixed_user[i];
-                username[sizeof(username)-1] = '\0';
+                { int i = 0;
+                  for (; fixed_user[i] && i < (int)sizeof(username)-1; i++)
+                      username[i] = fixed_user[i];
+                  username[i] = '\0'; }   /* terminate after the name, not at [63] */
             }
 
             uint32_t row_pass  = fixed_user ? mid - 2 : mid;
@@ -1251,8 +1468,8 @@ static void installer_run_inner(void)
             tui_at(lcol, row_hint,  "Press Enter to confirm", C_DIM, C_BG);
 
             char blanks[32]; for (int i=0;i<20;i++) blanks[i]=' '; blanks[20]='\0';
-            vesa_tty_paint_string_at(fcol, row_pass,  blanks, C_FG, C_BG);
-            vesa_tty_paint_string_at(fcol, row_pass2, blanks, C_FG, C_BG);
+            tui_at(fcol, row_pass,  blanks, C_FG, C_BG);
+            tui_at(fcol, row_pass2, blanks, C_FG, C_BG);
 
             readline_masked(pass1, sizeof(pass1), fcol, row_pass);
             if (!pass1[0] && required) {
@@ -1273,9 +1490,10 @@ static void installer_run_inner(void)
                 readline(username, sizeof(username));
                 if (!username[0]) goto next_acct;
             } else {
-                for (int i=0; fixed_user[i] && i<(int)sizeof(username)-1; i++)
-                    username[i] = fixed_user[i];
-                username[sizeof(username)-1] = '\0';
+                { int i = 0;
+                  for (; fixed_user[i] && i < (int)sizeof(username)-1; i++)
+                      username[i] = fixed_user[i];
+                  username[i] = '\0'; }   /* terminate after the name, not at [63] */
                 t_writestring("\nSet root password (Enter to skip): ");
             }
             readline_masked(pass1, sizeof(pass1), 0, 0);
@@ -1288,49 +1506,19 @@ static void installer_run_inner(void)
             }
         }
 
-        /* Build shadow line in memory — no disk I/O here. */
-        if (w_naccts < 2) {
-            /* Copy username */
-            size_t ui = 0;
-            while (username[ui] && ui < sizeof(w_accts[0].username)-1) {
-                w_accts[w_naccts].username[ui] = username[ui]; ui++;
-            }
-            w_accts[w_naccts].username[ui] = '\0';
-
-            /* Compute salt + hash */
-            char salt[17], hash[17];
-            {
-                uint32_t ticks = timer_get_ticks();
-                uint32_t rtcsec = 0; rtc_unix_time(&rtcsec);
-                uint8_t seed[8];
-                seed[0]=(uint8_t)ticks;       seed[1]=(uint8_t)(ticks>>8);
-                seed[2]=(uint8_t)(ticks>>16);  seed[3]=(uint8_t)(ticks>>24);
-                seed[4]=(uint8_t)rtcsec;       seed[5]=(uint8_t)(rtcsec>>8);
-                seed[6]=(uint8_t)(rtcsec>>16); seed[7]=(uint8_t)(rtcsec>>24);
-                microhash_hex16(seed, 8, salt);
-            }
-            {
-                size_t plen = strlen(pass1);
-                if (plen > 256) plen = 256;
-                uint8_t combined[16 + 256];
-                for (int i = 0; i < 16; i++) combined[i] = (uint8_t)salt[i];
-                for (size_t i = 0; i < plen; i++) combined[16+i] = (uint8_t)pass1[i];
-                microhash_hex16(combined, 16 + plen, hash);
-            }
-
-            /* "username:$mh$<salt16>$<hash16>:::::::\n" */
-            char *ln = w_accts[w_naccts].shadow_line;
-            size_t pos = 0;
-            for (size_t i = 0; username[i] && pos < 64; i++) ln[pos++] = username[i];
-            ln[pos++]=':'; ln[pos++]='$'; ln[pos++]='m';
-            ln[pos++]='h'; ln[pos++]='$';
-            for (int i=0;i<16;i++) ln[pos++]=salt[i];
-            ln[pos++]='$';
-            for (int i=0;i<16;i++) ln[pos++]=hash[i];
-            const char *tail = ":::::::\n";
-            for (int i=0;tail[i];i++) ln[pos++]=tail[i];
-            w_accts[w_naccts].shadow_len = pos;
-            w_naccts++;
+        /* Stash the confirmed plaintext into the shared params; the engine
+         * salts + hashes it into /etc/shadow (same path as the GUI installer). */
+        if (step == 0) {                 /* root */
+            int _i = 0; for (; pass1[_i] && _i < (int)sizeof(ip.root_pw)-1; _i++)
+                ip.root_pw[_i] = pass1[_i];
+            ip.root_pw[_i] = '\0';
+        } else {                         /* additional user */
+            int _i = 0; for (; username[_i] && _i < (int)sizeof(ip.user_name)-1; _i++)
+                ip.user_name[_i] = username[_i];
+            ip.user_name[_i] = '\0';
+            _i = 0; for (; pass1[_i] && _i < (int)sizeof(ip.user_pw)-1; _i++)
+                ip.user_pw[_i] = pass1[_i];
+            ip.user_pw[_i] = '\0';
         }
 
         next_acct:;
@@ -1340,14 +1528,9 @@ static void installer_run_inner(void)
     /* Auto-login toggle — offer to skip the password prompt on boot.     */
     /* ------------------------------------------------------------------ */
     {
-        /* Prefer the first non-root account; fall back to root. */
-        const char *cand = (const char *)0;
-        for (int i = 0; i < w_naccts; i++) {
-            const char *u = w_accts[i].username;
-            int is_root = (u[0]=='r'&&u[1]=='o'&&u[2]=='o'&&u[3]=='t'&&u[4]=='\0');
-            if (!is_root) { cand = u; break; }
-        }
-        if (!cand && w_naccts > 0) cand = w_accts[0].username;
+        /* Prefer the new user; fall back to root (if a root password was set). */
+        const char *cand = ip.user_name[0] ? ip.user_name
+                         : (ip.root_pw[0]  ? "root" : (const char *)0);
 
         if (cand) {
             char q[96]; size_t qp = 0;
@@ -1359,7 +1542,7 @@ static void installer_run_inner(void)
             q[qp] = '\0';
 
             unsigned char ans = 0;
-            if (g_gui) {
+            if (g_ansi) {
                 tui_frame("Auto-login",
                           "Skip the password prompt and sign in automatically on boot?");
                 uint32_t mid  = g_rows / 2;
@@ -1372,31 +1555,21 @@ static void installer_run_inner(void)
                 ans = (unsigned char)buf[0];
             }
             if (ans == 'y' || ans == 'Y') {
-                size_t i = 0;
-                while (cand[i] && i < sizeof(w_autologin)-1) { w_autologin[i] = cand[i]; i++; }
-                w_autologin[i] = '\0';
+                int i = 0;
+                for (; cand[i] && i < (int)sizeof(ip.autologin)-1; i++) ip.autologin[i] = cand[i];
+                ip.autologin[i] = '\0';
             }
         }
     }
 
     /* ------------------------------------------------------------------ */
-    /* Disk preparation: no partitioning/formatting/copying starts until */
-    /* all installer input has been collected.                           */
+    /* Execute via the shared engine -- identical to the GUI installer.    */
     /* ------------------------------------------------------------------ */
-
-    s_filebuf = (uint8_t *)kmalloc(INST_MAX_FILE_SIZE);
-    if (!s_filebuf) {
-        t_writestring("Error: out of memory for transfer buffer.\n");
-        return;
-    }
-
-    int rc = do_install((uint8_t)drive, hdd->size, fs);
-
-    if (rc != 0) {
+    exec_screen("Installing Makar");
+    tui_log("Preparing disk (partition + format + bootloader)...");
+    if (install_exec_begin(&ip) < 0) {
         t_writestring("INSTALL: failed\n");
-        kfree(s_filebuf);
-        s_filebuf = NULL;
-        if (g_gui) {
+        if (g_ansi) {
             tui_frame("Installer", "Press a key to return to the shell");
             tui_center(6, "Installation FAILED.", C_WARN, C_BG);
             tui_center(8, "See the messages above; nothing was finalised.", C_DIM, C_BG);
@@ -1406,227 +1579,27 @@ static void installer_run_inner(void)
         }
         return;
     }
-    Serial_WriteString("INSTALL: disk prepared ok\n");
-
-    /* ------------------------------------------------------------------ */
-    /* Final disk writes: boot files, account config, and optional trees. */
-    /* All file copying happens here, after the remaining wizard inputs. */
-    /* ------------------------------------------------------------------ */
     {
-        tui_log("Mounting boot partition...");
-        if (fat32_mounted()) fat32_unmount();
-        int bm = fat32_mount(s_inst_drive, s_inst_boot_lba);
-        if (bm == 0) {
-            g_root_fs = ROOTFS_FAT32;
-
-            tui_log("Creating boot directory tree...");
-            int brc;
-            if ((brc = fat32_mkdir("/boot")) != 0)
-                tui_log_rc("  WARNING: mkdir /boot failed.", brc);
-            if ((brc = fat32_mkdir("/limine")) != 0)
-                tui_log_rc("  WARNING: mkdir /limine failed.", brc);
-
-            tui_log("Copying kernel...");
-            copy_one("/boot/makar.kernel", "/boot/makar.kernel");
-
-            tui_log("Copying limine-bios.sys...");
-            copy_one(LIMINE_SYS_ISO_PATH, "/limine/limine-bios.sys");
-
-            tui_log("Writing limine.conf...");
-            {
-                static char limine_buf[1024];
-                uint32_t ln = build_limine_conf(limine_buf, sizeof limine_buf, w_autologin);
-                if ((brc = rfs_write("/limine/limine.conf", limine_buf, ln)) != 0)
-                    tui_log_rc("  WARNING: failed to write limine.conf.", brc);
-            }
-
-            fat32_unmount();
-        } else {
-            tui_log_rc("  WARNING: boot mount failed during final copy.", bm);
+        install_progress_t prog;
+        prog.done = 0; prog.files = 0; prog.total = 0; prog.current[0] = '\0';
+        while (install_exec_step(&prog) > 0) {
+            unsigned pct = prog.total ? (prog.files * 100u) / prog.total : 100u;
+            char st[80]; int _o = 0;
+            const char *cc = "  ["; while (*cc) st[_o++] = *cc++;
+            { uint32_t v=pct; char n[4]; int ni=0; if(!v)n[ni++]='0'; while(v){n[ni++]=(char)('0'+v%10);v/=10;} while(ni)st[_o++]=n[--ni]; }
+            const char *pp = "%] "; while (*pp) st[_o++] = *pp++;
+            for (const char *q = prog.current; *q && _o < (int)sizeof(st)-2; q++) st[_o++] = *q;
+            st[_o] = '\0';
+            tui_status(st);
         }
     }
-
-    {
-        int mnt = (s_inst_fs == ROOTFS_EXT2)
-            ? ext2_mount(s_inst_drive, s_inst_data_lba)
-            : fat32_mount(s_inst_drive, s_inst_data_lba);
-
-        if (mnt == 0) {
-            g_root_fs = s_inst_fs;
-
-            rfs_mkdir("/etc");
-
-            /* /etc/hostname */
-            {
-                size_t hlen = strlen(w_hostname);
-                char hfile[66];
-                for (size_t i = 0; i < hlen; i++) hfile[i] = w_hostname[i];
-                hfile[hlen] = '\n'; hfile[hlen+1] = '\0';
-                rfs_write("/etc/hostname", hfile, (uint32_t)(hlen + 1));
-                Serial_WriteString("[install] hostname: ");
-                Serial_WriteString(w_hostname);
-                Serial_WriteString("\n");
-            }
-
-            /* /etc/autologin — written only if the operator opted in. */
-            if (w_autologin[0]) {
-                char albuf[66];
-                size_t al = 0;
-                while (w_autologin[al] && al < sizeof(albuf) - 2) {
-                    albuf[al] = w_autologin[al]; al++;
-                }
-                albuf[al++] = '\n';
-                albuf[al]   = '\0';
-                rfs_write("/etc/autologin", albuf, (uint32_t)al);
-                Serial_WriteString("[install] autologin: ");
-                Serial_WriteString(w_autologin);
-                Serial_WriteString("\n");
-            }
-
-            /* /etc/shadow — concatenate all entries */
-            if (w_naccts > 0) {
-                static char shadow_buf[512];
-                size_t spos = 0;
-                for (int i = 0; i < w_naccts; i++) {
-                    size_t llen = w_accts[i].shadow_len;
-                    if (spos + llen < sizeof(shadow_buf)) {
-                        for (size_t j = 0; j < llen; j++)
-                            shadow_buf[spos++] = w_accts[i].shadow_line[j];
-                        Serial_WriteString("[install] shadow written for: ");
-                        Serial_WriteString(w_accts[i].username);
-                        Serial_WriteString("\n");
-                    }
-                }
-                rfs_write("/etc/shadow", shadow_buf, (uint32_t)spos);
-            }
-
-            /* Home directories + default .makshrc */
-            rfs_mkdir("/root");
-            rfs_mkdir("/home");
-            for (int i = 0; i < w_naccts; i++) {
-                int is_root = (w_accts[i].username[0]=='r' &&
-                               w_accts[i].username[1]=='o' &&
-                               w_accts[i].username[2]=='o' &&
-                               w_accts[i].username[3]=='t' &&
-                               w_accts[i].username[4]=='\0');
-
-                /* Compute home dir path */
-                char hdir[80];
-                size_t p = 0;
-                if (is_root) {
-                    hdir[p++]='/'; hdir[p++]='r'; hdir[p++]='o';
-                    hdir[p++]='o'; hdir[p++]='t'; hdir[p]='\0';
-                } else {
-                    hdir[p++]='/'; hdir[p++]='h'; hdir[p++]='o';
-                    hdir[p++]='m'; hdir[p++]='e'; hdir[p++]='/';
-                    for (size_t j = 0; w_accts[i].username[j] && p < sizeof(hdir)-1; j++)
-                        hdir[p++] = w_accts[i].username[j];
-                    hdir[p] = '\0';
-                    rfs_mkdir(hdir);
-                }
-                Serial_WriteString("[install] homedir: ");
-                Serial_WriteString(hdir);
-                Serial_WriteString("\n");
-
-                /* Write ~/.makshrc with defaults */
-                char rc_path[88];
-                p = 0;
-                for (size_t j = 0; hdir[j] && p < sizeof(rc_path)-10; j++)
-                    rc_path[p++] = hdir[j];
-                rc_path[p++]='/'; rc_path[p++]='.'; rc_path[p++]='m';
-                rc_path[p++]='a'; rc_path[p++]='k'; rc_path[p++]='s';
-                rc_path[p++]='h'; rc_path[p++]='r'; rc_path[p++]='c';
-                rc_path[p]='\0';
-
-                /* Default .makshrc content */
-                static const char makrc_root[] =
-                    "# ~/.makshrc -- sourced by sh.elf on login\n"
-                    "PATH=/apps:/bin\n";
-                static const char makrc_user[] =
-                    "# ~/.makshrc -- sourced by sh.elf on login\n"
-                    "PATH=/apps:/bin\n";
-                const char *rc_content = is_root ? makrc_root : makrc_user;
-                size_t rc_len = 0;
-                while (rc_content[rc_len]) rc_len++;
-                rfs_write(rc_path, rc_content, (uint32_t)rc_len);
-                Serial_WriteString("[install] makshrc: ");
-                Serial_WriteString(rc_path);
-                Serial_WriteString("\n");
-
-                /* Write ~/.vixrc enabling line numbers by default.  vix
-                 * itself ships with line numbers OFF; this rc opts each
-                 * installed account into them (Ctrl-N toggles at runtime). */
-                char vix_path[88];
-                p = 0;
-                for (size_t j = 0; hdir[j] && p < sizeof(vix_path) - 8; j++)
-                    vix_path[p++] = hdir[j];
-                vix_path[p++]='/'; vix_path[p++]='.'; vix_path[p++]='v';
-                vix_path[p++]='i'; vix_path[p++]='x'; vix_path[p++]='r';
-                vix_path[p++]='c'; vix_path[p]='\0';
-                static const char vixrc[] =
-                    "\" ~/.vixrc -- read by vix on startup\n"
-                    "set linenumbers\n";
-                size_t vix_len = 0;
-                while (vixrc[vix_len]) vix_len++;
-                rfs_write(vix_path, vixrc, (uint32_t)vix_len);
-                Serial_WriteString("[install] vixrc: ");
-                Serial_WriteString(vix_path);
-                Serial_WriteString("\n");
-
-                /* Write ~/.sbrc -- statusbar.elf layout (foreground command
-                 * left, resources right).  Sections: left/center/right + widgets. */
-                char sb_path[88];
-                p = 0;
-                for (size_t j = 0; hdir[j] && p < sizeof(sb_path) - 7; j++)
-                    sb_path[p++] = hdir[j];
-                sb_path[p++]='/'; sb_path[p++]='.'; sb_path[p++]='s';
-                sb_path[p++]='b'; sb_path[p++]='r'; sb_path[p++]='c';
-                sb_path[p]='\0';
-                static const char sbrc[] =
-                    "# ~/.sbrc -- statusbar layout: <section> <widgets...>\n"
-                    "# widgets: hostname user date time datetime uptime\n"
-                    "#          cpu mem rootfs command tabs\n"
-                    "left command\n"
-                    "center tabs\n"
-                    "right cpu mem rootfs time\n";
-                size_t sb_len = 0;
-                while (sbrc[sb_len]) sb_len++;
-                rfs_write(sb_path, sbrc, (uint32_t)sb_len);
-                Serial_WriteString("[install] sbrc: ");
-                Serial_WriteString(sb_path);
-                Serial_WriteString("\n");
-            }
-
-            copy_tree("/apps");
-            if (s_inst_docs) copy_tree("/docs");
-            if (s_inst_src)  copy_tree("/src");
-            copy_tree("/usr");
-
-            /* /bin is the scratch + output directory the in-OS kernel rebuild
-             * (rebuild-kernel.sh) writes to.  tmpfs has no subdirectories, so
-             * the rebuild can't use /tmp; it needs a real writable dir on the
-             * rootfs.  Create it empty here so the first `mkdir /bin/ktcc` from
-             * the script doesn't try to create a directory inside a missing
-             * parent.  No source tree to copy -- /bin lives only on the target. */
-            if (rfs_mkdir("/bin") != 0)
-                tui_log("  WARNING: mkdir /bin on rootfs failed (rebuild-kernel will need it).");
-
-            if (s_inst_fs == ROOTFS_EXT2) ext2_unmount();
-            else fat32_unmount();
-        } else {
-            Serial_WriteString("[install] WARNING: could not mount data fs for post-install writes\n");
-        }
-    }
-    kfree(s_filebuf);
-    s_filebuf = NULL;
-
-    /* ------------------------------------------------------------------ */
-    /* Done                                                                 */
-    /* ------------------------------------------------------------------ */
+    install_exec_finish(&ip);
+    tui_status("");
+    tui_log("Done.");
 
     t_writestring("INSTALL: complete ok\n");
-    Serial_WriteString("[install] complete — rebooting\n");
-    if (g_gui) {
+    Serial_WriteString("[install] complete -- rebooting\n");
+    if (g_ansi) {
         tui_frame("Installer", "Rebooting...");
         tui_center(6, "Installation complete!", C_OK, C_BG);
         tui_center(8, "Remove the install media. Rebooting in 3 seconds...", C_FG, C_BG);

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -239,6 +239,79 @@ static void test_vt_status_scroll(void)
     ktest_summary();
 }
 
+static void test_vt_ansi(void)
+{
+    ktest_begin("vt_ansi", "VT backing grid parses ANSI/VT100 escapes");
+
+    vt_buf_t vt;
+    memset(&vt, 0, sizeof vt);
+    KTEST_ASSERT(vt_init(&vt, 20, 6, 0x00FFFFFFu, 0x00000000u));
+    if (!vt.cells) { ktest_summary(); return; }
+
+    /* CUP: ESC[3;5H -> row 2, col 4 (1-based -> 0-based). */
+    const char *cup = "\x1b[3;5H";
+    for (const char *p = cup; *p; p++) vt_putchar(&vt, *p);
+    KTEST_ASSERT(vt.cur_row == 2);
+    KTEST_ASSERT(vt.cur_col == 4);
+
+    /* A glyph lands at the addressed cell, cursor advances. */
+    vt_putchar(&vt, 'X');
+    KTEST_ASSERT(vt_get_cell(&vt, 4, 2).ch == 'X');
+    KTEST_ASSERT(vt.cur_col == 5);
+
+    /* SGR red-on-default then a glyph: cell carries the red fg. */
+    const char *sgr = "\x1b[31m";
+    for (const char *p = sgr; *p; p++) vt_putchar(&vt, *p);
+    vt_putchar(&vt, 'R');
+    KTEST_ASSERT(vt_get_cell(&vt, 5, 2).ch == 'R');
+    KTEST_ASSERT(vt_get_cell(&vt, 5, 2).fg == 0x00AA0000u);
+
+    /* SGR reset returns to the default fg. */
+    const char *rst = "\x1b[0m";
+    for (const char *p = rst; *p; p++) vt_putchar(&vt, *p);
+    vt_putchar(&vt, 'W');
+    KTEST_ASSERT(vt_get_cell(&vt, 6, 2).fg == 0x00FFFFFFu);
+
+    /* EL(2): ESC[2K clears the whole current line. */
+    vt_set_cursor(&vt, 0, 0);
+    vt_putchar(&vt, 'a'); vt_putchar(&vt, 'b'); vt_putchar(&vt, 'c');
+    vt_set_cursor(&vt, 1, 0);
+    const char *el = "\x1b[2K";
+    for (const char *p = el; *p; p++) vt_putchar(&vt, *p);
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 0).ch == ' ');
+    KTEST_ASSERT(vt_get_cell(&vt, 2, 0).ch == ' ');
+
+    /* ED(2): ESC[2J clears the screen. */
+    vt_set_cursor(&vt, 0, 3);
+    vt_putchar(&vt, 'Z');
+    const char *ed = "\x1b[2J";
+    for (const char *p = ed; *p; p++) vt_putchar(&vt, *p);
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 3).ch == ' ');
+
+    /* Plain text + control chars still behave exactly as before. */
+    vt_set_cursor(&vt, 0, 0);
+    vt_putchar(&vt, 'h'); vt_putchar(&vt, 'i');
+    vt_putchar(&vt, '\r');
+    KTEST_ASSERT(vt.cur_col == 0);
+    vt_putchar(&vt, '\n');
+    KTEST_ASSERT(vt.cur_row == 1);
+    KTEST_ASSERT(vt_get_cell(&vt, 0, 0).ch == 'h');
+    KTEST_ASSERT(vt_get_cell(&vt, 1, 0).ch == 'i');
+
+    /* An unterminated/long CSI must never wedge: cursor save/restore. */
+    vt_set_cursor(&vt, 7, 3);
+    const char *sv = "\x1b[s";
+    for (const char *p = sv; *p; p++) vt_putchar(&vt, *p);
+    vt_set_cursor(&vt, 0, 0);
+    const char *rs = "\x1b[u";
+    for (const char *p = rs; *p; p++) vt_putchar(&vt, *p);
+    KTEST_ASSERT(vt.cur_col == 7);
+    KTEST_ASSERT(vt.cur_row == 3);
+
+    kfree(vt.cells);
+    ktest_summary();
+}
+
 /* ---------------------------------------------------------------------------
  * Suite: partition helpers
  *
@@ -3429,6 +3502,7 @@ int ktest_run_all(void)
     total_fail += ktest_fail_count;
 
     test_vt_status_scroll();
+    test_vt_ansi();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -31,6 +31,7 @@
 #include <kernel/signal.h>
 #include <kernel/tty.h>
 #include <kernel/keyboard.h>
+#include <kernel/installer.h>   /* install_exec_* (SYS_INSTALL_EXEC) */
 #include <kernel/mouse.h>
 #include <kernel/shell.h>
 #include <kernel/vfs.h>
@@ -139,8 +140,81 @@ static int ansi_sgr(char *b, unsigned char vga)
     int o = 0; b[o++] = 0x1b; b[o++] = '['; b[o++] = '0'; b[o++] = ';';
     o += ansi_u(b+o, fc); b[o++] = ';'; o += ansi_u(b+o, bc); b[o++] = 'm'; return o; }
 static int ansi_cup(char *b, unsigned row, unsigned col)
-{   int o = 0; b[o++] = 0x1b; b[o++] = '[';
-    o += ansi_u(b+o, row+1); b[o++] = ';'; o += ansi_u(b+o, col+1); b[o++] = 'H'; return o; }
+{   int o = 0; b[o++] = 0x1b; b[o++] = '['; o += ansi_u(b+o, row+1); b[o++] = ';';
+    o += ansi_u(b+o, col+1); b[o++] = 'H'; return o; }
+
+/* -------------------------------------------------------------------------
+ * Generic in-kernel terminal I/O on the calling task's standard streams
+ * (kernel/fd.h) -- the kernel-side analogue of write(1)/read(0).  In-kernel
+ * TUI code (e.g. the installer) uses these to speak to whatever terminal the
+ * invoking ring-3 task owns: a real text VT (bytes reach the framebuffer
+ * console's vt_putchar ANSI parser) or an mxterm window (bytes reach the
+ * client over a pipe).  This file provides the implementation; it deliberately
+ * knows nothing about who calls it.
+ * ------------------------------------------------------------------------- */
+long kfd_stdout_write(const char *buf, unsigned int len)
+{
+    task_t     *cur = task_current();
+    fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, 1);
+    if (!e) return -1;
+    if (e->kind == FD_KIND_PIPE && e->pipe_is_writer && e->pipe) {
+        ansi_pipe_write(e, buf, len);
+        return (long)len;
+    }
+    if (e->kind == FD_KIND_VGA || e->kind == FD_KIND_VGA_SERIAL) {
+        for (unsigned int i = 0; i < len; i++) t_putchar(buf[i]);
+        if (e->kind == FD_KIND_VGA_SERIAL && !g_serial_verbose)
+            for (unsigned int i = 0; i < len; i++) Serial_WriteChar(buf[i]);
+        return (long)len;
+    }
+    if (e->kind == FD_KIND_SERIAL) {
+        for (unsigned int i = 0; i < len; i++) Serial_WriteChar(buf[i]);
+        return (long)len;
+    }
+    return -1;
+}
+
+int kfd_stdout_is_pipe(void)
+{
+    task_t     *cur = task_current();
+    fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, 1);
+    return (e && e->kind == FD_KIND_PIPE && e->pipe_is_writer && e->pipe) ? 1 : 0;
+}
+
+int kfd_stdin_getbyte(void)
+{
+    task_t     *cur = task_current();
+    fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, 0);
+    if (e && e->kind == FD_KIND_PIPE && !e->pipe_is_writer && e->pipe) {
+        pipe_ring_t *r = e->pipe;
+        for (;;) {
+            if (r->head != r->tail) {
+                unsigned char b = r->buf[r->tail % PIPE_RING_CAP];
+                r->tail++;
+                return (int)b;
+            }
+            if (r->refcount_w == 0) return -1;   /* writer (mxterm) gone */
+            task_yield();
+        }
+    }
+    /* Real text VT (or no fd 0): raw single key, so arrows/Esc/Enter arrive
+     * un-line-buffered -- exactly what the wizard's getkey() expects. */
+    return (int)(unsigned char)keyboard_getchar();
+}
+
+void kfd_term_size(unsigned int *cols, unsigned int *rows)
+{
+    unsigned int c = 80, rw = 25;
+    task_t     *cur = task_current();
+    fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, 1);
+    if (e && e->kind == FD_KIND_PIPE && e->pipe && e->pipe->cols && e->pipe->rows) {
+        c = e->pipe->cols; rw = e->pipe->rows;
+    } else if (vesa_tty_is_ready()) {
+        c = vesa_tty_get_cols(); rw = vesa_tty_usable_rows();
+    }
+    if (cols) *cols = c;
+    if (rows) *rows = rw;
+}
 
 /* Callback + context for SYS_LS_DIR using vfs_complete. */
 typedef struct { char *buf; uint32_t cap; uint32_t off; } ls_ctx_t;
@@ -2217,6 +2291,20 @@ void syscall_dispatch(registers_t *regs)
     case SYS_INSTALL: {
         if (!task_is_admin(NULL)) { regs->eax = (uint32_t)-1; break; }
         regs->eax = (uint32_t)admin_install();
+        break;
+    }
+    /* Stepped headless installer for the GUI front-end (mxinstall.elf).
+     * EBX = cmd (0 begin, 1 step, 2 finish, 3 list-drives); ECX = the matching
+     * params / progress / drive-array pointer. */
+    case SYS_INSTALL_EXEC: {
+        if (!task_is_admin(NULL)) { regs->eax = (uint32_t)-1; break; }
+        int   cmd = (int)regs->ebx;
+        void *ptr = (void *)(uintptr_t)regs->ecx;
+        if      (cmd == 0) regs->eax = (uint32_t)install_exec_begin((const install_params_t *)ptr);
+        else if (cmd == 1) regs->eax = (uint32_t)install_exec_step((install_progress_t *)ptr);
+        else if (cmd == 2) regs->eax = (uint32_t)install_exec_finish((const install_params_t *)ptr);
+        else if (cmd == 3) regs->eax = (uint32_t)install_exec_drives((install_drive_t *)ptr);
+        else               regs->eax = (uint32_t)-1;
         break;
     }
     case SYS_MOUNT: {

--- a/src/kernel/include/kernel/fd.h
+++ b/src/kernel/include/kernel/fd.h
@@ -120,4 +120,29 @@ fd_entry_t *fd_get(fd_table_t *tbl, int fd);
  */
 int fd_close(fd_table_t *tbl, int fd);
 
+/* ------------------------------------------------------------------------
+ * Generic in-kernel terminal I/O on the *calling task's* standard streams.
+ *
+ * These are the kernel-side equivalents of write(1)/read(0) -- the moral
+ * analogue of Linux's kernel_write()/kernel_read() -- for in-kernel code that
+ * wants to talk to whatever terminal the invoking ring-3 task owns (a text VT,
+ * whose bytes reach the framebuffer console's ANSI parser, or an mxterm window
+ * over a pipe).  Consumers reference these; the syscall layer must not depend
+ * on any particular consumer.
+ * ------------------------------------------------------------------------ */
+
+/* Write to fd 1.  Returns bytes written, or -1 if it has no usable stdout. */
+long kfd_stdout_write(const char *buf, unsigned int len);
+
+/* One raw input byte from fd 0: a forwarded pipe byte (blocking) when piped,
+ * else keyboard_getchar().  Returns 0-255, or -1 on EOF. */
+int kfd_stdin_getbyte(void);
+
+/* Terminal size: the pty winsize when stdout is a pipe, else the VESA TTY
+ * usable area, else 80x25. */
+void kfd_term_size(unsigned int *cols, unsigned int *rows);
+
+/* Non-zero when stdout (fd 1) is a pipe (i.e. running under an mxterm window). */
+int kfd_stdout_is_pipe(void);
+
 #endif /* _KERNEL_FD_H */

--- a/src/kernel/include/kernel/installer.h
+++ b/src/kernel/include/kernel/installer.h
@@ -24,9 +24,44 @@
  */
 
 /*
- * installer_run – run the interactive OS installation wizard.
- * Does not return until the installation completes or is cancelled.
+ * installer_run – run the interactive TUI installation wizard (shell mode).
+ * Collects all choices via the ANSI text UI, then runs the shared execution
+ * engine below.  Does not return until the install completes or is cancelled.
  */
 void installer_run(void);
+
+/* ------------------------------------------------------------------------
+ * Headless execution engine (shared by the TUI wizard and the GUI installer).
+ *
+ * The TUI installer collects these choices with its text wizard; the GUI
+ * installer (mxinstall.elf) collects them graphically.  Both then drive the
+ * same three-phase engine.  Execution is *stepped* -- the caller copies one
+ * file per install_exec_step() call -- so a GUI front-end can repaint a
+ * progress bar and yield between files instead of freezing behind one giant
+ * blocking syscall.
+ * ------------------------------------------------------------------------ */
+
+/* install_params_t / install_progress_t / install_drive_t + INSTALL_* live in
+ * the shared kernel<->user ABI header so the GUI client agrees byte-for-byte. */
+#include <makar_abi.h>
+
+/* Enumerate selectable ATA target drives into out[INSTALL_MAX_DRIVES].
+ * Returns the count.  (The GUI installer can't reach ide_get_drive directly.) */
+int install_exec_drives(install_drive_t *out);
+
+/* Phase 1: partition + mkfs both partitions + limine MBR + boot files +
+ * account/hostname metadata; leaves the data partition mounted for copying.
+ * Returns 0 on success, negative on failure. */
+int install_exec_begin(const install_params_t *p);
+
+/* Phase 2: copy the next file of the /apps,/docs,/src,/usr trees into the
+ * mounted data partition.  Returns 1 while work remains (prog->done==0), 0 when
+ * the last file has been copied (prog->done==1), negative on error.  Call
+ * repeatedly; the caller repaints + yields between calls. */
+int install_exec_step(install_progress_t *prog);
+
+/* Phase 3: finalise (mkdir /bin, unmount).  Returns 0 on success.  After this
+ * the caller reboots. */
+int install_exec_finish(const install_params_t *p);
 
 #endif /* _KERNEL_INSTALLER_H */

--- a/src/kernel/include/kernel/vt.h
+++ b/src/kernel/include/kernel/vt.h
@@ -26,6 +26,8 @@ typedef struct vt_cell {
     uint32_t bg;      /* framebuffer-pixel-encoded background */
 } vt_cell_t;
 
+#define VT_NPARAM 8       /* max CSI numeric parameters tracked */
+
 typedef struct vt_buf {
     uint32_t   cols;
     uint32_t   rows;
@@ -35,6 +37,18 @@ typedef struct vt_buf {
     uint32_t   fg;        /* current attribute applied to incoming chars */
     uint32_t   bg;
     vt_cell_t *cells;     /* row-major: cells[row * cols + col] */
+
+    /* ANSI/VT100 escape-sequence parser.  Modelled on Linux's in-kernel
+     * console VT layer (drivers/tty/vt/vt.c): the backing grid itself
+     * interprets CSI/SGR so userspace drives it with escape bytes, not a
+     * cell-poke syscall.  GROUND-state bytes fall through to the plain
+     * \n/\r/\b + glyph path below. */
+    uint8_t    esc_state;     /* 0 ground, 1 ESC, 2 CSI, 3 OSC, 4 swallow1, 5 OSC-ESC */
+    uint8_t    esc_nparam;
+    uint8_t    esc_priv;      /* '?' private CSI seen */
+    uint16_t   esc_param[VT_NPARAM];
+    uint32_t   saved_col, saved_row;  /* ESC 7/8 + CSI s/u */
+    uint32_t   def_fg, def_bg;         /* SGR-reset colours (set in vt_init) */
 } vt_buf_t;
 
 /* Result of vt_putchar - lets the renderer know what to repaint without

--- a/src/kernel/include/makar_abi.h
+++ b/src/kernel/include/makar_abi.h
@@ -97,4 +97,40 @@ struct dirent {
 };
 #endif
 
+/* ------------------------------------------------------------------------
+ * Installer ABI -- shared by the in-kernel install engine (installer.c) and the
+ * GUI installer client (mxinstall.elf), driven via SYS_INSTALL_EXEC.
+ * ------------------------------------------------------------------------ */
+#define INSTALL_FS_EXT2    0
+#define INSTALL_FS_FAT32   1
+#define INSTALL_MAX_DRIVES 4
+
+#ifndef _MAKAR_STRUCT_INSTALL_DEFINED
+#define _MAKAR_STRUCT_INSTALL_DEFINED
+typedef struct {
+    unsigned char drive;          /* IDE drive index (target) */
+    unsigned char fs;             /* INSTALL_FS_EXT2 / INSTALL_FS_FAT32 (data part) */
+    unsigned char install_docs;   /* copy /docs */
+    unsigned char install_src;    /* copy /src  */
+    char          hostname[64];   /* "" -> "makar" */
+    char          autologin[64];  /* "" -> none */
+    char          root_pw[128];   /* "" -> leave root password unset */
+    char          user_name[64];  /* "" -> no extra user */
+    char          user_pw[128];
+} install_params_t;
+
+typedef struct {
+    int          done;            /* 1 once every tree has been copied */
+    unsigned int files;           /* files copied so far */
+    unsigned int total;           /* total files to copy (for the % bar) */
+    char         current[64];     /* name of the file just copied */
+} install_progress_t;
+
+typedef struct {
+    unsigned char index;          /* IDE drive index -> install_params_t.drive */
+    unsigned int  size_mib;
+    char          model[40];
+} install_drive_t;
+#endif
+
 #endif /* _MAKAR_ABI_H */

--- a/src/kernel/include/makar_syscalls.h
+++ b/src/kernel/include/makar_syscalls.h
@@ -116,6 +116,10 @@
 #define SYS_CAD_PENDING     271 /* int cad_pending(void) - test+clear Ctrl-Alt-Del */
 #define SYS_PTY_WINSIZE     272 /* int pty_winsize(int fd, (cols<<16)|rows) - set a
                                  * pipe's pty window size (GUI terminal -> child) */
+#define SYS_INSTALL_EXEC    273 /* int install_exec(cmd, ptr) - stepped headless
+                                 * installer for the GUI front-end.  EBX cmd:
+                                 * 0=begin(params*) 1=step(progress*) 2=finish(params*).
+                                 * Returns the engine's int result (see installer.h). */
 
 /*
  * Admin syscalls (219..229).

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -32,7 +32,7 @@ DOOM_CFLAGS=$(CFLAGS) -I$(DOOM_DIR) -include stddef.h -Wno-unused \
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf mxnet.elf mxdisk.elf mximg.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf mxnet.elf mxdisk.elf mximg.elf mxinstall.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -114,6 +114,9 @@ mxnet.elf: crt0.o mxnet.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxdisk.elf: crt0.o mxdisk.o gui_gfx.o gui_ui.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mxinstall.elf: crt0.o mxinstall.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mximg.elf: crt0.o mximg.o gui_gfx.o gui_ui.o gui_browser.o makx.o

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -32,7 +32,7 @@ DOOM_CFLAGS=$(CFLAGS) -I$(DOOM_DIR) -include stddef.h -Wno-unused \
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -102,6 +102,9 @@ mxtasks.elf: crt0.o mxtasks.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxabout.elf: crt0.o mxabout.o gui_gfx.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mxclock.elf: crt0.o mxclock.o gui_gfx.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 files.elf: crt0.o files.o

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -32,7 +32,7 @@ DOOM_CFLAGS=$(CFLAGS) -I$(DOOM_DIR) -include stddef.h -Wno-unused \
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf mxnet.elf mxdisk.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -108,6 +108,12 @@ mxclock.elf: crt0.o mxclock.o gui_gfx.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxcalc.elf: crt0.o mxcalc.o gui_gfx.o gui_ui.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mxnet.elf: crt0.o mxnet.o gui_gfx.o gui_ui.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mxdisk.elf: crt0.o mxdisk.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 files.elf: crt0.o files.o

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -32,7 +32,7 @@ DOOM_CFLAGS=$(CFLAGS) -I$(DOOM_DIR) -include stddef.h -Wno-unused \
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf mxnet.elf mxdisk.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf mxnet.elf mxdisk.elf mximg.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -114,6 +114,9 @@ mxnet.elf: crt0.o mxnet.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxdisk.elf: crt0.o mxdisk.o gui_gfx.o gui_ui.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mximg.elf: crt0.o mximg.o gui_gfx.o gui_ui.o gui_browser.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 files.elf: crt0.o files.o

--- a/src/userspace/Makefile
+++ b/src/userspace/Makefile
@@ -32,7 +32,7 @@ DOOM_CFLAGS=$(CFLAGS) -I$(DOOM_DIR) -include stddef.h -Wno-unused \
 DESTDIR?=
 ISODIR?=$(CURDIR)/../../isodir
 
-PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf
+PROGS=hello.elf help.elf calc.elf vix.elf diskinfo.elf lspci.elf maknetcfg.elf kbtester.elf makbox.elf makmux.elf statusbar.elf sigtest.elf maktop.elf clock.elf lines.elf forktest.elf execvetest.elf fdisk.elf cfdisk.elf basic.elf filetest.elf alloctest.elf sh.elf ar.elf microhash.elf sha256.elf md5.elf wget.elf ktest_uspace.elf gui.elf doom.elf files.elf mxterm.elf mxedit.elf mxfiles.elf mxtasks.elf mxabout.elf mxclock.elf mxcalc.elf
 
 # libc.a -- single archive of the userspace shim (malloc + FILE* stdio +
 # setjmp/longjmp + string/memory helpers).  Shipped under /usr/lib on the
@@ -105,6 +105,9 @@ mxabout.elf: crt0.o mxabout.o gui_gfx.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 mxclock.elf: crt0.o mxclock.o gui_gfx.o makx.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+mxcalc.elf: crt0.o mxcalc.o gui_gfx.o gui_ui.o makx.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
 files.elf: crt0.o files.o

--- a/src/userspace/gui_ui.c
+++ b/src/userspace/gui_ui.c
@@ -101,7 +101,11 @@ static int ui_textbox_impl(ui_ctx *c, gfx_surface *s, int x, int y, int w, int h
     int maxchars = (w - 8) / 8;
     int shown = len > maxchars ? maxchars : len;   /* tail that fits */
     if (masked) {
-        for (int i = 0; i < shown; i++) gfx_char(s, tx + i * 8, ty, '*', UI_COL_TEXT);
+        /* One round dot per character (the bitmap font has no bullet glyph, so
+         * draw a small filled rounded square that reads as a dot). */
+        gfx_u32 dot_bg = focused ? UI_COL_FIELD_FC : UI_COL_FIELD;
+        for (int i = 0; i < shown; i++)
+            gfx_round(s, tx + i * 8 + 2, ty + 2, 5, 5, UI_COL_TEXT, dot_bg);
     } else {
         const char *show = buf;
         if (len > maxchars) show = buf + (len - maxchars);

--- a/src/userspace/mxcalc.c
+++ b/src/userspace/mxcalc.c
@@ -1,0 +1,140 @@
+/*
+ * mxcalc.elf -- a calculator, as a makx client.  A button grid + display over
+ * a small integer expression evaluator (the same recursive-descent grammar as
+ * the shell calc.elf: + - * / %, parens, unary).  Mouse or keyboard input.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "gui_ui.h"
+#include "makx.h"
+
+#define RGB GFX_RGB
+#define COL_BG    RGB(0x12,0x16,0x1e)
+#define COL_DISP  RGB(0x0a,0x0d,0x12)
+#define COL_TEXT  RGB(0xd3,0xd7,0xcf)
+#define COL_ERR   RGB(0xff,0x60,0x60)
+
+static int slen(const char *s){ int n=0; while(s[n])n++; return n; }
+
+/* ---- integer expression evaluator (no stdout; 0 ok / -1 error) ---------- */
+static const char *p_; static int p_err;
+static long e_expr(void);
+static void e_ws(void){ while(*p_==' '||*p_=='\t') p_++; }
+static long e_factor(void){
+    e_ws();
+    if(*p_=='('){ p_++; long v=e_expr(); e_ws(); if(*p_==')') p_++; else p_err=1; return v; }
+    if(*p_<'0'||*p_>'9'){ p_err=1; return 0; }
+    long v=0; while(*p_>='0'&&*p_<='9') v=v*10+(*p_++-'0'); return v;
+}
+static long e_unary(void){
+    e_ws();
+    if(*p_=='-'){ p_++; return -e_unary(); }
+    if(*p_=='+'){ p_++; return  e_unary(); }
+    return e_factor();
+}
+static long e_term(void){
+    long v=e_unary();
+    for(;;){ e_ws(); if(p_err) return 0; char op=*p_;
+        if(op!='*'&&op!='/'&&op!='%') break;
+        p_++; long r=e_unary(); if(p_err) return 0;
+        if(op=='*') v*=r; else if(r==0){ p_err=1; return 0; }
+        else if(op=='/') v/=r; else v%=r;
+    }
+    return v;
+}
+static long e_expr(void){
+    long v=e_term();
+    for(;;){ e_ws(); if(p_err) return 0; char op=*p_;
+        if(op!='+'&&op!='-') break;
+        p_++; long r=e_term(); if(p_err) return 0;
+        if(op=='+') v+=r; else v-=r;
+    }
+    return v;
+}
+static int eval(const char *s, long *out){
+    p_=s; p_err=0; long v=e_expr(); e_ws();
+    if(*p_) p_err=1;
+    if(p_err) return -1;
+    *out=v; return 0;
+}
+static void ltoa(long v, char *b){
+    char t[24]; int i=0; int neg = v<0;
+    unsigned long u = neg ? (unsigned long)(-v) : (unsigned long)v;
+    if(!u) t[i++]='0';
+    while(u){ t[i++]=(char)('0'+u%10); u/=10; }
+    int j=0; if(neg) b[j++]='-';
+    while(i) b[j++]=t[--i];
+    b[j]=0;
+}
+
+/* ---- input handling ----------------------------------------------------- */
+static char expr[40];
+static int  err;
+
+static void append(char c){ int n=slen(expr); if(n<(int)sizeof expr-1){ expr[n]=c; expr[n+1]=0; err=0; } }
+static void backspace(void){ int n=slen(expr); if(n){ expr[n-1]=0; err=0; } }
+static void clear(void){ expr[0]=0; err=0; }
+static void equals(void){
+    if(!expr[0]) return;
+    long r; if(eval(expr,&r)==0){ ltoa(r,expr); err=0; } else err=1;
+}
+static void feed(char c){
+    if((c>='0'&&c<='9')||c=='+'||c=='-'||c=='*'||c=='/'||c=='%'||c=='('||c==')') append(c);
+    else if(c=='='||c=='\n'||c=='\r') equals();
+    else if(c=='\b'||c==127) backspace();
+    else if(c=='c'||c=='C') clear();
+}
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if(mx_connect(&c, argc, argv, 240, 300, MX_F_RESIZABLE)!=0) return 1;
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++)((int*)&u)[i]=0;
+
+    /* 4-col x 5-row keypad. */
+    static const char *labels[5][4] = {
+        { "C", "<", "(", ")" },
+        { "7", "8", "9", "/" },
+        { "4", "5", "6", "*" },
+        { "1", "2", "3", "-" },
+        { "0", "=", "%", "+" },
+    };
+    int first=1, lmx=-1, lmy=-1;
+
+    while(!c.closed){
+        mx_pump(&c);
+        int k, keyed=0;
+        while((k=mx_key(&c))>=0){ feed((char)k); keyed=1; }
+
+        int moved = (c.mx!=lmx||c.my!=lmy); lmx=c.mx; lmy=c.my;
+        if(!(first||keyed||c.mpressed||c.mreleased||moved||c.resized)){ sys_yield(); continue; }
+        first=0;
+
+        gfx_surface *s=&c.surf;
+        gfx_fill(s,0,0,s->w,s->h,COL_BG);
+
+        /* display */
+        int dh=36, pad=6;
+        gfx_fill(s,pad,pad,s->w-2*pad,dh,COL_DISP);
+        const char *shown = expr[0] ? expr : "0";
+        gfx_str(s,pad+8,pad+(dh-8)/2, shown, err?COL_ERR:COL_TEXT);
+
+        /* keypad fills the area below the display */
+        int gy=pad+dh+pad, gx=pad;
+        int gw=s->w-2*pad, gh=s->h-gy-pad;
+        int bw=gw/4, bh=gh/5;
+        ui_begin(&u,c.mx,c.my,c.mdown,c.mpressed,c.mreleased,-1);
+        for(int r=0;r<5;r++) for(int col=0;col<4;col++){
+            const char *lab=labels[r][col];
+            if(ui_button(&u,s,gx+col*bw,gy+r*bh,bw-4,bh-4,lab)){
+                char ch=lab[0];
+                if(ch=='<') backspace();
+                else feed(ch);
+            }
+        }
+        mx_present(&c);
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mxclock.c
+++ b/src/userspace/mxclock.c
@@ -1,0 +1,109 @@
+/*
+ * mxclock.elf -- a desktop clock, as a makx client.  Reads /proc/rtc once a
+ * second and draws a large digital time + date into its makx surface.  The GUI
+ * peer of the fullscreen clock.elf; reuses the same /proc/rtc parse.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "makx.h"
+#include "font8x8.h"
+
+#define RGB GFX_RGB
+#define COL_BG   RGB(0x10,0x14,0x1c)
+#define COL_TIME RGB(0x8a,0xe2,0x34)
+#define COL_DATE RGB(0xd3,0xd7,0xcf)
+#define COL_DIM  RGB(0x60,0x6a,0x76)
+
+static int slen(const char *s){ int n=0; while(s[n])n++; return n; }
+
+static long read_file(const char *path, char *buf, unsigned cap)
+{
+    int fd = sys_open(path, O_RDONLY); if (fd < 0) return -1;
+    long n = sys_read(fd, buf, cap - 1); sys_close(fd);
+    if (n < 0) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+/* "YYYY-MM-DD HH:MM:SS" -> date[11], time[9].  1 ok / 0 parse fail. */
+static int parse_rtc(const char *buf, char *date_out, char *time_out)
+{
+    if ((unsigned)slen(buf) < 19) return 0;
+    for (int i = 0; i < 10; i++) {
+        char c = buf[i], want = (i==4||i==7) ? '-' : 0;
+        if (want ? (c != want) : (c < '0' || c > '9')) return 0;
+        date_out[i] = c;
+    }
+    date_out[10] = '\0';
+    if (buf[10] != ' ') return 0;
+    for (int i = 0; i < 8; i++) {
+        char c = buf[11+i], want = (i==2||i==5) ? ':' : 0;
+        if (want ? (c != want) : (c < '0' || c > '9')) return 0;
+        time_out[i] = c;
+    }
+    time_out[8] = '\0';
+    return 1;
+}
+
+/* Draw one 8x8 glyph scaled by `sc` (each set pixel becomes an sc*sc block).
+ * Matches gfx_char's bit order: bit 0 = leftmost column. */
+static void glyph_scaled(gfx_surface *s, int x, int y, unsigned char ch, int sc, gfx_u32 fg)
+{
+    if (ch >= 128) ch = '?';
+    const unsigned char *g = FONT8x8[ch];
+    for (int r = 0; r < 8; r++)
+        for (int c = 0; c < 8; c++)
+            if (g[r] & (1u << c)) gfx_fill(s, x + c*sc, y + r*sc, sc, sc, fg);
+}
+static int str_scaled_w(const char *s, int sc){ return slen(s) * 8 * sc; }
+static void str_scaled(gfx_surface *s, int x, int y, const char *str, int sc, gfx_u32 fg)
+{
+    for (; *str; str++, x += 8*sc) glyph_scaled(s, x, y, (unsigned char)*str, sc, fg);
+}
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if (mx_connect(&c, argc, argv, 360, 200, MX_F_RESIZABLE) != 0) return 1;
+
+    char date[16] = "----------", tstr[16] = "--:--:--";
+    unsigned next = 0;          /* uptime tick of the next refresh */
+    int first = 1;
+
+    while (!c.closed) {
+        mx_pump(&c);
+        while (mx_key(&c) >= 0) { /* clock ignores keys */ }
+
+        int tick_due = 0;
+        unsigned now = sys_uptime();
+        if (now >= next) {       /* USER_HZ = 100 -> +100 = 1 s */
+            char buf[64];
+            if (read_file("/proc/rtc", buf, sizeof buf) > 0)
+                parse_rtc(buf, date, tstr);
+            next = now + 100u;
+            tick_due = 1;
+        }
+
+        if (tick_due || first || c.resized) {
+            gfx_surface *s = &c.surf;
+            gfx_fill(s, 0, 0, s->w, s->h, COL_BG);
+            /* Pick a time scale that fits the width with margin. */
+            int sc = (s->w - 16) / (8 * 8);          /* 8 glyphs "HH:MM:SS" */
+            if (sc < 1) sc = 1;
+            if (sc > 8) sc = 8;
+            int tw = str_scaled_w(tstr, sc);
+            int th = 8 * sc;
+            int tx = (s->w - tw) / 2;
+            int ty = (s->h - th) / 2 - 8;
+            str_scaled(s, tx, ty, tstr, sc, COL_TIME);
+            /* Date in plain 8x8, centred under the time. */
+            int dx = (s->w - gfx_text_w(date)) / 2;
+            gfx_str(s, dx, ty + th + 10, date, COL_DATE);
+            mx_present(&c);
+            first = 0;
+        }
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mxdisk.c
+++ b/src/userspace/mxdisk.c
@@ -1,0 +1,64 @@
+/*
+ * mxdisk.elf -- disk / partition info, as a makx client.  Read-only view of
+ * SYS_DISK_INFO (drives, partition table, FAT32 BPB) -- the GUI peer of
+ * diskinfo.elf.  Destructive partitioning stays in cfdisk/fdisk.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "gui_ui.h"
+#include "makx.h"
+
+#define RGB GFX_RGB
+#define COL_BG   RGB(0x12,0x16,0x1e)
+#define COL_TEXT RGB(0xd3,0xd7,0xcf)
+#define COL_HDR  RGB(0xf0,0xa8,0x30)
+
+static char info[1024];
+
+static void refresh(void)
+{
+    int n = sys_disk_info(info, (unsigned)sizeof info - 1);
+    if (n < 0) n = 0;
+    info[n] = '\0';
+    if (!info[0]) {
+        const char *m = "(no disk info)";
+        int i=0; for(; m[i]; i++) info[i]=m[i]; info[i]=0;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if (mx_connect(&c, argc, argv, 520, 360, MX_F_RESIZABLE) != 0) return 1;
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++)((int*)&u)[i]=0;
+    refresh();
+    int first=1, lmx=-1, lmy=-1;
+
+    while (!c.closed) {
+        mx_pump(&c);
+        while (mx_key(&c) >= 0) { /* read-only */ }
+
+        int moved=(c.mx!=lmx||c.my!=lmy); lmx=c.mx; lmy=c.my;
+        if(!(first||c.mpressed||c.mreleased||moved||c.resized)){ sys_yield(); continue; }
+        first=0;
+
+        gfx_surface *s=&c.surf;
+        gfx_fill(s,0,0,s->w,s->h,COL_BG);
+
+        ui_begin(&u,c.mx,c.my,c.mdown,c.mpressed,c.mreleased,-1);
+        if(ui_button(&u,s,8,8,84,22,"Refresh")) refresh();
+        gfx_str(s,104,14,"Disks & partitions (read-only)",COL_HDR);
+
+        int x=10, y=42;
+        for(const char *p=info; *p; ){
+            char line[120]; int i=0;
+            while(*p && *p!='\n' && i<(int)sizeof line-1) line[i++]=*p++;
+            line[i]=0; if(*p=='\n') p++;
+            if(y < s->h-10){ gfx_str_clip(s,x,y,line,COL_TEXT,s->w-10); y+=12; }
+        }
+        mx_present(&c);
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mximg.c
+++ b/src/userspace/mximg.c
@@ -1,0 +1,152 @@
+/*
+ * mximg.elf -- an image viewer, as a makx client.  Opens an image (Open dialog
+ * or a path argument), decodes it, and scales it to fit the window (aspect-
+ * preserving, nearest-neighbour).  This first cut decodes BMP (24/32-bpp
+ * uncompressed); GIF/PNG/JPEG land next.  Reuses the shared gui_browser file
+ * dialog (like mxedit) so it's usable straight from its desktop icon.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "gui_ui.h"
+#include "gui_browser.h"
+#include "makx.h"
+
+#define RGB GFX_RGB
+#define COL_BG   RGB(0x0c,0x0e,0x12)
+#define COL_BAR  RGB(0x16,0x1b,0x24)
+#define COL_TEXT RGB(0xd3,0xd7,0xcf)
+#define COL_ERR  RGB(0xff,0x60,0x60)
+
+#define IMG_MAXW 1600
+#define IMG_MAXH 1200
+#define FILE_CAP (8u*1024u*1024u)
+
+static gfx_u32 *img_px;          /* decoded pixels (mmap, IMG_MAXW*IMG_MAXH) */
+static unsigned char *fbuf;            /* file read buffer (mmap, FILE_CAP)        */
+static int img_w, img_h;         /* current image size (0 = none)           */
+static char msg[96] = "Open an image (BMP).";
+
+static void scpy(char *d,const char *s,int max){int i=0;while(s[i]&&i<max-1){d[i]=s[i];i++;}d[i]=0;}
+static unsigned rd32(const unsigned char *p){ return p[0]|(p[1]<<8)|(p[2]<<16)|((unsigned)p[3]<<24); }
+static int      rd16(const unsigned char *p){ return p[0]|(p[1]<<8); }
+
+/* Decode an uncompressed 24/32-bpp BMP from fbuf[0..n) into img_px. 0 ok. */
+static int decode_bmp(unsigned n)
+{
+    if (n < 54 || fbuf[0] != 'B' || fbuf[1] != 'M') { scpy(msg,"not a BMP file",sizeof msg); return -1; }
+    unsigned off = rd32(fbuf+10);
+    int w = (int)rd32(fbuf+18);
+    int hh = (int)rd32(fbuf+22);
+    int bpp = rd16(fbuf+28);
+    unsigned comp = rd32(fbuf+30);
+    int topdown = 0;
+    if (hh < 0) { hh = -hh; topdown = 1; }
+    if (comp != 0 || (bpp != 24 && bpp != 32)) { scpy(msg,"unsupported BMP (need 24/32-bpp uncompressed)",sizeof msg); return -1; }
+    if (w < 1 || hh < 1 || w > IMG_MAXW || hh > IMG_MAXH) { scpy(msg,"image too large",sizeof msg); return -1; }
+    int bypp = bpp/8;
+    unsigned stride = ((unsigned)(w*bypp) + 3u) & ~3u;
+    if (off + stride*(unsigned)hh > n) { scpy(msg,"truncated BMP",sizeof msg); return -1; }
+    for (int y = 0; y < hh; y++) {
+        int srcrow = topdown ? y : (hh-1-y);
+        const unsigned char *row = fbuf + off + (unsigned)srcrow*stride;
+        gfx_u32 *dst = img_px + (unsigned)y*w;
+        for (int x = 0; x < w; x++) {
+            const unsigned char *px = row + x*bypp;
+            dst[x] = RGB(px[2], px[1], px[0]);   /* BMP is BGR(A) */
+        }
+    }
+    img_w = w; img_h = hh;
+    return 0;
+}
+
+static void load_image(const char *path)
+{
+    img_w = img_h = 0;
+    int fd = sys_open(path, O_RDONLY);
+    if (fd < 0) { scpy(msg,"cannot open file",sizeof msg); return; }
+    long sz = sys_lseek(fd, 0, SEEK_END);
+    sys_lseek(fd, 0, 0);
+    if (sz <= 0 || (unsigned long)sz > FILE_CAP) { sys_close(fd); scpy(msg,"file too large",sizeof msg); return; }
+    unsigned got = 0;
+    while (got < (unsigned)sz) {
+        long r = sys_read(fd, fbuf+got, (unsigned)sz-got);
+        if (r <= 0) break;
+        got += (unsigned)r;
+    }
+    sys_close(fd);
+    if (decode_bmp(got) == 0) {
+        /* path basename into msg */
+        const char *b = path; for (const char *p=path; *p; p++) if (*p=='/') b=p+1;
+        scpy(msg, b, sizeof msg);
+    }
+}
+
+static int slen(const char*s){int n=0;while(s[n])n++;return n;}
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if (mx_connect(&c, argc, argv, 600, 460, MX_F_RESIZABLE) != 0) return 1;
+    img_px = (gfx_u32*)sys_mmap(0,(unsigned long)IMG_MAXW*IMG_MAXH*4,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
+    fbuf   = (unsigned char*)sys_mmap(0,FILE_CAP,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
+    if (img_px==(void*)MAP_FAILED || fbuf==(void*)MAP_FAILED) return 1;
+
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++)((int*)&u)[i]=0;
+    browser brz; for(unsigned i=0;i<sizeof brz/sizeof(int);i++)((int*)&brz)[i]=0;
+    int dlg=0;
+
+    /* Optional path argument (skip -makx <pid>). */
+    for(int i=1;i<argc;i++){
+        if(argv[i][0]=='-'){ i++; continue; }
+        load_image(argv[i]); break;
+    }
+
+    int first=1, lmx=-1, lmy=-1;
+    while(!c.closed){
+        mx_pump(&c);
+        while(mx_key(&c)>=0){ /* keys go to the dialog via ui */ }
+        int moved=(c.mx!=lmx||c.my!=lmy); lmx=c.mx; lmy=c.my;
+        if(!(first||c.mpressed||c.mreleased||moved||c.resized)){ sys_yield(); continue; }
+        first=0;
+
+        gfx_surface *s=&c.surf;
+        gfx_fill(s,0,0,s->w,s->h,COL_BG);
+
+        /* toolbar */
+        gfx_fill(s,0,0,s->w,30,COL_BAR);
+        ui_begin(&u,c.mx,c.my,c.mdown,c.mpressed,c.mreleased,-1);
+        int open_c=ui_button(&u,s,6,5,64,20,"Open");
+        gfx_str_clip(s,80,11,msg,COL_TEXT,s->w-8);
+        if(open_c){ scpy(brz.cwd,"/apps",sizeof brz.cwd); brz.sel=brz.scroll=0; brz.loaded=0; br_load(&brz); dlg=1; }
+
+        if(dlg){
+            char full[256];
+            int r=br_dialog(&brz,&u,s,6,34,s->w-12,s->h-34-6,1,(char*)0,0,full,sizeof full);
+            if(r==1){ load_image(full); dlg=0; }
+            else if(r==2){ dlg=0; }
+        } else if(img_w>0){
+            /* aspect-fit the image into the area below the toolbar */
+            int ax=4, ay=34, aw=s->w-8, ah=s->h-34-4;
+            int fw, fh;
+            if((long)img_w*ah > (long)img_h*aw){ fw=aw; fh=(int)((long)img_h*aw/img_w); }
+            else { fh=ah; fw=(int)((long)img_w*ah/img_h); }
+            if(fw<1)fw=1; if(fh<1)fh=1;
+            int fx=ax+(aw-fw)/2, fy=ay+(ah-fh)/2;
+            gfx_surface src={ img_px, img_w, img_h };
+            gfx_blit_scaled(s, fx, fy, fw, fh, &src);
+            /* size readout "WxH" in the corner */
+            char dim[48]; int o=0;
+            { int v=img_w; char t[8]; int ti=0; if(!v)t[ti++]='0'; while(v){t[ti++]=(char)('0'+v%10);v/=10;} while(ti)dim[o++]=t[--ti]; }
+            dim[o++]='x'; { int v=img_h; char t[8]; int ti=0; if(!v)t[ti++]='0'; while(v){t[ti++]=(char)('0'+v%10);v/=10;} while(ti)dim[o++]=t[--ti]; }
+            dim[o]=0;
+            gfx_str(s, s->w-gfx_text_w(dim)-6, s->h-12, dim, COL_TEXT);
+        } else {
+            const char *h="No image. Click Open to choose a BMP file.";
+            gfx_str(s,(s->w-gfx_text_w(h))/2, s->h/2, h, (msg[0]&&msg[slen(msg)-1]!='.')?COL_ERR:COL_TEXT);
+        }
+        mx_present(&c);
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mximg.c
+++ b/src/userspace/mximg.c
@@ -1,9 +1,9 @@
 /*
  * mximg.elf -- an image viewer, as a makx client.  Opens an image (Open dialog
  * or a path argument), decodes it, and scales it to fit the window (aspect-
- * preserving, nearest-neighbour).  This first cut decodes BMP (24/32-bpp
- * uncompressed); GIF/PNG/JPEG land next.  Reuses the shared gui_browser file
- * dialog (like mxedit) so it's usable straight from its desktop icon.
+ * preserving, nearest-neighbour).  Decodes BMP (24/32-bpp uncompressed) and GIF
+ * (87a/89a first frame, LZW, interlace); PNG/JPEG land next.  Reuses the shared
+ * gui_browser file dialog (like mxedit) so it's usable straight from its icon.
  */
 #include "syscall.h"
 #include "gui_gfx.h"
@@ -24,7 +24,7 @@
 static gfx_u32 *img_px;          /* decoded pixels (mmap, IMG_MAXW*IMG_MAXH) */
 static unsigned char *fbuf;            /* file read buffer (mmap, FILE_CAP)        */
 static int img_w, img_h;         /* current image size (0 = none)           */
-static char msg[96] = "Open an image (BMP).";
+static char msg[96] = "Open an image (BMP/GIF).";
 
 static void scpy(char *d,const char *s,int max){int i=0;while(s[i]&&i<max-1){d[i]=s[i];i++;}d[i]=0;}
 static unsigned rd32(const unsigned char *p){ return p[0]|(p[1]<<8)|(p[2]<<16)|((unsigned)p[3]<<24); }
@@ -59,6 +59,87 @@ static int decode_bmp(unsigned n)
     return 0;
 }
 
+/* ---- GIF (87a/89a): first frame, LZW, global/local palette, interlace ---- */
+static unsigned short g_pfx[4096];
+static unsigned char  g_sfx[4096];
+static unsigned char  g_stk[4096];
+static unsigned char  g_pal[256][3];
+
+static const unsigned char *g_dp,*g_dend; static int g_dsub;     /* sub-block byte source */
+static int gbyte(void){
+    if(g_dsub==0){ if(g_dp>=g_dend) return -1; g_dsub=*g_dp++; if(g_dsub==0) return -1; }
+    if(g_dp>=g_dend) return -1;
+    g_dsub--; return *g_dp++;
+}
+static unsigned g_acc; static int g_nb;
+static int gcode(int w){
+    while(g_nb<w){ int b=gbyte(); if(b<0) return -1; g_acc|=((unsigned)b)<<g_nb; g_nb+=8; }
+    int c=(int)(g_acc&((1u<<w)-1)); g_acc>>=w; g_nb-=w; return c;
+}
+
+static int decode_gif(unsigned n)
+{
+    if(n<13 || fbuf[0]!='G'||fbuf[1]!='I'||fbuf[2]!='F'){ scpy(msg,"not a GIF file",sizeof msg); return -1; }
+    int sw=rd16(fbuf+6), sh=rd16(fbuf+8);
+    unsigned char packed=fbuf[10];
+    unsigned p=13;
+    int gct = packed&0x80, gctsz = 2<<(packed&7);
+    if(gct){ for(int i=0;i<gctsz && p+3<=n;i++){ g_pal[i][0]=fbuf[p];g_pal[i][1]=fbuf[p+1];g_pal[i][2]=fbuf[p+2];p+=3; } }
+    (void)sw;(void)sh;
+    /* walk blocks to the first image descriptor (skip extensions). */
+    while(p<n){
+        unsigned char b=fbuf[p++];
+        if(b==0x3B) break;                       /* trailer, no image */
+        if(b==0x21){ p++; while(p<n){ int len=fbuf[p++]; if(!len)break; p+=len; } continue; } /* extension */
+        if(b!=0x2C) continue;                    /* unknown */
+        if(p+9>n){ scpy(msg,"truncated GIF",sizeof msg); return -1; }
+        int iw=rd16(fbuf+p+4), ih=rd16(fbuf+p+6);
+        unsigned char ip=fbuf[p+8]; p+=9;
+        int interlace = ip&0x40;
+        if(ip&0x80){ int lsz=2<<(ip&7); for(int i=0;i<lsz && p+3<=n;i++){ g_pal[i][0]=fbuf[p];g_pal[i][1]=fbuf[p+1];g_pal[i][2]=fbuf[p+2];p+=3; } }
+        if(iw<1||ih<1||iw>IMG_MAXW||ih>IMG_MAXH){ scpy(msg,"image too large",sizeof msg); return -1; }
+        if(p>=n){ scpy(msg,"truncated GIF",sizeof msg); return -1; }
+        int mincode=fbuf[p++];
+        if(mincode<1||mincode>8){ scpy(msg,"bad GIF LZW",sizeof msg); return -1; }
+        g_dp=fbuf+p; g_dend=fbuf+n; g_dsub=0; g_acc=0; g_nb=0;
+        int clear=1<<mincode, end=clear+1, csz=mincode+1, avail=end+1, oldc=-1;
+        unsigned char first=0;
+        int starts[4]={0,4,2,1}, steps[4]={8,8,4,2}, npass=interlace?4:1;
+        int pass=0, gx=0, gy=interlace?0:0;
+        for(;;){
+            int code=gcode(csz);
+            if(code<0||code==end) break;
+            if(code==clear){ csz=mincode+1; avail=end+1; oldc=-1; continue; }
+            int sp=0, c;
+            if(oldc<0){ first=(unsigned char)code; c=code; }
+            else { if(code<avail) c=code; else { g_stk[sp++]=first; c=oldc; } }
+            while(c>=clear){ if(sp>=4096)break; g_stk[sp++]=g_sfx[c]; c=g_pfx[c]; }
+            first=(unsigned char)c; g_stk[sp++]=(unsigned char)c;
+            while(sp>0){
+                unsigned char idx=g_stk[--sp];
+                if(gy<ih){ img_px[(unsigned)gy*iw+gx]=RGB(g_pal[idx][0],g_pal[idx][1],g_pal[idx][2]); }
+                if(++gx>=iw){ gx=0; gy+=steps[pass];
+                    while(gy>=ih && pass+1<npass){ pass++; gy=starts[pass]; } }
+            }
+            if(oldc>=0 && avail<4096){ g_pfx[avail]=(unsigned short)oldc; g_sfx[avail]=first; avail++;
+                if(avail==(1<<csz) && csz<12) csz++; }
+            oldc=code;
+        }
+        img_w=iw; img_h=ih;
+        return 0;
+    }
+    scpy(msg,"no image in GIF",sizeof msg);
+    return -1;
+}
+
+static int decode_image(unsigned n)
+{
+    if(n>=2 && fbuf[0]=='B'&&fbuf[1]=='M') return decode_bmp(n);
+    if(n>=3 && fbuf[0]=='G'&&fbuf[1]=='I'&&fbuf[2]=='F') return decode_gif(n);
+    scpy(msg,"unsupported format (BMP/GIF)",sizeof msg);
+    return -1;
+}
+
 static void load_image(const char *path)
 {
     img_w = img_h = 0;
@@ -74,7 +155,7 @@ static void load_image(const char *path)
         got += (unsigned)r;
     }
     sys_close(fd);
-    if (decode_bmp(got) == 0) {
+    if (decode_image(got) == 0) {
         /* path basename into msg */
         const char *b = path; for (const char *p=path; *p; p++) if (*p=='/') b=p+1;
         scpy(msg, b, sizeof msg);
@@ -141,7 +222,7 @@ int main(int argc, char **argv)
             dim[o]=0;
             gfx_str(s, s->w-gfx_text_w(dim)-6, s->h-12, dim, COL_TEXT);
         } else {
-            const char *h="No image. Click Open to choose a BMP file.";
+            const char *h="No image. Click Open to choose a BMP or GIF file.";
             gfx_str(s,(s->w-gfx_text_w(h))/2, s->h/2, h, (msg[0]&&msg[slen(msg)-1]!='.')?COL_ERR:COL_TEXT);
         }
         mx_present(&c);

--- a/src/userspace/mxinstall.c
+++ b/src/userspace/mxinstall.c
@@ -1,0 +1,240 @@
+/*
+ * mxinstall.elf -- graphical OS installer, as a makx client.
+ *
+ * The GUI peer of the text-mode (TUI) installer: a step-by-step wizard that
+ * collects the target drive, filesystem, hostname and accounts, then drives the
+ * kernel's shared headless install engine (SYS_INSTALL_EXEC) one file at a time.
+ * Because the copy is *stepped* -- one install_exec_step() per frame -- the
+ * window repaints a live progress bar and the desktop/compositor keep running
+ * between files, so the install never freezes the GUI the way a single blocking
+ * install syscall would.
+ *
+ * The TUI installer (installer_run, run from a shell) and this client share the
+ * exact same execution engine and install_params_t; only the front-end differs.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "gui_ui.h"
+#include "makx.h"
+#include <makar_abi.h>   /* install_params_t / _progress_t / _drive_t (shared ABI) */
+
+#define RGB GFX_RGB
+#define COL_BG     RGB(0x12,0x16,0x1e)
+#define COL_PANEL  RGB(0x1b,0x22,0x2e)
+#define COL_TITLE  RGB(0x40,0xc0,0xff)
+#define COL_TEXT   RGB(0xe6,0xea,0xf0)
+#define COL_MUTED  RGB(0x90,0xa0,0xb5)
+#define COL_WARN   RGB(0xff,0x70,0x70)
+#define COL_OK     RGB(0x60,0xff,0x80)
+#define COL_BAR    RGB(0x4c,0x8d,0xff)
+
+static void scpy(char *d,const char *s,int max){ int i=0; while(s[i]&&i<max-1){d[i]=s[i];i++;} d[i]=0; }
+/* unsigned -> decimal, appended at *o in buf */
+static void udec(char *buf,int *o,unsigned v){
+    char t[12]; int n=0; if(!v){buf[(*o)++]='0';return;}
+    while(v){t[n++]=(char)('0'+v%10);v/=10;}
+    while(n) buf[(*o)++]=t[--n];
+}
+
+enum { ST_WELCOME=0, ST_DRIVE, ST_FS, ST_HOST, ST_ACCT, ST_CONFIRM, ST_RUN, ST_DONE, ST_FAIL };
+enum { PH_PREP=0, PH_COPY, PH_FIN, PH_DONE, PH_FAIL };
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if (mx_connect(&c, argc, argv, 580, 460, MX_F_RESIZABLE) != 0) return 1;
+
+    ui_ctx u; for (unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
+
+    install_params_t  p;
+    for (unsigned i=0;i<sizeof p;i++) ((unsigned char*)&p)[i]=0;
+    p.fs = INSTALL_FS_EXT2; p.install_docs = 1; p.install_src = 1;
+    scpy(p.hostname, "makar", sizeof p.hostname);
+
+    install_drive_t drv[INSTALL_MAX_DRIVES];
+    char drvlbl[INSTALL_MAX_DRIVES][64];
+    const char *drvptr[INSTALL_MAX_DRIVES];
+    int ndrv = sys_install_exec(3, drv);
+    if (ndrv < 0) ndrv = 0;
+    for (int i=0;i<ndrv;i++){
+        int o=0; drvlbl[i][o++]='h'; drvlbl[i][o++]='d'; drvlbl[i][o++]=(char)('a'+i);
+        drvlbl[i][o++]=' '; drvlbl[i][o++]='(';
+        udec(drvlbl[i],&o,drv[i].size_mib);
+        const char *mib=" MiB)  "; for(int k=0;mib[k];k++) drvlbl[i][o++]=mib[k];
+        for(const char *m=drv[i].model; *m && o<62; m++) drvlbl[i][o++]=*m;
+        drvlbl[i][o]=0; drvptr[i]=drvlbl[i];
+    }
+    int drv_sel=0, drv_scroll=0;
+    if (ndrv>0) p.drive = drv[0].index;
+
+    int step = ST_WELCOME, phase = PH_PREP, exec_rc = 0;
+    install_progress_t prog; prog.done=0; prog.files=0; prog.current[0]=0;
+    unsigned done_at = 0;
+    int autologin_on = 0;
+    int shown_step = -1;   /* drives auto-focus of the first field per step */
+
+    while (!c.closed) {
+        mx_pump(&c);
+        int key = mx_key(&c);
+
+        gfx_surface *s = &c.surf;
+        int W = s->w, H = s->h;
+        gfx_fill(s, 0, 0, W, H, COL_BG);
+        gfx_fill(s, 0, 0, W, 30, COL_PANEL);
+        gfx_str(s, 14, 11, "Install Makar OS", COL_TITLE);
+
+        ui_begin(&u, c.mx, c.my, c.mdown, c.mpressed, c.mreleased, key);
+        /* Immediate-mode focus is set by clicking a widget, so without this the
+         * focus stays on whatever "Next" button got us here and typing goes
+         * nowhere.  On entering a step, focus its first input (always widget id
+         * 1 here -- listbox / textbox / first password).  Tab cycles fields. */
+        if (step != shown_step) { u.focus = 1; shown_step = step; }
+        if (key == '\t') { u.focus = u.focus + 1; if (u.focus > 3) u.focus = 1; }
+        int by = H - 38, bnext = W - 104, bback = 14;
+        int x = 20, y = 46;
+
+        if (step == ST_WELCOME) {
+            gfx_str(s, x, y,    "This wizard installs Makar OS to a hard disk.", COL_TEXT);
+            gfx_str(s, x, y+20, "The target disk will be ERASED.", COL_WARN);
+            gfx_str(s, x, y+48, "34 MiB FAT32 boot partition + a data partition", COL_MUTED);
+            gfx_str(s, x, y+64, "(ext2 or FAT32) holding /apps, /docs, /src, /usr.", COL_MUTED);
+            if (ndrv == 0)
+                gfx_str(s, x, y+96, "No ATA target drive found - cannot install.", COL_WARN);
+            if (ndrv > 0 && ui_button(&u,s,bnext,by,90,26,"Next >")) step = ST_DRIVE;
+        }
+        else if (step == ST_DRIVE) {
+            gfx_str(s, x, y, "Select the target drive:", COL_TEXT);
+            ui_listbox(&u, s, x, y+22, W-40, 120, drvptr, ndrv, &drv_sel, &drv_scroll);
+            gfx_str(s, x, y+150, "WARNING: all data on the chosen drive is erased.", COL_WARN);
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_WELCOME;
+            if (ui_button(&u,s,bnext,by,90,26,"Next >")) {
+                if (ndrv>0) p.drive = drv[drv_sel].index;
+                step = ST_FS;
+            }
+        }
+        else if (step == ST_FS) {
+            gfx_str(s, x, y, "Data filesystem:", COL_TEXT);
+            if (ui_button(&u,s,x,     y+22,150,26, p.fs==INSTALL_FS_EXT2 ? "[*] ext2" : "[ ] ext2"))
+                p.fs = INSTALL_FS_EXT2;
+            if (ui_button(&u,s,x+160, y+22,150,26, p.fs==INSTALL_FS_FAT32? "[*] FAT32": "[ ] FAT32"))
+                p.fs = INSTALL_FS_FAT32;
+            gfx_str(s, x, y+66, "Optional components:", COL_TEXT);
+            if (ui_button(&u,s,x,     y+88,150,26, p.install_docs ? "[x] docs" : "[ ] docs"))
+                p.install_docs = !p.install_docs;
+            if (ui_button(&u,s,x+160, y+88,150,26, p.install_src  ? "[x] src"  : "[ ] src"))
+                p.install_src = !p.install_src;
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_DRIVE;
+            if (ui_button(&u,s,bnext,by,90,26,"Next >")) step = ST_HOST;
+        }
+        else if (step == ST_HOST) {
+            gfx_str(s, x, y, "Hostname:", COL_TEXT);
+            ui_textbox(&u, s, x, y+22, 260, 26, p.hostname, sizeof p.hostname);
+            gfx_str(s, x, y+58, "Letters, digits and hyphens.", COL_MUTED);
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_FS;
+            if (ui_button(&u,s,bnext,by,90,26,"Next >")) step = ST_ACCT;
+        }
+        else if (step == ST_ACCT) {
+            gfx_str(s, x, y,    "Root password:", COL_TEXT);
+            ui_password(&u, s, x+150, y, 200, 24, p.root_pw, sizeof p.root_pw);
+            gfx_str(s, x, y+34, "New user (optional):", COL_TEXT);
+            ui_textbox(&u, s, x+150, y+34, 200, 24, p.user_name, sizeof p.user_name);
+            gfx_str(s, x, y+68, "User password:", COL_TEXT);
+            ui_password(&u, s, x+150, y+68, 200, 24, p.user_pw, sizeof p.user_pw);
+            if (ui_button(&u,s,x,y+104,210,26, autologin_on ? "[x] auto-login on boot" : "[ ] auto-login on boot"))
+                autologin_on = !autologin_on;
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_HOST;
+            if (ui_button(&u,s,bnext,by,90,26,"Next >")) {
+                /* Prefer the new user for auto-login, else root. */
+                p.autologin[0]=0;
+                if (autologin_on) {
+                    if (p.user_name[0] && p.user_pw[0]) scpy(p.autologin, p.user_name, sizeof p.autologin);
+                    else if (p.root_pw[0])              scpy(p.autologin, "root", sizeof p.autologin);
+                }
+                step = ST_CONFIRM;
+            }
+        }
+        else if (step == ST_CONFIRM) {
+            char line[96]; int o;
+            gfx_str(s, x, y, "Ready to install:", COL_TEXT);
+            o=0; { const char *t="  Target : "; for(int k=0;t[k];k++) line[o++]=t[k]; }
+            { const char *m = (ndrv>0)? drvlbl[drv_sel] : "(none)"; for(int k=0;m[k]&&o<94;k++) line[o++]=m[k]; }
+            line[o]=0; gfx_str(s, x, y+24, line, COL_MUTED);
+            o=0; { const char *t="  Filesys: "; for(int k=0;t[k];k++) line[o++]=t[k]; }
+            { const char *m = p.fs==INSTALL_FS_FAT32?"FAT32":"ext2"; for(int k=0;m[k];k++) line[o++]=m[k]; }
+            line[o]=0; gfx_str(s, x, y+40, line, COL_MUTED);
+            o=0; { const char *t="  Host   : "; for(int k=0;t[k];k++) line[o++]=t[k]; }
+            { const char *m=p.hostname; for(int k=0;m[k]&&o<94;k++) line[o++]=m[k]; }
+            line[o]=0; gfx_str(s, x, y+56, line, COL_MUTED);
+            gfx_str(s, x, y+88, "This ERASES the target drive. This cannot be undone.", COL_WARN);
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_CONFIRM, step = ST_ACCT;
+            if (ui_button(&u,s,bnext-40,by,140,26,"Erase & Install")) { step = ST_RUN; phase = PH_PREP; }
+        }
+        else if (step == ST_RUN) {
+            /* Draw the current status, present it, THEN do one unit of work --
+             * so the "Preparing..." / current-file label is on screen during
+             * the (brief) blocking begin/finish and during each file copy. */
+            gfx_str(s, x, y, "Installing - please do not power off.", COL_TEXT);
+            const char *pl = phase==PH_PREP ? "Preparing disk (partition + format)..."
+                           : phase==PH_COPY ? "Copying files..."
+                           : phase==PH_FIN  ? "Finishing..." : "";
+            gfx_str(s, x, y+28, pl, COL_MUTED);
+            /* progress: "<files>/<total> (P%)  <current>" + a real % bar. */
+            if (phase==PH_COPY) {
+                unsigned pct = prog.total ? (prog.files * 100u) / prog.total : 0u;
+                char line[96]; int o=0;
+                line[o++]=' '; line[o++]=' ';
+                udec(line,&o,prog.files); line[o++]='/'; udec(line,&o,prog.total);
+                line[o++]=' '; line[o++]='(';
+                udec(line,&o,pct); line[o++]='%'; line[o++]=')'; line[o++]=' '; line[o++]=' ';
+                for(const char *q=prog.current; *q && o<94; q++) line[o++]=*q;
+                line[o]=0; gfx_str(s, x, y+50, line, COL_TEXT);
+                int bw=W-40, bx=x, byb=y+76;
+                gfx_fill(s,bx,byb,bw,14,COL_PANEL);
+                int fillw = (int)((unsigned)(bw-2) * pct / 100u);
+                gfx_fill(s,bx+1,byb+1,fillw,12,COL_BAR);
+            }
+            mx_present(&c);
+
+            if (phase==PH_PREP) {
+                exec_rc = sys_install_exec(0, &p);
+                phase = (exec_rc < 0) ? PH_FAIL : PH_COPY;
+                if (phase==PH_FAIL) step = ST_FAIL;
+            } else if (phase==PH_COPY) {
+                int r = sys_install_exec(1, &prog);
+                if (r < 0) { exec_rc = r; phase = PH_FAIL; step = ST_FAIL; }
+                else if (prog.done) phase = PH_FIN;
+            } else if (phase==PH_FIN) {
+                sys_install_exec(2, &p);
+                phase = PH_DONE; step = ST_DONE; done_at = sys_uptime();
+            }
+            sys_yield();
+            continue;   /* already presented this frame */
+        }
+        else if (step == ST_DONE) {
+            (void)done_at;
+            gfx_str(s, x, y,    "Installation complete!", COL_OK);
+            gfx_str(s, x, y+24, "Remove the install media before rebooting.", COL_TEXT);
+            gfx_str(s, x, y+44, "You can keep using the live session, or reboot", COL_MUTED);
+            gfx_str(s, x, y+58, "into your newly installed system.", COL_MUTED);
+            /* No auto-reboot: let the operator decide (Ubuntu-style) -- and on a
+             * live CD keep the session up so they can see it finished. */
+            if (ui_button(&u,s,bback,by,150,26,"Continue (live)")) break;
+            if (ui_button(&u,s,bnext-20,by,120,26,"Reboot now"))    sys_reboot();
+        }
+        else if (step == ST_FAIL) {
+            char line[64]; int o=0;
+            const char *t="Installation failed (rc="; for(int k=0;t[k];k++) line[o++]=t[k];
+            if (exec_rc<0){ line[o++]='-'; udec(line,&o,(unsigned)(-exec_rc)); }
+            else udec(line,&o,(unsigned)exec_rc);
+            line[o++]=')'; line[o]=0;
+            gfx_str(s, x, y, line, COL_WARN);
+            gfx_str(s, x, y+24, "Nothing was finalised. See the serial log.", COL_MUTED);
+            if (ui_button(&u,s,bnext,by,90,26,"Quit")) break;
+        }
+
+        mx_present(&c);
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mxnet.c
+++ b/src/userspace/mxnet.c
@@ -1,0 +1,72 @@
+/*
+ * mxnet.elf -- network status, as a makx client.  Shows the eth0 / DHCP / DNS
+ * state from SYS_NET_INFO and offers Renew / Release / Flush-DNS buttons
+ * (SYS_NET_CTL) -- the GUI peer of the maknetcfg.elf shell tool.
+ */
+#include "syscall.h"
+#include "gui_gfx.h"
+#include "gui_ui.h"
+#include "makx.h"
+
+#define RGB GFX_RGB
+#define COL_BG   RGB(0x12,0x16,0x1e)
+#define COL_TEXT RGB(0xd3,0xd7,0xcf)
+#define COL_HDR  RGB(0x8a,0xe2,0x34)
+
+static char info[512];
+
+static void refresh(void)
+{
+    int n = sys_net_info(info, (unsigned)sizeof info - 1);
+    if (n < 0) n = 0;
+    info[n] = '\0';
+    if (!info[0]) {
+        const char *m = "(no network info)";
+        int i=0; for(; m[i]; i++) info[i]=m[i]; info[i]=0;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    mx_conn c;
+    if (mx_connect(&c, argc, argv, 460, 320, MX_F_RESIZABLE) != 0) return 1;
+    ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++)((int*)&u)[i]=0;
+    refresh();
+    int first=1, lmx=-1, lmy=-1;
+
+    while (!c.closed) {
+        mx_pump(&c);
+        while (mx_key(&c) >= 0) { /* no keyboard actions */ }
+
+        int moved=(c.mx!=lmx||c.my!=lmy); lmx=c.mx; lmy=c.my;
+        if(!(first||c.mpressed||c.mreleased||moved||c.resized)){ sys_yield(); continue; }
+        first=0;
+
+        gfx_surface *s=&c.surf;
+        gfx_fill(s,0,0,s->w,s->h,COL_BG);
+
+        ui_begin(&u,c.mx,c.my,c.mdown,c.mpressed,c.mreleased,-1);
+        int bx=8;
+        if(ui_button(&u,s,bx,8,84,22,"Refresh")) refresh();
+        bx+=90;
+        if(ui_button(&u,s,bx,8,84,22,"Renew"))   { sys_net_ctl(NET_CTL_DHCP_RENEW);   refresh(); }
+        bx+=90;
+        if(ui_button(&u,s,bx,8,84,22,"Release")) { sys_net_ctl(NET_CTL_DHCP_RELEASE); refresh(); }
+        bx+=90;
+        if(ui_button(&u,s,bx,8,96,22,"Flush DNS")){ sys_net_ctl(NET_CTL_DNS_FLUSH);    refresh(); }
+
+        /* Render the info text line by line. */
+        int x=10, y=42;
+        gfx_str(s,x,y,"Network:",COL_HDR); y+=14;
+        for(const char *p=info; *p; ){
+            char line[96]; int i=0;
+            while(*p && *p!='\n' && i<(int)sizeof line-1) line[i++]=*p++;
+            line[i]=0; if(*p=='\n') p++;
+            if(y < s->h-10){ gfx_str_clip(s,x,y,line,COL_TEXT,s->w-10); y+=12; }
+        }
+        mx_present(&c);
+        sys_yield();
+    }
+    mx_close(&c);
+    return 0;
+}

--- a/src/userspace/mxterm.c
+++ b/src/userspace/mxterm.c
@@ -26,6 +26,9 @@ static const gfx_u32 PAL[16] = {
 
 static vt_term vt;
 static int term_pid=-1, term_in=-1, term_out=-1;
+/* If non-NULL (e.g. the desktop Install icon passes "install"), run this as a
+ * one-shot command via `sh.elf -c <cmd>` instead of an interactive login shell.*/
+static const char *g_runcmd = 0;
 
 static void feed(const char *s){ while(*s) vt_putc(&vt,(unsigned char)*s++); }
 
@@ -39,6 +42,11 @@ static void term_spawn(void){
         sys_close(ip[1]);sys_close(op[0]);
         sys_dup2(ip[0],0);sys_dup2(op[1],1);sys_dup2(op[1],2);
         sys_close(ip[0]);sys_close(op[1]);
+        if(g_runcmd){
+            char *av[4]={"sh.elf","-c",(char*)g_runcmd,0};
+            sys_execve("/apps/sh.elf",av,(char*const*)0);
+            sys_exit(127);
+        }
         char user[48],uarg[64];char*av[3]={"sh.elf",0,0};
         if(sys_whoami(user,sizeof user)>0){scpy(uarg,"--user=",sizeof uarg);scat(uarg,user);av[1]=uarg;}
         sys_execve("/apps/sh.elf",av,(char*const*)0);
@@ -88,9 +96,18 @@ static void term_draw(gfx_surface *s, int focused){
         gfx_fill(s,4+vt.cx*8,4+vt.cy*8,8,8,RGB(0x8a,0xe2,0x34));
 }
 
+static int streq(const char *a,const char *b){ while(*a&&*a==*b){a++;b++;} return *a==*b; }
+
 int main(int argc,char**argv){
     mx_conn c;
     if(mx_connect(&c,argc,argv,640,400,MX_F_RESIZABLE)!=0) return 1;
+    /* Optional one-shot command: the first non-flag arg after `-makx <pid>`
+     * (e.g. the Install icon passes "install"). */
+    for(int i=1;i<argc;i++){
+        if(streq(argv[i],"-makx")){ i++; continue; }
+        if(argv[i][0]=='-') continue;
+        g_runcmd=argv[i]; break;
+    }
     { int cols=(c.surf.w-8)/8, rows=(c.surf.h-8)/8; vt_init(&vt,cols,rows); }
     term_spawn();
     int first=1;

--- a/src/userspace/syscall.h
+++ b/src/userspace/syscall.h
@@ -666,6 +666,13 @@ static inline int sys_install(void)
 {
     return (int)syscall1(SYS_INSTALL, 0);
 }
+/* Stepped headless installer for the GUI front-end.  cmd: 0 begin / 1 step /
+ * 2 finish; ptr -> install_params_t (begin/finish) or install_progress_t (step).
+ * See <kernel/installer.h> for the structs. */
+static inline int sys_install_exec(int cmd, void *ptr)
+{
+    return (int)syscall2(SYS_INSTALL_EXEC, (long)cmd, (long)ptr);
+}
 static inline int sys_mount(const char *dev, const char *mnt)
 {
     return (int)syscall2(SYS_MOUNT, (long)dev, (long)mnt);

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -165,10 +165,11 @@ static void win_free(int i)
 /* Each icon names a client *.elf and the default outer window geometry.  The
  * program path is launcher data -- the server bakes in no application. */
 typedef struct { int x,y,w,h; const char *label; gfx_u32 tint; const char *cmd; int winw, winh; } icon_t;
-#define ICON_N 6
+#define ICON_N 7
 /* winw/winh are sized so each client's fixed surface (mxterm 640x400, mxfiles
- * 560x380, mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430) fits
- * the window's client rect 1:1 (client_w = winw-2, client_h = winh-TH-1). */
+ * 560x380, mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430,
+ * mxclock 360x200) fits the window's client rect 1:1 (client_w = winw-2,
+ * client_h = winh-TH-1). */
 static icon_t icons[ICON_N] = {
     { 24,  40, 96,70, "Terminal", RGB(0x4c,0x8d,0xff), "/apps/mxterm.elf",  648,424 },
     { 24, 124, 96,70, "Files",    RGB(0xf0,0xa8,0x30), "/apps/mxfiles.elf", 568,404 },
@@ -176,6 +177,7 @@ static icon_t icons[ICON_N] = {
     { 24, 292, 96,70, "Tasks",    RGB(0x9b,0x6c,0xff), "/apps/mxtasks.elf", 568,384 },
     { 24, 376, 96,70, "Doom",     RGB(0xc0,0x40,0x40), "/apps/doom.elf",    648,424 },
     { 24, 460, 96,70, "About",    RGB(0x35,0x6a,0xa8), "/apps/mxabout.elf", 568,454 },
+    { 24, 544, 96,70, "Clock",    RGB(0x40,0xc0,0xb0), "/apps/mxclock.elf", 384,232 },
 };
 
 /* Fork+exec a client, handing it `-makx <server-pid>` and a stdout/stderr pipe

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -164,8 +164,8 @@ static void win_free(int i)
 /* ===================== desktop icons (client launchers) ================== */
 /* Each icon names a client *.elf and the default outer window geometry.  The
  * program path is launcher data -- the server bakes in no application. */
-typedef struct { int x,y,w,h; const char *label; gfx_u32 tint; const char *cmd; int winw, winh; } icon_t;
-#define ICON_N 8
+typedef struct { int x,y,w,h; const char *label; gfx_u32 tint; const char *cmd; int winw, winh; const char *arg; } icon_t;
+#define ICON_N 11
 /* Two-column desktop icon grid (col x = 24 / 128, rows step 84).  winw/winh are
  * sized so each client's fixed surface (mxterm 640x400, mxfiles 560x380,
  * mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430, mxclock
@@ -180,6 +180,11 @@ static icon_t icons[ICON_N] = {
     { 128, 208, 96,70, "About",    RGB(0x35,0x6a,0xa8), "/apps/mxabout.elf", 568,454 },
     {  24, 292, 96,70, "Clock",    RGB(0x40,0xc0,0xb0), "/apps/mxclock.elf", 384,232 },
     { 128, 292, 96,70, "Calc",     RGB(0xe0,0x80,0x40), "/apps/mxcalc.elf",  264,324 },
+    {  24, 376, 96,70, "Net",      RGB(0x4c,0xb0,0xff), "/apps/mxnet.elf",   468,344 },
+    { 128, 376, 96,70, "Disk",     RGB(0xc0,0xa0,0x40), "/apps/mxdisk.elf",  528,384 },
+    /* Install: run the in-OS installer inside a terminal window (Phase-11 ANSI
+     * bridge renders its TUI).  arg "install" -> mxterm runs `sh.elf -c install`. */
+    {  24, 460, 96,70, "Install",  RGB(0xff,0x70,0x70), "/apps/mxterm.elf",  648,424, "install" },
 };
 
 /* Fork+exec a client, handing it `-makx <server-pid>` and a stdout/stderr pipe
@@ -209,7 +214,8 @@ static void launch_icon(int ii)
         sys_dup2(op[1],0); sys_dup2(op[1],1); sys_dup2(op[1],2);
         sys_close(op[1]);
         char pids[12]; u2s((unsigned)server_pid, pids);
-        char *av[4]={ (char*)icons[ii].cmd, "-makx", pids, 0 };
+        char *av[5]={ (char*)icons[ii].cmd, "-makx", pids, 0, 0 };
+        if (icons[ii].arg) av[3]=(char*)icons[ii].arg;   /* e.g. Install -> "install" */
         sys_execve(icons[ii].cmd, av, (char *const*)0);
         sys_exit(127);
     }

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -165,19 +165,21 @@ static void win_free(int i)
 /* Each icon names a client *.elf and the default outer window geometry.  The
  * program path is launcher data -- the server bakes in no application. */
 typedef struct { int x,y,w,h; const char *label; gfx_u32 tint; const char *cmd; int winw, winh; } icon_t;
-#define ICON_N 7
-/* winw/winh are sized so each client's fixed surface (mxterm 640x400, mxfiles
- * 560x380, mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430,
- * mxclock 360x200) fits the window's client rect 1:1 (client_w = winw-2,
- * client_h = winh-TH-1). */
+#define ICON_N 8
+/* Two-column desktop icon grid (col x = 24 / 128, rows step 84).  winw/winh are
+ * sized so each client's fixed surface (mxterm 640x400, mxfiles 560x380,
+ * mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430, mxclock
+ * 360x200, mxcalc 240x300) fits the window's client rect 1:1 (client_w =
+ * winw-2, client_h = winh-TH-1). */
 static icon_t icons[ICON_N] = {
-    { 24,  40, 96,70, "Terminal", RGB(0x4c,0x8d,0xff), "/apps/mxterm.elf",  648,424 },
-    { 24, 124, 96,70, "Files",    RGB(0xf0,0xa8,0x30), "/apps/mxfiles.elf", 568,404 },
-    { 24, 208, 96,70, "Editor",   RGB(0x35,0xc7,0x59), "/apps/mxedit.elf",  628,444 },
-    { 24, 292, 96,70, "Tasks",    RGB(0x9b,0x6c,0xff), "/apps/mxtasks.elf", 568,384 },
-    { 24, 376, 96,70, "Doom",     RGB(0xc0,0x40,0x40), "/apps/doom.elf",    648,424 },
-    { 24, 460, 96,70, "About",    RGB(0x35,0x6a,0xa8), "/apps/mxabout.elf", 568,454 },
-    { 24, 544, 96,70, "Clock",    RGB(0x40,0xc0,0xb0), "/apps/mxclock.elf", 384,232 },
+    {  24,  40, 96,70, "Terminal", RGB(0x4c,0x8d,0xff), "/apps/mxterm.elf",  648,424 },
+    { 128,  40, 96,70, "Files",    RGB(0xf0,0xa8,0x30), "/apps/mxfiles.elf", 568,404 },
+    {  24, 124, 96,70, "Editor",   RGB(0x35,0xc7,0x59), "/apps/mxedit.elf",  628,444 },
+    { 128, 124, 96,70, "Tasks",    RGB(0x9b,0x6c,0xff), "/apps/mxtasks.elf", 568,384 },
+    {  24, 208, 96,70, "Doom",     RGB(0xc0,0x40,0x40), "/apps/doom.elf",    648,424 },
+    { 128, 208, 96,70, "About",    RGB(0x35,0x6a,0xa8), "/apps/mxabout.elf", 568,454 },
+    {  24, 292, 96,70, "Clock",    RGB(0x40,0xc0,0xb0), "/apps/mxclock.elf", 384,232 },
+    { 128, 292, 96,70, "Calc",     RGB(0xe0,0x80,0x40), "/apps/mxcalc.elf",  264,324 },
 };
 
 /* Fork+exec a client, handing it `-makx <server-pid>` and a stdout/stderr pipe

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -182,9 +182,10 @@ static icon_t icons[ICON_N] = {
     { 128, 292, 96,70, "Calc",     RGB(0xe0,0x80,0x40), "/apps/mxcalc.elf",  264,324 },
     {  24, 376, 96,70, "Net",      RGB(0x4c,0xb0,0xff), "/apps/mxnet.elf",   468,344 },
     { 128, 376, 96,70, "Disk",     RGB(0xc0,0xa0,0x40), "/apps/mxdisk.elf",  528,384 },
-    /* Install: run the in-OS installer inside a terminal window (Phase-11 ANSI
-     * bridge renders its TUI).  arg "install" -> mxterm runs `sh.elf -c install`. */
-    {  24, 460, 96,70, "Install",  RGB(0xff,0x70,0x70), "/apps/mxterm.elf",  648,424, "install" },
+    /* Install: the graphical installer (mxinstall.elf).  It drives the kernel's
+     * stepped install engine one file per frame, so the desktop stays responsive
+     * during the copy (the TUI installer is for shell mode). */
+    {  24, 460, 96,70, "Install",  RGB(0xff,0x70,0x70), "/apps/mxinstall.elf", 588,492 },
     { 128, 460, 96,70, "Image",    RGB(0x70,0xb0,0x70), "/apps/mximg.elf",   608,468 },
 };
 
@@ -451,6 +452,46 @@ static void icon_glyph(int idx, int gx, int gy)
         gfx_round(&scr,gx+2,gy,28,26,RGB(0x35,0x6a,0xa8),bg);
         gfx_fill(&scr,gx+15,gy+5,3,3,0xFFFFFF);
         gfx_fill(&scr,gx+15,gy+10,3,11,0xFFFFFF);
+        break;
+    case 6: /* Clock: round face with hour/minute hands */
+        gfx_round(&scr,gx+2,gy,28,26,RGB(0x10,0x2a,0x26),bg);
+        gfx_outline(&scr,gx+2,gy,28,26,RGB(0x40,0xc0,0xb0));
+        gfx_fill(&scr,gx+15,gy+5,2,9,0xFFFFFF);          /* minute hand (up) */
+        gfx_fill(&scr,gx+16,gy+12,7,2,0xFFFFFF);         /* hour hand (right) */
+        gfx_fill(&scr,gx+15,gy+12,3,3,RGB(0x40,0xc0,0xb0)); /* hub */
+        break;
+    case 7: /* Calc: display over a 3x3 keypad */
+        gfx_round(&scr,gx+3,gy,26,26,RGB(0x20,0x24,0x2c),bg);
+        gfx_fill(&scr,gx+6,gy+3,20,6,RGB(0x8a,0xe2,0x34)); /* display */
+        for(int r=0;r<3;r++) for(int k=0;k<3;k++)
+            gfx_fill(&scr,gx+6+k*7,gy+12+r*5,5,3,RGB(0xe0,0x80,0x40));
+        break;
+    case 8: /* Net: ascending signal bars */
+        gfx_round(&scr,gx,gy,32,26,RGB(0x10,0x20,0x38),bg);
+        gfx_fill(&scr,gx+6, gy+15,5,7, RGB(0x4c,0xb0,0xff));
+        gfx_fill(&scr,gx+14,gy+10,5,12,RGB(0x4c,0xb0,0xff));
+        gfx_fill(&scr,gx+22,gy+5, 5,17,RGB(0x4c,0xb0,0xff));
+        break;
+    case 9: /* Disk: drive body with platter + spindle */
+        gfx_round(&scr,gx,gy,32,26,RGB(0x20,0x1c,0x10),bg);
+        gfx_outline(&scr,gx+4,gy+4,24,18,RGB(0xc0,0xa0,0x40));
+        gfx_round(&scr,gx+9,gy+7,10,10,RGB(0x80,0x6a,0x28),RGB(0x20,0x1c,0x10));
+        gfx_fill(&scr,gx+13,gy+11,3,3,RGB(0xc0,0xa0,0x40)); /* spindle */
+        gfx_fill(&scr,gx+22,gy+16,3,3,RGB(0xc0,0xa0,0x40)); /* corner screw */
+        break;
+    case 10: /* Install: download arrow into a tray */
+        gfx_round(&scr,gx,gy,32,26,RGB(0x30,0x16,0x16),bg);
+        gfx_fill(&scr,gx+14,gy+3, 4,9, RGB(0xff,0xc0,0xc0)); /* shaft */
+        gfx_fill(&scr,gx+10,gy+11,12,2,RGB(0xff,0xc0,0xc0)); /* arrowhead */
+        gfx_fill(&scr,gx+12,gy+13,8, 2,RGB(0xff,0xc0,0xc0));
+        gfx_fill(&scr,gx+14,gy+15,4, 2,RGB(0xff,0xc0,0xc0));
+        gfx_fill(&scr,gx+5, gy+20,22,3,RGB(0xff,0x70,0x70)); /* tray */
+        break;
+    case 11: /* Image: framed picture with sun and hill */
+        gfx_round(&scr,gx,gy,32,26,RGB(0x10,0x22,0x12),bg);
+        gfx_outline(&scr,gx+3,gy+2,26,22,RGB(0x70,0xb0,0x70));
+        gfx_fill(&scr,gx+8,gy+6,5,5,RGB(0xff,0xe0,0x60));    /* sun */
+        gfx_fill(&scr,gx+5,gy+15,22,7,RGB(0x40,0x90,0x50));  /* hill/ground */
         break;
     default:
         gfx_round(&scr,gx,gy,32,26,RGB(0x4c,0x8d,0xff),bg);

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -165,7 +165,7 @@ static void win_free(int i)
 /* Each icon names a client *.elf and the default outer window geometry.  The
  * program path is launcher data -- the server bakes in no application. */
 typedef struct { int x,y,w,h; const char *label; gfx_u32 tint; const char *cmd; int winw, winh; const char *arg; } icon_t;
-#define ICON_N 11
+#define ICON_N 12
 /* Two-column desktop icon grid (col x = 24 / 128, rows step 84).  winw/winh are
  * sized so each client's fixed surface (mxterm 640x400, mxfiles 560x380,
  * mxedit 620x420, mxtasks 560x360, doom 640x400, mxabout 560x430, mxclock
@@ -185,6 +185,7 @@ static icon_t icons[ICON_N] = {
     /* Install: run the in-OS installer inside a terminal window (Phase-11 ANSI
      * bridge renders its TUI).  arg "install" -> mxterm runs `sh.elf -c install`. */
     {  24, 460, 96,70, "Install",  RGB(0xff,0x70,0x70), "/apps/mxterm.elf",  648,424, "install" },
+    { 128, 460, 96,70, "Image",    RGB(0x70,0xb0,0x70), "/apps/mximg.elf",   608,468 },
 };
 
 /* Fork+exec a client, handing it `-makx <server-pid>` and a stdout/stderr pipe


### PR DESCRIPTION
## Summary

New **desktop GUI applications** plus an **image viewer**, all as makx clients
(server/client split unchanged). Rounds out the desktop with the everyday tools
that previously only existed as shell programs.

PR #4 of the split (see `CLAUDE.roadmap.md`). All gates green: `./run.sh ktest`
(875/0), `./run.sh iso test` (ALL GROUPS PASSED), `./run.sh guitest`
(`GUI: READY`).

## New makx clients

- **mxclock** — large digital time + date from `/proc/rtc` (scaled-glyph; GUI
  peer of `clock.elf`).
- **mxcalc** — button-grid calculator over the same integer expression evaluator
  as `calc.elf` (`+ - * / %`, parens, unary); mouse **or** keyboard.
- **mxnet** — eth0/DHCP/DNS status (`SYS_NET_INFO`) + Renew / Release /
  Flush-DNS (`SYS_NET_CTL`); GUI peer of `maknetcfg.elf`.
- **mxdisk** — read-only drives + partition table + FAT32 BPB (`SYS_DISK_INFO`);
  GUI peer of `diskinfo.elf` (partitioning stays in `cfdisk`/`fdisk`).
- **mximg** — image viewer: Open dialog (shared `gui_browser`) or a path arg,
  decode, aspect-fit via `gfx_blit_scaled`. Decodes **BMP** (24/32-bpp) and
  **GIF** (87a/89a first frame, LZW + interlace), hand-written, no libc; mmap
  file/pixel buffers. **PNG/JPEG are a follow-up** (will vendor `stb_image`).

## Desktop / WM

- Icons laid out in a **2-column grid** (was overflowing one column).
- **Install** icon: launches `mxterm` with a one-shot command
  (`mxterm.elf -makx <pid> install` → runs `sh.elf -c install`), so the in-OS
  installer's TUI renders in a terminal window via the cell-API→ANSI bridge.
- `mxterm` gains an optional one-shot command (first non-flag arg → `sh.elf -c
  <cmd>`); `icon_t` gains an `arg` field.

12 desktop icons: Terminal, Files, Editor, Tasks, Doom, About, Clock, Calc,
Net, Disk, Install, Image.

## Deferred to a follow-up PR (#4b)

- `mximg` **PNG + JPEG** (vendor `stb_image` + a tiny inflate; freestanding link
  work).
- **mxweb** — a web browser (HTTP over lwIP + a minimal HTML renderer).

## Testing notes

Each client builds clean and reaches `GUI: READY`; docs updated in
`docs/gui.md`. GUI interaction (clicking icons, the calculator keypad, the image
Open dialog) is manual — the headless gate verifies the desktop composes and all
clients link/launch. The RWX-LOAD-segment linker warning is the standard one all
freestanding `*.elf` get.
