### PR TITLE
Linux-ification groundwork: preemption-safe locking, demand-paged memory, raw-key GUI clients

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -111,10 +111,27 @@ the server with no name service.
 
 Client → server requests (sent with `sys_ipc_sendrec`):
 
-- `MX_HELLO(w,h)` → reply `(win, sid)`: create a window + a `w×h` surface.
+- `MX_HELLO(w,h,flags)` → reply `(win, sid)`: create a window + a `w×h` surface.
+  `flags` is a bitmask: `MX_F_RESIZABLE` (the client re-flows to fill the window;
+  the server blits 1:1 and sends `MXEV_RESIZE` instead of scaling) and
+  `MX_F_RAWKEYS` (see *Keyboard delivery* below).
 - `MX_PRESENT(win)` → reply = one input event: "I drew a frame, composite it."
 - `MX_POLL(win)` → reply = one input event (drain input without presenting).
 - `MX_BYE(win)` → ack; the client is exiting.
+
+### Keyboard delivery (cooked vs raw)
+
+By default `MXEV_KEY` carries a **cooked** byte (ASCII or a `KEY_*` sentinel) —
+key-down only, the right thing for terminals, editors and text fields. A game
+needs real key *up* events, so a client may set `MX_F_RAWKEYS` in its HELLO. While
+such a client holds focus the WM switches the kernel keyboard to
+scancode-passthrough (`sys_keyboard_raw(2)`) and forwards the raw set-1 make/break
+scancode stream as the `MXEV_KEY` value (`low7 | 0x80` = break); on focus loss,
+and around its own modal dialogs (login/power/passwd) and teardown, it restores
+cooked mode. This is how windowed **DOOM** shares the exact input path its
+fullscreen mode uses, with no synthesized releases. `Ctrl-Alt-Del` is detected
+ahead of the passthrough in the kernel, so it still raises the power menu (and the
+mash-twice hard reset) even while a raw-keys client is focused.
 
 Each reply carries **one** input event (`MXEV_KEY/MOUSE/FOCUS/CLOSE/NONE`) plus
 a "still pending" count in `data[MX_PENDING]`, so a client drains its input by

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -191,9 +191,19 @@ bit 3: RSVD  1 if a reserved-bit was set in a page-table entry
 bit 4: I/D   1 on an instruction fetch (PAE/long mode only)
 ```
 
-`debug/page_fault.c` decodes these and prints a panic screen. There is no
-page-fault *handler* yet — every fault is fatal. The eventual demand-paged
-allocator and CoW (§11) live here.
+The handler in `debug/debug.c` (`page_fault_handler`) resolves three cases
+before giving up, in order:
+
+1. **Demand paging** (`try_handle_anon_fault`) — a *not-present* fault inside the
+   faulting task's reserved heap `[user_brk_base, user_brk)` or anonymous-mmap
+   `[USER_MMAP_BASE, mmap_next)` window maps a fresh zeroed frame and retries.
+   `SYS_BRK`/`SYS_MMAP2` only reserve the range (Linux's lazy model), so a
+   multi-MiB allocation costs O(1) in the syscall and the per-page work is spread
+   across short faults instead of stalling the system in one interrupts-off loop.
+2. **Copy-on-write** (`try_handle_cow_fault`) — a *write* to a present RO+COW page
+   (fork) copies or re-promotes it (§11).
+3. Otherwise: a ring-3 fault delivers `SIGSEGV` (the offender is reaped); a ring-0
+   fault is a real kernel bug and panics.
 
 ---
 
@@ -212,6 +222,12 @@ gets its own page directory. Construction (`vmm_create_pd`):
    though we only ever populate two slots:
    - `USER_CODE_BASE = 0x40000000` (PDE 256) — one 4 KiB page for code.
    - `USER_STACK_TOP = 0xBFFF0000` (PDE 767) — `USER_STACK_PAGES = 8` pages (32 KiB) eagerly mapped at exec, occupying `[USER_STACK_TOP − 32 KiB, USER_STACK_TOP)`.  Was one 4 KiB page until TCC's recursive-descent parser overflowed it on sh.c.
+   - **Heap** (`brk`, grows up from the end of the image) and the **anonymous
+     mmap window** (`USER_MMAP_BASE = 0x90000000`, PDE 576) are *demand-paged*:
+     `SYS_BRK`/`SYS_MMAP2` only advance the reservation pointer, and the
+     page-fault handler maps zeroed frames on first touch (§4). This is what
+     keeps a big `malloc` (e.g. DOOM's 6 MiB zone) from mapping ~1500 pages in
+     one interrupts-off syscall.
 
 The mirror is a one-time snapshot, not a live shadow. If something maps a new
 kernel PDE *after* `vmm_create_pd` runs (e.g., the heap grows past 16 MiB), the
@@ -305,9 +321,21 @@ of `task_t` and `vesa_pane_t` and a few KiB of FAT32 buffers.
 
 ## 7. Tasking
 
-`src/kernel/arch/i386/proc/task.c`. Fixed-size pool of 8 `task_t` slots,
-round-robin scheduler, voluntary `task_yield()` *and* preemptive timer-driven
-yields (PIT 100 Hz, `SCHED_QUANTUM=4` ticks → 40 ms time slice).
+`src/kernel/arch/i386/proc/task.c`. Fixed-size pool of `MAX_TASKS` (32) `task_t`
+slots, round-robin scheduler, voluntary `task_yield()` *and* preemptive
+timer-driven yields (PIT `TIMER_HZ` = 250 Hz, `g_sched_quantum = 1` tick → 4 ms
+time slice).
+
+Ring-3 is preemptible (the timer yields between slices); **syscalls are still
+serialized** — the `int 0x80` gate clears IF and the handler keeps it clear, so
+a syscall runs to completion or yields voluntarily (§10). Long operations opt
+into preemption explicitly instead (`sti` inside the installer's stepped copy),
+and the worst eager stalls were removed structurally (demand-paged `brk`/`mmap`,
+§4). The shared mutable structures a future global `sti` would expose —
+`schedule()`, `task_exit`, the kernel heap, the task pool (`task_create`/
+`task_fork`) and the PMM buddy lists — are already `cli`-guarded so flipping it
+is gateable; the remaining prerequisite is an lwIP net lock plus fork/exec
+stress testing.
 
 ### `task_t` (abbreviated)
 

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -66,7 +66,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 40 | `SYS_RMDIR` | `path` | remove empty directory |
 | 41 | `SYS_DUP` | `oldfd` | duplicate to lowest free fd |
 | 42 | `SYS_PIPE` | `int pipefd[2]` | creates read/write fds |
-| 45 | `SYS_BRK` | `addr` | query/grow heap break |
+| 45 | `SYS_BRK` | `addr` | query/grow heap break (demand-paged) |
 | 48 | `SYS_SIGNAL` | `signo, handler` | simple signal handler install |
 | 54 | `SYS_IOCTL` | `fd, request, ...` | compatibility stub, returns `-ENOTTY` |
 | 55 | `SYS_FCNTL` | `fd, cmd, arg` | `F_GETFL`, `F_SETFL` |
@@ -81,7 +81,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 141 | `SYS_READDIR` | `path, index, dirent *` | indexed Makar syscall, libc wraps it |
 | 158 | `SYS_YIELD` | none | scheduler yield |
 | 175 | `SYS_RT_SIGPROCMASK` | Linux args | startup compatibility stub |
-| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anonymous only |
+| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anonymous only, demand-paged |
 | 240 | `SYS_FUTEX` | Linux args | single-threaded compatibility stub |
 | 243 | `SYS_SET_THREAD_AREA` | `user_desc *` | one-slot i386 TLS |
 | 252 | `SYS_EXIT_GROUP` | `status` | same as exit |
@@ -293,11 +293,20 @@ The scheduler restores TLS state for TLS-active tasks.
 - requires `MAP_ANONYMOUS`
 - rejects `MAP_FIXED`
 - ignores file descriptors and offsets
-- maps zero-filled pages
-- uses a per-task bump pointer
+- **demand-paged**: only reserves the range (advances a per-task bump pointer);
+  zero-filled frames are mapped on first touch by the page-fault handler, the
+  same lazy model Linux uses. A large mapping therefore costs O(1) in the call
+  rather than mapping every page up front.
 - returns `MAP_FAILED` (`(void *)-1`) on unsupported requests
 
+`SYS_BRK` is likewise lazy: growing the break only advances `user_brk`; pages in
+`[user_brk_base, user_brk)` fault in zeroed on first touch. (Query/shrink-to
+forms behave as before; the break only ever grows.)
+
 `SYS_MUNMAP` unmaps pages but does not currently recycle virtual addresses.
+Because the mmap window is a grow-only bump arena, touching a munmap'd address
+below `mmap_next` simply re-faults a fresh zero page rather than `SIGSEGV`-ing —
+acceptable for the current bring-up (no address reuse).
 
 ## Compatibility Stubs
 

--- a/src/kernel/arch/i386/debug/debug.c
+++ b/src/kernel/arch/i386/debug/debug.c
@@ -857,6 +857,47 @@ static void gpf_handler(registers_t *regs)
 #define PFE_PAGE_WRITABLE 0x2u
 #define PFE_PAGE_LARGE    0x80u
 
+/* Demand-paging handler (lazy brk + anonymous mmap).
+ *
+ * SYS_BRK and SYS_MMAP2 only *reserve* address ranges; the actual frames are
+ * mapped here on first touch -- the WWLD model (Linux brk/anon-mmap are lazy).
+ * This keeps a multi-MiB allocation (doom's 6 MiB zone) from mapping every
+ * page in one interrupts-off syscall and stalling the whole system.
+ *
+ * Returns 1 if the fault hit a reserved-but-unmapped page in the current
+ * task's heap [user_brk_base, user_brk) or anon-mmap [USER_MMAP_BASE,
+ * mmap_next) window and we mapped a fresh zeroed frame; 0 otherwise (caller
+ * falls through to the COW check / SIGSEGV). */
+static int try_handle_anon_fault(uint32_t fault_addr, uint32_t err_code)
+{
+    /* A present-page fault here means a protection violation, not a missing
+     * page -- leave it to COW / SIGSEGV. */
+    if (err_code & PF_ERR_PRESENT)
+        return 0;
+
+    task_t *t = task_current();
+    if (!t || t->user_brk == 0)
+        return 0;                       /* not a user process */
+
+    int in_heap = (t->user_brk_base && fault_addr >= t->user_brk_base &&
+                   fault_addr <  t->user_brk);
+    int in_mmap = (t->mmap_next && fault_addr >= USER_MMAP_BASE &&
+                   fault_addr <  t->mmap_next);
+    if (!in_heap && !in_mmap)
+        return 0;                       /* genuine wild access */
+
+    uint32_t phys = pmm_alloc_frame();
+    if (phys == PMM_ALLOC_ERROR)
+        return 0;                       /* OOM: fall through to SIGSEGV/panic */
+
+    /* Frame is kernel-identity-mapped (< 256 MiB) so we can zero it directly. */
+    memset((void *)phys, 0, 0x1000u);
+    vmm_map_page(t->page_dir, fault_addr & ~0xFFFu, phys,
+                 VMM_FLAG_USER | VMM_FLAG_WRITABLE);
+    asm volatile("invlpg (%0)" :: "r"(fault_addr & ~0xFFFu) : "memory");
+    return 1;
+}
+
 static int try_handle_cow_fault(uint32_t fault_addr, uint32_t err_code)
 {
     /* Not a write fault?  Can't be COW.  (A read against a present
@@ -919,6 +960,9 @@ static void page_fault_handler(registers_t *regs)
 {
     uint32_t fault_addr;
     asm volatile("mov %%cr2, %0" : "=r"(fault_addr));
+
+    if (try_handle_anon_fault(fault_addr, regs->err_code))
+        return;
 
     if (try_handle_cow_fault(fault_addr, regs->err_code))
         return;

--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -998,23 +998,6 @@ static void on_make(kc_t kc)
         default: break;
     }
 
-    /* Ctrl-Alt-Del: request the system menu.  In a text session it's serviced
-     * by keyboard_getchar -> cad_menu; under the GUI the WM polls
-     * SYS_CAD_PENDING and opens its power menu.  Escape hatch: a *second* CAD
-     * within ~1 s (e.g. a wedged GUI that never drained the flag) triggers an
-     * immediate 8042 CPU reset -- safe from IRQ context, no disk flush, the
-     * classic "mash Ctrl-Alt-Del to reboot". */
-    if (mod_ctrl && mod_alt && kc == KC_DELETE) {
-        static uint32_t last_cad = 0;
-        uint32_t now = timer_get_ticks();
-        if (last_cad && (now - last_cad) < TIMER_HZ) {
-            outb(0x64, 0xFE);                 /* pulse RESET line via the 8042 */
-        }
-        last_cad = now;
-        __atomic_store_n(&kb_cad_pending, 1, __ATOMIC_RELEASE);
-        return;
-    }
-
     /* Cooked-mode shortcuts: Alt+Fn TTY switch, Ctrl+Tab cycle, and
      * Ctrl-A pane prefix.  Raw-mode apps (kbtester) need every keystroke
      * as data, so the global F5/F6 console switch is handled earlier in
@@ -1162,6 +1145,24 @@ static void deliver_kc(kc_t kc, int is_break)
             default:
                 break;
         }
+    }
+
+    /* Ctrl-Alt-Del is a firmware-level chord: detect it in BOTH cooked and
+     * scancode mode (on_make is skipped in scancode mode, so it can't live
+     * there) so a focused game -- doom in a window or fullscreen -- can still
+     * raise the GUI power menu and the mash-twice hard reset.  Consumed here so
+     * it never reaches the game.  In a text session it's serviced by
+     * keyboard_getchar -> cad_menu; under the GUI the WM polls SYS_CAD_PENDING.
+     * Escape hatch: a *second* CAD within ~1 s triggers an immediate 8042 CPU
+     * reset -- safe from IRQ context, the classic "mash Ctrl-Alt-Del". */
+    if (!is_break && mod_ctrl && mod_alt && kc == KC_DELETE) {
+        static uint32_t last_cad = 0;
+        uint32_t now = timer_get_ticks();
+        if (last_cad && (now - last_cad) < TIMER_HZ)
+            outb(0x64, 0xFE);                 /* pulse RESET line via the 8042 */
+        last_cad = now;
+        __atomic_store_n(&kb_cad_pending, 1, __ATOMIC_RELEASE);
+        return;
     }
 
     /* Scancode passthrough: raw set-1 byte (low7 | 0x80-break) for make AND

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -322,10 +322,12 @@ static int vfs_route(const char *abs, const char **drv_path)
  * call so the higher-level vfs_* functions stay legible.
  * ---------------------------------------------------------------------- */
 
+static int fs_backend_disk(vfs_backend_t b);   /* defined after the dispatchers */
+
 static int backend_ls(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:    r = ext2_ls(p); break;
     case VFS_BACKEND_FAT32:   r = fat32_ls(p); break;
@@ -336,20 +338,20 @@ static int backend_ls(vfs_mount_t *m, const char *p)
     case VFS_BACKEND_LOGFS:   r = logfs_ls(p); break;
     default:                  r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
 static int backend_cd(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:  r = ext2_cd(p); break;
     case VFS_BACKEND_FAT32: r = fat32_cd(p); break;
     default:                r = 0; break;   /* flat backends accept any "/X" */
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
@@ -397,10 +399,20 @@ void vfs_fs_unlock(void)
     fs_irq_restore(fl);
 }
 
+/* Only the on-disk backends share the static FS scratch and so need the lock.
+ * procfs/tmpfs/logfs/devfs are independent in-memory backends -- locking them
+ * against a long disk operation (e.g. the installer holding the lock for a
+ * whole file) would needlessly block statusbar's /proc polling and starve the
+ * compositor. */
+static int fs_backend_disk(vfs_backend_t b)
+{
+    return b == VFS_BACKEND_EXT2 || b == VFS_BACKEND_FAT32 || b == VFS_BACKEND_ISO9660;
+}
+
 static int backend_read_file(vfs_mount_t *m, const char *p,
                               void *buf, uint32_t bufsz, uint32_t *out_sz)
 {
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     int r;
     switch (m->backend) {
     case VFS_BACKEND_EXT2:    r = ext2_read_file(p, buf, bufsz, out_sz); break;
@@ -420,7 +432,7 @@ static int backend_read_file(vfs_mount_t *m, const char *p,
     }
     default: r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
@@ -428,7 +440,7 @@ static int backend_write_file(vfs_mount_t *m, const char *p,
                                const void *buf, uint32_t size)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:  r = ext2_write_file(p, buf, size); break;
     case VFS_BACKEND_FAT32: r = fat32_write_file(p, buf, size); break;
@@ -444,55 +456,55 @@ static int backend_write_file(vfs_mount_t *m, const char *p,
     case VFS_BACKEND_TMPFS: r = (tmpfs_write(p, buf, size) < 0) ? -1 : 0; break;
     default: r = -1; break;   /* read-only or non-writable backend */
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
 static int backend_mkdir(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:  r = ext2_mkdir(p); break;
     case VFS_BACKEND_FAT32: r = fat32_mkdir(p); break;
     case VFS_BACKEND_TMPFS: r = tmpfs_mkdir(p); break;
     default: r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
 static int backend_delete_file(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:  r = ext2_delete_file(p); break;
     case VFS_BACKEND_FAT32: r = fat32_delete_file(p); break;
     case VFS_BACKEND_TMPFS: r = tmpfs_delete(p); break;
     default: r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
 static int backend_delete_dir(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:  r = ext2_delete_dir(p); break;
     case VFS_BACKEND_FAT32: r = fat32_delete_dir(p); break;
     default: r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
 static int backend_file_exists(vfs_mount_t *m, const char *p)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:    r = ext2_file_exists(p); break;
     case VFS_BACKEND_FAT32:   r = fat32_file_exists(p); break;
@@ -503,7 +515,7 @@ static int backend_file_exists(vfs_mount_t *m, const char *p)
     case VFS_BACKEND_TMPFS:   r = tmpfs_file_exists(p); break;
     default: r = 0; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 
@@ -511,7 +523,7 @@ static int backend_complete(vfs_mount_t *m, const char *p, const char *pre,
                              fat32_complete_cb_t cb, void *ctx)
 {
     int r;
-    vfs_fs_lock();
+    int _dk = fs_backend_disk(m->backend); if (_dk) vfs_fs_lock();
     switch (m->backend) {
     case VFS_BACKEND_EXT2:    r = ext2_complete(p, pre, cb, ctx); break;
     case VFS_BACKEND_FAT32:   r = fat32_complete(p, pre, cb, ctx); break;
@@ -522,7 +534,7 @@ static int backend_complete(vfs_mount_t *m, const char *p, const char *pre,
     case VFS_BACKEND_TMPFS:   r = tmpfs_complete(p, pre, cb, ctx); break;
     default: r = -1; break;
     }
-    vfs_fs_unlock();
+    if (_dk) vfs_fs_unlock();
     return r;
 }
 

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -324,25 +324,33 @@ static int vfs_route(const char *abs, const char **drv_path)
 
 static int backend_ls(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:    return ext2_ls(p);
-    case VFS_BACKEND_FAT32:   return fat32_ls(p);
-    case VFS_BACKEND_ISO9660: return iso9660_ls(m->drive, p);
-    case VFS_BACKEND_DEVFS:   return devfs_ls(p);
-    case VFS_BACKEND_PROCFS:  return procfs_ls(p);
-    case VFS_BACKEND_TMPFS:   return tmpfs_ls(p);
-    case VFS_BACKEND_LOGFS:   return logfs_ls(p);
-    default:                  return -1;
+    case VFS_BACKEND_EXT2:    r = ext2_ls(p); break;
+    case VFS_BACKEND_FAT32:   r = fat32_ls(p); break;
+    case VFS_BACKEND_ISO9660: r = iso9660_ls(m->drive, p); break;
+    case VFS_BACKEND_DEVFS:   r = devfs_ls(p); break;
+    case VFS_BACKEND_PROCFS:  r = procfs_ls(p); break;
+    case VFS_BACKEND_TMPFS:   r = tmpfs_ls(p); break;
+    case VFS_BACKEND_LOGFS:   r = logfs_ls(p); break;
+    default:                  r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_cd(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:  return ext2_cd(p);
-    case VFS_BACKEND_FAT32: return fat32_cd(p);
-    default:                return 0;   /* flat backends accept any "/X" */
+    case VFS_BACKEND_EXT2:  r = ext2_cd(p); break;
+    case VFS_BACKEND_FAT32: r = fat32_cd(p); break;
+    default:                r = 0; break;   /* flat backends accept any "/X" */
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 /* -------------------------------------------------------------------------
@@ -456,35 +464,47 @@ static int backend_mkdir(vfs_mount_t *m, const char *p)
 
 static int backend_delete_file(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:  return ext2_delete_file(p);
-    case VFS_BACKEND_FAT32: return fat32_delete_file(p);
-    case VFS_BACKEND_TMPFS: return tmpfs_delete(p);
-    default: return -1;
+    case VFS_BACKEND_EXT2:  r = ext2_delete_file(p); break;
+    case VFS_BACKEND_FAT32: r = fat32_delete_file(p); break;
+    case VFS_BACKEND_TMPFS: r = tmpfs_delete(p); break;
+    default: r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_delete_dir(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:  return ext2_delete_dir(p);
-    case VFS_BACKEND_FAT32: return fat32_delete_dir(p);
-    default: return -1;
+    case VFS_BACKEND_EXT2:  r = ext2_delete_dir(p); break;
+    case VFS_BACKEND_FAT32: r = fat32_delete_dir(p); break;
+    default: r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_file_exists(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:    return ext2_file_exists(p);
-    case VFS_BACKEND_FAT32:   return fat32_file_exists(p);
-    case VFS_BACKEND_ISO9660: return iso9660_file_exists(m->drive, p);
-    case VFS_BACKEND_PROCFS:  return procfs_file_exists(p);
-    case VFS_BACKEND_DEVFS:   return devfs_file_exists(p);
-    case VFS_BACKEND_LOGFS:   return logfs_file_exists(p);
-    case VFS_BACKEND_TMPFS:   return tmpfs_file_exists(p);
-    default: return 0;
+    case VFS_BACKEND_EXT2:    r = ext2_file_exists(p); break;
+    case VFS_BACKEND_FAT32:   r = fat32_file_exists(p); break;
+    case VFS_BACKEND_ISO9660: r = iso9660_file_exists(m->drive, p); break;
+    case VFS_BACKEND_PROCFS:  r = procfs_file_exists(p); break;
+    case VFS_BACKEND_DEVFS:   r = devfs_file_exists(p); break;
+    case VFS_BACKEND_LOGFS:   r = logfs_file_exists(p); break;
+    case VFS_BACKEND_TMPFS:   r = tmpfs_file_exists(p); break;
+    default: r = 0; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_complete(vfs_mount_t *m, const char *p, const char *pre,

--- a/src/kernel/arch/i386/fs/vfs.c
+++ b/src/kernel/arch/i386/fs/vfs.c
@@ -345,34 +345,85 @@ static int backend_cd(vfs_mount_t *m, const char *p)
     }
 }
 
+/* -------------------------------------------------------------------------
+ * Filesystem big-lock.
+ *
+ * The on-disk FS backends (ext2/fat32/iso9660) share static scratch buffers
+ * (s_blk/s_sec/s_sector + mount state), so two tasks running FS operations at
+ * once would corrupt each other.  With non-preemptible (interrupts-off)
+ * syscalls that could never happen; as the kernel moves to preemptible
+ * syscalls it can, so a single recursive lock serialises FS access across
+ * tasks.  Recursive (owner pid + depth) so a VFS op that nests into another
+ * locked op never self-deadlocks; the test/set is irq-guarded so it is correct
+ * from both interrupts-off and interrupts-on contexts.  A task that finds the
+ * lock held by another yields until it frees.  Wired at the backend dispatch
+ * chokepoints here + the installer's direct backend calls.
+ * ------------------------------------------------------------------------- */
+static inline uint32_t fs_irq_save(void)
+{ uint32_t f; __asm__ volatile("pushfl; popl %0; cli" : "=r"(f) :: "memory"); return f; }
+static inline void fs_irq_restore(uint32_t f)
+{ __asm__ volatile("pushl %0; popfl" :: "r"(f) : "memory", "cc"); }
+
+static volatile int s_fs_owner = -1;   /* pid (or -2 boot) holding the lock */
+static volatile int s_fs_depth = 0;
+
+void vfs_fs_lock(void)
+{
+    task_t *t = task_current();
+    int me = t ? t->pid : -2;          /* -2 = pre-tasking / no-task context */
+    for (;;) {
+        uint32_t fl = fs_irq_save();
+        if (s_fs_owner == -1 || s_fs_owner == me) {
+            s_fs_owner = me; s_fs_depth++;
+            fs_irq_restore(fl);
+            return;
+        }
+        fs_irq_restore(fl);
+        task_yield();
+    }
+}
+void vfs_fs_unlock(void)
+{
+    uint32_t fl = fs_irq_save();
+    if (s_fs_depth > 0 && --s_fs_depth == 0) s_fs_owner = -1;
+    fs_irq_restore(fl);
+}
+
 static int backend_read_file(vfs_mount_t *m, const char *p,
                               void *buf, uint32_t bufsz, uint32_t *out_sz)
 {
+    vfs_fs_lock();
+    int r;
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:    return ext2_read_file(p, buf, bufsz, out_sz);
-    case VFS_BACKEND_FAT32:   return fat32_read_file(p, buf, bufsz, out_sz);
-    case VFS_BACKEND_ISO9660: return iso9660_read_file(m->drive, p, buf, bufsz, out_sz);
-    case VFS_BACKEND_PROCFS:  return procfs_read_file(p, buf, bufsz, out_sz);
-    case VFS_BACKEND_LOGFS:   return (logfs_read(p, buf, bufsz, out_sz) < 0) ? -1 : 0;
-    case VFS_BACKEND_TMPFS:   return (tmpfs_read(p, buf, bufsz, out_sz) < 0) ? -1 : 0;
+    case VFS_BACKEND_EXT2:    r = ext2_read_file(p, buf, bufsz, out_sz); break;
+    case VFS_BACKEND_FAT32:   r = fat32_read_file(p, buf, bufsz, out_sz); break;
+    case VFS_BACKEND_ISO9660: r = iso9660_read_file(m->drive, p, buf, bufsz, out_sz); break;
+    case VFS_BACKEND_PROCFS:  r = procfs_read_file(p, buf, bufsz, out_sz); break;
+    case VFS_BACKEND_LOGFS:   r = (logfs_read(p, buf, bufsz, out_sz) < 0) ? -1 : 0; break;
+    case VFS_BACKEND_TMPFS:   r = (tmpfs_read(p, buf, bufsz, out_sz) < 0) ? -1 : 0; break;
     case VFS_BACKEND_DEVFS: {
         int idx = devfs_lookup(p);
-        if (idx < 0) return -1;
-        long r = devfs_pread(idx, buf, bufsz, 0);
-        if (r < 0) return -1;
-        if (out_sz) *out_sz = (uint32_t)r;
-        return 0;
+        if (idx < 0) { r = -1; break; }
+        long dr = devfs_pread(idx, buf, bufsz, 0);
+        if (dr < 0) { r = -1; break; }
+        if (out_sz) *out_sz = (uint32_t)dr;
+        r = 0;
+        break;
     }
-    default: return -1;
+    default: r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_write_file(vfs_mount_t *m, const char *p,
                                const void *buf, uint32_t size)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:  return ext2_write_file(p, buf, size);
-    case VFS_BACKEND_FAT32: return fat32_write_file(p, buf, size);
+    case VFS_BACKEND_EXT2:  r = ext2_write_file(p, buf, size); break;
+    case VFS_BACKEND_FAT32: r = fat32_write_file(p, buf, size); break;
     case VFS_BACKEND_LOGFS:
         /* /log is kernel-write only (Linux's /var/log model).  klog_write
          * + friends in logfs.c reach the ring directly via ring_append;
@@ -381,20 +432,26 @@ static int backend_write_file(vfs_mount_t *m, const char *p,
          * vfs_mkdir.  Use /tmp for user-writable scratch files. */
         (void)p; (void)buf; (void)size;
         t_writestring("write: read-only filesystem (/log)\n");
-        return -1;
-    case VFS_BACKEND_TMPFS: return (tmpfs_write(p, buf, size) < 0) ? -1 : 0;
-    default: return -1;   /* read-only or non-writable backend */
+        r = -1; break;
+    case VFS_BACKEND_TMPFS: r = (tmpfs_write(p, buf, size) < 0) ? -1 : 0; break;
+    default: r = -1; break;   /* read-only or non-writable backend */
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_mkdir(vfs_mount_t *m, const char *p)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:  return ext2_mkdir(p);
-    case VFS_BACKEND_FAT32: return fat32_mkdir(p);
-    case VFS_BACKEND_TMPFS: return tmpfs_mkdir(p);
-    default: return -1;
+    case VFS_BACKEND_EXT2:  r = ext2_mkdir(p); break;
+    case VFS_BACKEND_FAT32: r = fat32_mkdir(p); break;
+    case VFS_BACKEND_TMPFS: r = tmpfs_mkdir(p); break;
+    default: r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static int backend_delete_file(vfs_mount_t *m, const char *p)
@@ -433,16 +490,20 @@ static int backend_file_exists(vfs_mount_t *m, const char *p)
 static int backend_complete(vfs_mount_t *m, const char *p, const char *pre,
                              fat32_complete_cb_t cb, void *ctx)
 {
+    int r;
+    vfs_fs_lock();
     switch (m->backend) {
-    case VFS_BACKEND_EXT2:    return ext2_complete(p, pre, cb, ctx);
-    case VFS_BACKEND_FAT32:   return fat32_complete(p, pre, cb, ctx);
-    case VFS_BACKEND_ISO9660: return iso9660_complete(m->drive, p, pre, cb, ctx);
-    case VFS_BACKEND_PROCFS:  return procfs_complete(p, pre, cb, ctx);
-    case VFS_BACKEND_DEVFS:   return devfs_complete(p, pre, cb, ctx);
-    case VFS_BACKEND_LOGFS:   return logfs_complete(p, pre, cb, ctx);
-    case VFS_BACKEND_TMPFS:   return tmpfs_complete(p, pre, cb, ctx);
-    default: return -1;
+    case VFS_BACKEND_EXT2:    r = ext2_complete(p, pre, cb, ctx); break;
+    case VFS_BACKEND_FAT32:   r = fat32_complete(p, pre, cb, ctx); break;
+    case VFS_BACKEND_ISO9660: r = iso9660_complete(m->drive, p, pre, cb, ctx); break;
+    case VFS_BACKEND_PROCFS:  r = procfs_complete(p, pre, cb, ctx); break;
+    case VFS_BACKEND_DEVFS:   r = devfs_complete(p, pre, cb, ctx); break;
+    case VFS_BACKEND_LOGFS:   r = logfs_complete(p, pre, cb, ctx); break;
+    case VFS_BACKEND_TMPFS:   r = tmpfs_complete(p, pre, cb, ctx); break;
+    default: r = -1; break;
     }
+    vfs_fs_unlock();
+    return r;
 }
 
 static void backend_unmount(vfs_backend_t b)

--- a/src/kernel/arch/i386/mm/pmm.c
+++ b/src/kernel/arch/i386/mm/pmm.c
@@ -58,6 +58,18 @@ static uint32_t s_max_frames;               /* highest managed frame + 1   */
 static uint32_t s_free_frames;              /* O(1) free-frame accounting   */
 static uint32_t s_total_managed_frames;     /* constant after pmm_init      */
 
+/* IRQ guard for the buddy free-lists + descriptor table.  The PMM is touched
+ * from many contexts (mmap/brk demand-fault, fork COW, page-table alloc, heap
+ * growth); once syscalls run preemptively (IF=1) two tasks can allocate frames
+ * concurrently and corrupt the free lists.  A cli/restore lock keeps each
+ * alloc/free atomic against the timer IRQ and any preempting task.  No-op while
+ * syscalls are still serialized (IF=0); load-bearing once sti is flipped on.
+ * Same pattern as heap.c's heap_irq_save/restore. */
+static inline uint32_t pmm_irq_save(void)
+{ uint32_t f; __asm__ volatile("pushfl; popl %0; cli" : "=r"(f) :: "memory"); return f; }
+static inline void pmm_irq_restore(uint32_t f)
+{ __asm__ volatile("pushl %0; popfl" :: "r"(f) : "memory", "cc"); }
+
 /* --------------------------------------------------------------------------
  * Free-list primitives (doubly-linked via frame indices)
  * -------------------------------------------------------------------------- */
@@ -220,12 +232,16 @@ uint32_t pmm_alloc_pages(unsigned order)
 	if (order >= PMM_MAX_ORDER)
 		return PMM_ALLOC_ERROR;
 
+	uint32_t fl = pmm_irq_save();
+
 	/* Find the smallest available order >= the request. */
 	unsigned o = order;
 	while (o < PMM_MAX_ORDER && free_lists[o] == PMM_NIL)
 		o++;
-	if (o >= PMM_MAX_ORDER)
+	if (o >= PMM_MAX_ORDER) {
+		pmm_irq_restore(fl);
 		return PMM_ALLOC_ERROR;           /* out of memory at this size */
+	}
 
 	uint32_t f = free_lists[o];
 	list_del(o, f);
@@ -243,6 +259,7 @@ uint32_t pmm_alloc_pages(unsigned order)
 	mem_map[f].flags   &= (uint8_t)~PG_BUDDY;
 	s_free_frames      -= (1U << order);
 
+	pmm_irq_restore(fl);
 	return f * PMM_FRAME_SIZE;
 }
 
@@ -261,7 +278,10 @@ void pmm_free_pages(uint32_t addr, unsigned order)
 	if (f >= s_max_frames)
 		return;
 
+	uint32_t fl = pmm_irq_save();
+
 	if (mem_map[f].refcount == 0) {
+		pmm_irq_restore(fl);
 		KLOG("pmm_free_pages: refcount underflow at frame ");
 		KLOG_HEX(f);
 		KLOG("\n");
@@ -273,6 +293,8 @@ void pmm_free_pages(uint32_t addr, unsigned order)
 	(void)order;
 	if (--mem_map[f].refcount == 0)
 		buddy_free(f, mem_map[f].order);
+
+	pmm_irq_restore(fl);
 }
 
 void pmm_free_frame(uint32_t addr)
@@ -285,19 +307,23 @@ void pmm_inc_ref(uint32_t addr)
 	uint32_t frame = addr / PMM_FRAME_SIZE;
 	if (frame >= s_max_frames)
 		return;
+	uint32_t fl = pmm_irq_save();
 	if (mem_map[frame].refcount == 0) {
+		pmm_irq_restore(fl);
 		KLOG("pmm_inc_ref: frame not allocated, refcount=0 at ");
 		KLOG_HEX(frame);
 		KLOG("\n");
 		return;
 	}
 	if (mem_map[frame].refcount == 0xFF) {
+		pmm_irq_restore(fl);
 		KLOG("pmm_inc_ref: refcount saturated at 255 for frame ");
 		KLOG_HEX(frame);
 		KLOG("\n");
 		return;
 	}
 	mem_map[frame].refcount++;
+	pmm_irq_restore(fl);
 }
 
 uint8_t pmm_ref_count(uint32_t addr)

--- a/src/kernel/arch/i386/proc/elf.c
+++ b/src/kernel/arch/i386/proc/elf.c
@@ -52,6 +52,44 @@ static inline uint32_t align_down(uint32_t v, uint32_t a) { return v & ~(a - 1u)
 static inline uint32_t align_up  (uint32_t v, uint32_t a) { return (v + a - 1u) & ~(a - 1u); }
 
 /* -------------------------------------------------------------------------
+ * execve serialization lock.
+ *
+ * SYS_EXECVE copies the caller's argv into a single large file-scope scratch
+ * buffer (its user PD is about to be freed), which elf_exec then packs onto the
+ * new task's stack.  Under preemptible syscalls two execves would clobber that
+ * scratch, so SYS_EXECVE takes this lock on entry; elf_exec releases it the
+ * moment argv has been consumed onto the new stack (execve_unlock below), just
+ * before the no-return ring3_enter -- so the success path frees it too.  Owner-
+ * based, so the fresh-task / ktest callers of elf_exec (which don't take it)
+ * unlock as a no-op.  Yields while held by another task; irq-guarded test/set.
+ * ------------------------------------------------------------------------- */
+static inline uint32_t elf_irq_save(void)
+{ uint32_t f; __asm__ volatile("pushfl; popl %0; cli" : "=r"(f) :: "memory"); return f; }
+static inline void elf_irq_restore(uint32_t f)
+{ __asm__ volatile("pushl %0; popfl" :: "r"(f) : "memory", "cc"); }
+
+static volatile int s_execve_owner = -1;
+void execve_lock(void)
+{
+    task_t *t = task_current();
+    int me = t ? t->pid : -2;
+    for (;;) {
+        uint32_t fl = elf_irq_save();
+        if (s_execve_owner == -1) { s_execve_owner = me; elf_irq_restore(fl); return; }
+        elf_irq_restore(fl);
+        task_yield();
+    }
+}
+void execve_unlock(void)
+{
+    task_t *t = task_current();
+    int me = t ? t->pid : -2;
+    uint32_t fl = elf_irq_save();
+    if (s_execve_owner == me) s_execve_owner = -1;   /* no-op if we never held it */
+    elf_irq_restore(fl);
+}
+
+/* -------------------------------------------------------------------------
  * elf_exec
  * ------------------------------------------------------------------------- */
 
@@ -308,6 +346,11 @@ int elf_exec(const char *path, int argc, const char *const *argv)
     *(uint32_t *)(spage + off) = (uint32_t)argc;
 
     uint32_t initial_esp = stack_virt + off;
+
+    /* argv has now been fully packed onto the new task's stack; the caller's
+     * execve scratch is free to reuse, so drop the execve lock before the
+     * no-return ring3 entry (no-op for non-SYS_EXECVE callers). */
+    execve_unlock();
 
     /* 7. Activate the address space and enter ring 3.
      *

--- a/src/kernel/arch/i386/proc/elf.c
+++ b/src/kernel/arch/i386/proc/elf.c
@@ -224,6 +224,7 @@ int elf_exec(const char *path, int argc, const char *const *argv)
         if (end > top_vaddr) top_vaddr = end;
     }
     task_current()->user_brk = top_vaddr;
+    task_current()->user_brk_base = top_vaddr;  /* lower bound of the lazy brk region */
     task_current()->mmap_next = 0;   /* fresh address space: reset anon-mmap window */
     task_current()->tls_gs = 0x23u;  /* fresh image: drop any prior TLS */
     task_current()->tls_active = 0;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -230,20 +230,23 @@ static void ls_cb(const char *name, int is_dir, void *ctx)
     c->buf[c->off] = '\0';
 }
 
-/* Callback + context for SYS_READDIR.  Static name buffer is OK: the
- * complete() backends can be re-entered but the kernel context is not. */
-struct rd_ctx { uint32_t target; uint32_t cur; int found; };
-static char s_name[DIRENT_NAME_MAX];
-static int  s_is_dir;
+/* Callback + context for SYS_READDIR.  The found name/type live in the ctx (on
+ * the caller's stack), not in file-scope statics -- so two tasks running
+ * readdir concurrently under preemptible syscalls don't clobber each other. */
+struct rd_ctx {
+    uint32_t target; uint32_t cur; int found;
+    char     name[DIRENT_NAME_MAX];
+    int      is_dir;
+};
 static void readdir_collect_cb(const char *n, int is_dir, void *vctx)
 {
     struct rd_ctx *c = (struct rd_ctx *)vctx;
     if (c->found) return;
     if (c->cur == c->target) {
         uint32_t i = 0;
-        while (n[i] && i < DIRENT_NAME_MAX - 1) { s_name[i] = n[i]; i++; }
-        s_name[i] = '\0';
-        s_is_dir = is_dir;
+        while (n[i] && i < DIRENT_NAME_MAX - 1) { c->name[i] = n[i]; i++; }
+        c->name[i] = '\0';
+        c->is_dir = is_dir;
         c->found = 1;
     }
     c->cur++;
@@ -585,8 +588,10 @@ void syscall_dispatch(registers_t *regs)
                 }
                 break;
             }
-            /* Line-buffered stdin with echo, backspace, and cursor editing. */
-            static char s_stdin_line[256];
+            /* Line-buffered stdin with echo, backspace, and cursor editing.
+             * On the stack (not static) so concurrent readers under preemptible
+             * syscalls don't share one line buffer. */
+            char s_stdin_line[256];
             uint32_t cap = (len < sizeof(s_stdin_line)) ? len : (uint32_t)sizeof(s_stdin_line);
             shell_readline(s_stdin_line, (size_t)cap);
             uint32_t n = (uint32_t)strlen(s_stdin_line);
@@ -1653,18 +1658,18 @@ void syscall_dispatch(registers_t *regs)
         uint32_t       idx  = regs->ecx;
         struct dirent *ude  = (struct dirent *)(uintptr_t)regs->edx;
         if (!path || !ude) { regs->eax = (uint32_t)-1; break; }
-        struct rd_ctx ctx = { idx, 0, 0 };
+        struct rd_ctx ctx = { idx, 0, 0, {0}, 0 };
         if (vfs_complete(path, "", readdir_collect_cb, &ctx) != 0) {
             regs->eax = (uint32_t)-1; break;
         }
         if (!ctx.found) { regs->eax = 0; break; }
         memset(ude, 0, sizeof(*ude));
         uint32_t h = 2166136261u;
-        for (const char *q = s_name; *q; q++) { h ^= (uint8_t)*q; h *= 16777619u; }
+        for (const char *q = ctx.name; *q; q++) { h ^= (uint8_t)*q; h *= 16777619u; }
         ude->d_ino  = h;
-        ude->d_type = s_is_dir ? DT_DIR : DT_REG;
+        ude->d_type = ctx.is_dir ? DT_DIR : DT_REG;
         uint32_t i = 0;
-        while (s_name[i] && i < DIRENT_NAME_MAX - 1) { ude->d_name[i] = s_name[i]; i++; }
+        while (ctx.name[i] && i < DIRENT_NAME_MAX - 1) { ude->d_name[i] = ctx.name[i]; i++; }
         ude->d_name[i] = '\0';
         regs->eax = 1;
         break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -2312,19 +2312,18 @@ void syscall_dispatch(registers_t *regs)
         if (!task_is_admin(NULL)) { regs->eax = (uint32_t)-1; break; }
         int   cmd = (int)regs->ebx;
         void *ptr = (void *)(uintptr_t)regs->ecx;
-        /* The install engine calls the FS backends directly (not via VFS), and
-         * runs preemptibly, so serialise it under the FS big-lock: a file op in
-         * another task can't then race the installer's writes on the shared FS
-         * scratch.  Held for one begin/step/finish (one file per step) -- the
-         * recursive lock covers the engine's nested backend calls; drive
-         * enumeration touches no FS scratch so it stays outside. */
-        if (cmd == 3) { regs->eax = (uint32_t)install_exec_drives((install_drive_t *)ptr); break; }
-        vfs_fs_lock();
+        /* NOTE: the install engine runs WITHOUT the FS big-lock held across the
+         * step.  Holding vfs_fs_lock across a whole begin/step (the engine is
+         * preemptible) stalled the copy, so we keep the v0.10.0 behaviour: the
+         * engine's direct backend calls go unlocked.  The remaining race is the
+         * installer's iso9660 read vs. another task's iso9660 read on the shared
+         * sector scratch -- low severity (read/read, contained), to be closed in
+         * the preemption phase by per-op locking of the engine's backend calls. */
         if      (cmd == 0) regs->eax = (uint32_t)install_exec_begin((const install_params_t *)ptr);
         else if (cmd == 1) regs->eax = (uint32_t)install_exec_step((install_progress_t *)ptr);
         else if (cmd == 2) regs->eax = (uint32_t)install_exec_finish((const install_params_t *)ptr);
+        else if (cmd == 3) regs->eax = (uint32_t)install_exec_drives((install_drive_t *)ptr);
         else               regs->eax = (uint32_t)-1;
-        vfs_fs_unlock();
         break;
     }
     case SYS_MOUNT: {

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -2300,11 +2300,19 @@ void syscall_dispatch(registers_t *regs)
         if (!task_is_admin(NULL)) { regs->eax = (uint32_t)-1; break; }
         int   cmd = (int)regs->ebx;
         void *ptr = (void *)(uintptr_t)regs->ecx;
+        /* The install engine calls the FS backends directly (not via VFS), and
+         * runs preemptibly, so serialise it under the FS big-lock: a file op in
+         * another task can't then race the installer's writes on the shared FS
+         * scratch.  Held for one begin/step/finish (one file per step) -- the
+         * recursive lock covers the engine's nested backend calls; drive
+         * enumeration touches no FS scratch so it stays outside. */
+        if (cmd == 3) { regs->eax = (uint32_t)install_exec_drives((install_drive_t *)ptr); break; }
+        vfs_fs_lock();
         if      (cmd == 0) regs->eax = (uint32_t)install_exec_begin((const install_params_t *)ptr);
         else if (cmd == 1) regs->eax = (uint32_t)install_exec_step((install_progress_t *)ptr);
         else if (cmd == 2) regs->eax = (uint32_t)install_exec_finish((const install_params_t *)ptr);
-        else if (cmd == 3) regs->eax = (uint32_t)install_exec_drives((install_drive_t *)ptr);
         else               regs->eax = (uint32_t)-1;
+        vfs_fs_unlock();
         break;
     }
     case SYS_MOUNT: {

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1409,25 +1409,14 @@ void syscall_dispatch(registers_t *regs)
             break;
         }
 
-        /* Align the current break up to the next page boundary, then map
-         * all pages needed to reach new_brk. */
-        uint32_t cur_page = (t->user_brk + 0xFFFu) & ~0xFFFu;
-        uint32_t new_page = (new_brk     + 0xFFFu) & ~0xFFFu;
-
-        for (uint32_t va = cur_page; va < new_page; va += 0x1000u) {
-            uint32_t phys = pmm_alloc_frame();
-            if (phys == PMM_ALLOC_ERROR) {
-                /* Return what we managed to allocate so far. */
-                regs->eax = t->user_brk;
-                goto brk_done;
-            }
-            memset((void *)phys, 0, 0x1000u);
-            vmm_map_page(t->page_dir, va, phys,
-                         VMM_FLAG_USER | VMM_FLAG_WRITABLE);
-        }
+        /* Demand-paged heap (WWLD: Linux brk only reserves; pages are mapped
+         * lazily on first touch).  Just advance the break -- the page-fault
+         * handler maps a zeroed frame for any access in [user_brk_base,
+         * user_brk).  This keeps a multi-MiB growth (e.g. doom's 6 MiB zone)
+         * from stalling every other task in one interrupts-off syscall. */
+        if (t->user_brk_base == 0) t->user_brk_base = t->user_brk;
         t->user_brk = new_brk;
         regs->eax   = new_brk;
-    brk_done:
         break;
     }
 
@@ -1441,7 +1430,6 @@ void syscall_dispatch(registers_t *regs)
      * a hosted malloc (musl mallocng) needs beyond brk.
      * ------------------------------------------------------------------ */
     case SYS_MMAP2: {
-        #define USER_MMAP_BASE 0x90000000u
         #define MMAP_MAP_ANONYMOUS 0x20u
         #define MMAP_MAP_FIXED     0x10u
         uint32_t len   = regs->ecx;
@@ -1462,20 +1450,9 @@ void syscall_dispatch(registers_t *regs)
             regs->eax = (uint32_t)-1; break;
         }
 
-        for (uint32_t i = 0; i < pages; i++) {
-            uint32_t phys = pmm_alloc_frame();
-            if (phys == PMM_ALLOC_ERROR) {
-                /* Roll back what we mapped so far. */
-                for (uint32_t j = 0; j < i; j++) {
-                    uint32_t va = base + (j << 12);
-                    vmm_unmap_page(t->page_dir, va);
-                }
-                regs->eax = (uint32_t)-1; break;
-            }
-            memset((void *)phys, 0, 0x1000u);
-            vmm_map_page(t->page_dir, base + (i << 12), phys,
-                         VMM_FLAG_USER | VMM_FLAG_WRITABLE);
-        }
+        /* Demand-paged anonymous mmap: reserve the window only; the page-fault
+         * handler maps a zeroed frame on first touch in [USER_MMAP_BASE,
+         * mmap_next).  Same WWLD lazy model as brk above. */
         t->mmap_next = base + (pages << 12);
         regs->eax = base;
         break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -421,6 +421,12 @@ void syscall_dispatch(registers_t *regs)
 
         if (!upath) { regs->eax = (uint32_t)-14; break; }   /* -EFAULT */
 
+        /* Serialise execve so the shared argv scratch below is safe under
+         * preemptible syscalls.  elf_exec releases the lock once argv is packed
+         * onto the new stack (covering its no-return success path); we release
+         * it here on the error-return path. */
+        execve_lock();
+
         enum { EXECVE_MAX_ARGC = 128, EXECVE_ARG_MAX = 256 };  /* full kernel-rebuild link line */
         static char  s_path[256];
         static char  s_argbuf[EXECVE_MAX_ARGC * EXECVE_ARG_MAX];
@@ -515,6 +521,7 @@ void syscall_dispatch(registers_t *regs)
          * (never returns).  Any return value here means it failed; pass
          * the negative errno back to the caller via EAX. */
         int rc = elf_exec(s_path, kargc, (const char *const *)s_argv);
+        execve_unlock();   /* only reached when elf_exec failed (success no-returns) */
         regs->eax = (uint32_t)(int32_t)rc;
         break;
     }

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -172,6 +172,14 @@ task_t *task_create(const char *name, void (*entry)(void))
     if (!new_fds)
         return NULL;
 
+    /* Serialize the task-pool mutation (slot claim, DEAD-slot reclaim, run-list
+     * relink, task_pool_count/next_pid bumps) against the timer IRQ -> schedule()
+     * which walks ->next, and against a concurrent task_create/task_fork.  A
+     * no-op while syscalls still run with IF=0; load-bearing once preemptive sti
+     * is flipped on.  The up-front fd-table alloc above is outside the lock so a
+     * slow kmalloc doesn't extend the critical section. */
+    uint32_t _tf = irq_save_disable();
+
     /* Try to reclaim a DEAD slot before allocating a new one. */
     for (int i = 1; i < task_pool_count; i++) {
         if (task_pool[i].state == TASK_DEAD) {
@@ -220,12 +228,14 @@ task_t *task_create(const char *name, void (*entry)(void))
 
     if (!t) {
         if (task_pool_count >= MAX_TASKS) {
+            irq_restore(_tf);
             fd_table_destroy(new_fds);
             return NULL;
         }
 
         uint8_t *stack = (uint8_t *)kmalloc(TASK_STACK_SIZE);
         if (!stack) {
+            irq_restore(_tf);
             fd_table_destroy(new_fds);
             return NULL;
         }
@@ -283,6 +293,7 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->next            = current_task->next;
     current_task->next = t;
 
+    irq_restore(_tf);
     return t;
 }
 
@@ -318,7 +329,9 @@ task_t *task_fork(registers_t *parent_regs)
     }
 
     /* Reserve a slot (same logic as task_create, modulo the explicit
-     * stack/PD init below). */
+     * stack/PD init below).  IRQ-guarded for the same reason -- see the lock
+     * comment in task_create; the up-front fd/PD clones above stay outside it. */
+    uint32_t _tf = irq_save_disable();
     task_t *t = NULL;
     for (int i = 1; i < task_pool_count; i++) {
         if (task_pool[i].state == TASK_DEAD) {
@@ -350,12 +363,14 @@ task_t *task_fork(registers_t *parent_regs)
     }
     if (!t) {
         if (task_pool_count >= MAX_TASKS) {
+            irq_restore(_tf);
             vmm_free_pd(child_pd);
             fd_table_destroy(child_fds);
             return NULL;
         }
         uint8_t *stack = (uint8_t *)kmalloc(TASK_STACK_SIZE);
         if (!stack) {
+            irq_restore(_tf);
             vmm_free_pd(child_pd);
             fd_table_destroy(child_fds);
             return NULL;
@@ -439,6 +454,7 @@ task_t *task_fork(registers_t *parent_regs)
     t->next            = current_task->next;
     current_task->next = t;
 
+    irq_restore(_tf);
     return t;
 }
 

--- a/src/kernel/arch/i386/proc/task.c
+++ b/src/kernel/arch/i386/proc/task.c
@@ -125,6 +125,7 @@ void tasking_init(void)
     idle->next     = idle;               /* circular list of one for now             */
     idle->pid      = 1;
     idle->user_brk = 0;
+    idle->user_brk_base = 0;
     fpu_init_state(idle->fpu_state);
     idle->tls_gs = 0x23u; idle->tls_active = 0;
     /* Seed idle->cwd from the boot-time scratch cwd that vfs_init() /
@@ -240,6 +241,7 @@ task_t *task_create(const char *name, void (*entry)(void))
     t->state       = TASK_READY;
     t->name        = name;
     t->user_brk    = 0;
+    t->user_brk_base = 0;
     t->mmap_next   = 0;
     fpu_init_state(t->fpu_state);
     t->tls_gs = 0x23u; t->tls_active = 0;   /* default %gs = user data; no TLS yet */
@@ -367,6 +369,7 @@ task_t *task_fork(registers_t *parent_regs)
     t->state       = TASK_READY;
     t->name        = current_task->name;     /* same image */
     t->user_brk    = current_task->user_brk;
+    t->user_brk_base = current_task->user_brk_base;
     t->mmap_next   = current_task->mmap_next;
     fpu_init_state(t->fpu_state);   /* child starts clean (fork+exec common path) */
     t->tls_gs = 0x23u; t->tls_active = 0;

--- a/src/kernel/include/kernel/elf.h
+++ b/src/kernel/include/kernel/elf.h
@@ -95,4 +95,13 @@ typedef struct {
  */
 int elf_exec(const char *path, int argc, const char *const *argv);
 
+/*
+ * execve serialization lock.  SYS_EXECVE takes execve_lock() before filling its
+ * shared argv scratch; elf_exec calls execve_unlock() once argv is packed onto
+ * the new stack (so the no-return success path releases it).  Owner-based:
+ * unlock is a no-op for callers that never locked (fresh-task/ktest paths).
+ */
+void execve_lock(void);
+void execve_unlock(void);
+
 #endif /* _KERNEL_ELF_H */

--- a/src/kernel/include/kernel/task.h
+++ b/src/kernel/include/kernel/task.h
@@ -21,6 +21,10 @@
 /* TTY index meaning "not bound to any TTY". */
 #define TASK_TTY_NONE    (-1)
 
+/* Base of the per-task anonymous-mmap bump window (below the ring-3 stack).
+ * Shared by SYS_MMAP2 and the demand-paging fault handler. */
+#define USER_MMAP_BASE   0x90000000u
+
 typedef enum {
     TASK_READY   = 0,
     TASK_RUNNING = 1,
@@ -60,6 +64,7 @@ typedef struct task {
 
     /* --- user memory --- */
     uint32_t      user_brk;  /* current user-space heap break (0 = not a user process) */
+    uint32_t      user_brk_base; /* initial heap break: lower bound of the lazy brk region */
     uint32_t      mmap_next; /* bump pointer for anonymous mmap (0 = lazily init to USER_MMAP_BASE) */
     uint8_t       fpu_state[512] __attribute__((aligned(16))); /* x87/SSE fxsave area, saved/restored on context switch */
     /* Thread-Local Storage (set_thread_area): per-task %gs.  tls_gs defaults

--- a/src/kernel/include/kernel/vfs.h
+++ b/src/kernel/include/kernel/vfs.h
@@ -238,4 +238,14 @@ int vfs_rename(const char *old_path, const char *new_path);
 int vfs_complete(const char *dir, const char *prefix,
                  fat32_complete_cb_t cb, void *ctx);
 
+/*
+ * Filesystem big-lock (recursive).  The on-disk FS backends share static
+ * scratch, so concurrent FS work from preemptible syscalls would corrupt them.
+ * VFS ops take this internally; in-kernel code that calls the FS backends
+ * *directly* (e.g. the installer engine) wraps its operation in the same lock
+ * so the two paths serialise.  Recursive: nesting from one task is safe.
+ */
+void vfs_fs_lock(void);
+void vfs_fs_unlock(void);
+
 #endif /* _KERNEL_VFS_H */

--- a/src/userspace/doomgeneric_makar.c
+++ b/src/userspace/doomgeneric_makar.c
@@ -21,19 +21,14 @@ static unsigned int *fullfb;
 
 /* Windowed mode: Doom is a makx *client* (launched by the display server with
  * `-makx <server-pid>`).  It renders into a shared surface the server
- * composites, takes decoded keys the server forwards over IPC (not the raw
- * scancode stream), and never calls SYS_FB_PRESENT -- only the server owns
- * scanout.  See makx.h / docs/gui.md.  Without -makx, Doom runs its normal
+ * composites and never calls SYS_FB_PRESENT -- only the server owns scanout.
+ * It connects with MX_F_RAWKEYS, so while it holds focus the server forwards
+ * the raw make/break scancode stream as MXEV_KEY values -- the same stream the
+ * fullscreen path reads directly -- giving true key-up events (no synthesized
+ * releases).  See makx.h / docs/gui.md.  Without -makx, Doom runs its normal
  * fullscreen path (shell `doom`). */
 static int     s_windowed = 0;
 static mx_conn s_mc;
-
-/* stdin in windowed mode carries decoded key-*down* bytes only (no break
- * codes), so a held movement key would stick.  Synthesize a release a short
- * time after each press: tap-to-move.  Crude but playable for menus/turning. */
-#define HOLD_TICS 12            /* ~120ms at 100Hz */
-#define HELD_MAX  8
-static struct { unsigned char key; unsigned int expire; } s_held[HELD_MAX];
 
 static void kq_push(int pressed, unsigned char k)
 {
@@ -72,28 +67,6 @@ static unsigned char convertToDoomKey(unsigned char sc)
     }
 }
 
-/* Windowed mode: map a decoded key byte (ASCII or KEY_ARROW_* sentinel, as the
- * WM forwards) to a Doom key.  Returns 0 for keys we don't bind. */
-static unsigned char convertWinKey(unsigned char a)
-{
-    switch (a) {
-        case 13: case 10: return KEY_ENTER;
-        case 27:          return KEY_ESCAPE;
-        case 0x82:        return KEY_LEFTARROW;   /* KEY_ARROW_LEFT  */
-        case 0x83:        return KEY_RIGHTARROW;  /* KEY_ARROW_RIGHT */
-        case 0x80:        return KEY_UPARROW;     /* KEY_ARROW_UP    */
-        case 0x81:        return KEY_DOWNARROW;   /* KEY_ARROW_DOWN  */
-        case ' ':         return KEY_FIRE;
-        case '\t':        return KEY_TAB;
-        case 'e': case 'E': return KEY_USE;
-        default:
-            if (a >= '1' && a <= '9') return a;
-            if (a >= 'a' && a <= 'z') return a;
-            if (a >= 'A' && a <= 'Z') return (unsigned char)(a + 32);
-            return 0;
-    }
-}
-
 void DG_Init(void)
 {
     if (s_windowed) {
@@ -125,25 +98,18 @@ void DG_Init(void)
 static void handle_input(void)
 {
     if (s_windowed) {
-        unsigned int now = sys_uptime();
-        /* expire held keys -> synthesize releases */
-        for (int i = 0; i < HELD_MAX; i++)
-            if (s_held[i].key && (int)(now - s_held[i].expire) >= 0) {
-                kq_push(0, s_held[i].key);
-                s_held[i].key = 0;
-            }
+        /* The WM forwards the raw make/break scancode stream (MX_F_RAWKEYS), so
+         * the windowed path is the fullscreen path with mx_key() as the source:
+         * real key-up events, no synthesized releases. */
         mx_pump(&s_mc);
         if (s_mc.closed) sys_exit(0);        /* server closed our window */
         int a;
         while ((a = mx_key(&s_mc)) >= 0) {
-            unsigned char k = convertWinKey((unsigned char)a);
+            unsigned char sc = (unsigned char)a;
+            int pressed = (sc & 0x80) ? 0 : 1;
+            unsigned char k = convertToDoomKey(sc & 0x7F);
             if (!k) continue;
-            kq_push(1, k);
-            /* (re)arm an auto-release slot for this key */
-            int slot = -1;
-            for (int i = 0; i < HELD_MAX; i++) { if (s_held[i].key == k) { slot = i; break; } }
-            if (slot < 0) for (int i = 0; i < HELD_MAX; i++) if (!s_held[i].key) { slot = i; break; }
-            if (slot >= 0) { s_held[slot].key = k; s_held[slot].expire = now + HOLD_TICS; }
+            kq_push(pressed, k);
         }
         return;
     }
@@ -219,7 +185,8 @@ int main(int argc, char **argv)
      * makx client and request a 640x400 surface up front -- DG_Init then renders
      * into it.  Strip the flag so doomgeneric never sees it.  No -makx -> the
      * normal fullscreen path (shell `doom`). */
-    if (mx_connect(&s_mc, argc, argv, DOOMGENERIC_RESX, DOOMGENERIC_RESY, 0) == 0)
+    if (mx_connect(&s_mc, argc, argv, DOOMGENERIC_RESX, DOOMGENERIC_RESY,
+                   MX_F_RAWKEYS) == 0)
         s_windowed = 1;
 
     static char *fa[34];

--- a/src/userspace/makx.h
+++ b/src/userspace/makx.h
@@ -47,6 +47,12 @@
  * scaled).  Without it the surface is fixed-size and the server scales it to the
  * window (e.g. doom, a fixed-resolution game). */
 #define MX_F_RESIZABLE  1
+/* MX_F_RAWKEYS: the client wants the raw set-1 make/break scancode stream (a
+ * game -- doom) rather than cooked key-down bytes.  While such a client holds
+ * focus the server puts the keyboard in scancode-passthrough mode and forwards
+ * each scancode (low7 | 0x80=break) as the MXEV_KEY value; on focus loss it
+ * restores cooked mode.  Mirrors a display server flipping evdev/tty modes. */
+#define MX_F_RAWKEYS    2
 
 /* server -> client reply event kinds (carried in the reply ipc_msg_t.type).
  * data[5] always carries the count of further events still queued, so the

--- a/src/userspace/mxinstall.c
+++ b/src/userspace/mxinstall.c
@@ -29,6 +29,7 @@
 #define COL_BAR    RGB(0x4c,0x8d,0xff)
 
 static void scpy(char *d,const char *s,int max){ int i=0; while(s[i]&&i<max-1){d[i]=s[i];i++;} d[i]=0; }
+static int  seq(const char *a,const char *b){ int i=0; while(a[i]&&a[i]==b[i])i++; return a[i]==b[i]; }
 /* unsigned -> decimal, appended at *o in buf */
 static void udec(char *buf,int *o,unsigned v){
     char t[12]; int n=0; if(!v){buf[(*o)++]='0';return;}
@@ -72,6 +73,8 @@ int main(int argc, char **argv)
     unsigned done_at = 0;
     int autologin_on = 0;
     int shown_step = -1;   /* drives auto-focus of the first field per step */
+    char root_pw2[128] = {0}, user_pw2[128] = {0};   /* password confirmations */
+    const char *acct_err = 0;
 
     while (!c.closed) {
         mx_pump(&c);
@@ -89,7 +92,7 @@ int main(int argc, char **argv)
          * nowhere.  On entering a step, focus its first input (always widget id
          * 1 here -- listbox / textbox / first password).  Tab cycles fields. */
         if (step != shown_step) { u.focus = 1; shown_step = step; }
-        if (key == '\t') { u.focus = u.focus + 1; if (u.focus > 3) u.focus = 1; }
+        if (key == '\t') { u.focus = u.focus + 1; if (u.focus > 5) u.focus = 1; }
         int by = H - 38, bnext = W - 104, bback = 14;
         int x = 20, y = 46;
 
@@ -134,23 +137,32 @@ int main(int argc, char **argv)
             if (ui_button(&u,s,bnext,by,90,26,"Next >")) step = ST_ACCT;
         }
         else if (step == ST_ACCT) {
-            gfx_str(s, x, y,    "Root password:", COL_TEXT);
-            ui_password(&u, s, x+150, y, 200, 24, p.root_pw, sizeof p.root_pw);
-            gfx_str(s, x, y+34, "New user (optional):", COL_TEXT);
-            ui_textbox(&u, s, x+150, y+34, 200, 24, p.user_name, sizeof p.user_name);
-            gfx_str(s, x, y+68, "User password:", COL_TEXT);
-            ui_password(&u, s, x+150, y+68, 200, 24, p.user_pw, sizeof p.user_pw);
-            if (ui_button(&u,s,x,y+104,210,26, autologin_on ? "[x] auto-login on boot" : "[ ] auto-login on boot"))
+            int yy = y, fx = x + 170, fw = 180;
+            gfx_str(s, x, yy+4, "Root password:",    COL_TEXT); ui_password(&u, s, fx, yy, fw, 22, p.root_pw,   sizeof p.root_pw);   yy += 28;
+            gfx_str(s, x, yy+4, "Confirm:",           COL_TEXT); ui_password(&u, s, fx, yy, fw, 22, root_pw2,    sizeof root_pw2);    yy += 34;
+            gfx_str(s, x, yy+4, "New user (opt'l):",  COL_TEXT); ui_textbox (&u, s, fx, yy, fw, 22, p.user_name, sizeof p.user_name); yy += 28;
+            gfx_str(s, x, yy+4, "User password:",     COL_TEXT); ui_password(&u, s, fx, yy, fw, 22, p.user_pw,   sizeof p.user_pw);   yy += 28;
+            gfx_str(s, x, yy+4, "Confirm:",           COL_TEXT); ui_password(&u, s, fx, yy, fw, 22, user_pw2,    sizeof user_pw2);    yy += 34;
+            if (ui_button(&u,s,x,yy,210,24, autologin_on ? "[x] auto-login on boot" : "[ ] auto-login on boot"))
                 autologin_on = !autologin_on;
-            if (ui_button(&u,s,bback,by,90,26,"< Back")) step = ST_HOST;
+            if (acct_err) gfx_str(s, x, by-18, acct_err, COL_WARN);
+            if (ui_button(&u,s,bback,by,90,26,"< Back")) { acct_err = 0; step = ST_HOST; }
             if (ui_button(&u,s,bnext,by,90,26,"Next >")) {
-                /* Prefer the new user for auto-login, else root. */
-                p.autologin[0]=0;
-                if (autologin_on) {
-                    if (p.user_name[0] && p.user_pw[0]) scpy(p.autologin, p.user_name, sizeof p.autologin);
-                    else if (p.root_pw[0])              scpy(p.autologin, "root", sizeof p.autologin);
+                /* Passwords must be confirmed (typed twice). */
+                if (!seq(p.root_pw, root_pw2)) {
+                    acct_err = "Root passwords do not match.";
+                } else if (p.user_name[0] && !seq(p.user_pw, user_pw2)) {
+                    acct_err = "User passwords do not match.";
+                } else {
+                    acct_err = 0;
+                    /* Prefer the new user for auto-login, else root. */
+                    p.autologin[0]=0;
+                    if (autologin_on) {
+                        if (p.user_name[0] && p.user_pw[0]) scpy(p.autologin, p.user_name, sizeof p.autologin);
+                        else if (p.root_pw[0])              scpy(p.autologin, "root", sizeof p.autologin);
+                    }
+                    step = ST_CONFIRM;
                 }
-                step = ST_CONFIRM;
             }
         }
         else if (step == ST_CONFIRM) {

--- a/src/userspace/wm.c
+++ b/src/userspace/wm.c
@@ -74,6 +74,7 @@ typedef struct {
     int          x, y, w, h;    /* outer rect                              */
     int          minimized, maximized;
     int          resizable;     /* MX_F_RESIZABLE: re-flow (blit 1:1) vs scale */
+    int          rawkeys;       /* MX_F_RAWKEYS: wants make/break scancodes     */
     int          sx, sy, sw, sh;/* geometry saved before maximise          */
     char         title[40];
     mxev         ev[EVQ]; int eh, et;     /* per-window event queue        */
@@ -148,6 +149,14 @@ static void set_focus(int i)
     g_dirty=1; damage_full();   /* both borders recolour: simplest to repaint all */
 }
 static void refocus(void){ set_focus(z_topmost()); }
+
+/* Keyboard delivery mode.  The server reads keys with sys_read(0): cooked bytes
+ * (0) normally, raw set-1 scancodes (2) while a MX_F_RAWKEYS client (doom) holds
+ * focus -- the kernel keeps the mode per focused-task slot, so this is just the
+ * server telling the kernel which stream it wants.  Tracked so we only issue the
+ * syscall on a transition.  Modals (login/power/passwd) force cooked. */
+static int s_kbd_mode = 0;
+static void kbd_mode(int m){ if (m != s_kbd_mode){ sys_keyboard_raw(m); s_kbd_mode = m; } }
 
 /* free a window slot whose client has gone (reaped) or been told to close */
 static void win_free(int i)
@@ -277,6 +286,7 @@ static void serve_requests(void)
             } else {
                 W[i].sid=sid; W[i].surf.px=(gfx_u32*)base; W[i].surf.w=w; W[i].surf.h=h; W[i].sw=w; W[i].sh=h;
                 W[i].resizable = (flags & MX_F_RESIZABLE) ? 1 : 0;
+                W[i].rawkeys   = (flags & MX_F_RAWKEYS)   ? 1 : 0;
                 r.data[0]=(unsigned)i; r.data[1]=(unsigned)sid;
                 z_raise(i); set_focus(i); g_dirty=1; damage_full();
                 /* A resizable client re-flows to fill: ask it to size its surface
@@ -720,6 +730,7 @@ static int fstest(void)
 static void do_login(const char *prefill_user)
 {
     char user[64]={0}, pass[64]={0}, err[40]={0};
+    kbd_mode(0);                 /* modal needs cooked bytes, not scancodes */
     if (prefill_user && prefill_user[0]) scpy(user, prefill_user, sizeof user);
     int cx=(int)FBW/2, cy=(int)FBH/2, prev_left=0, dirty=1;
     ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
@@ -775,6 +786,7 @@ enum { PWR_NONE=0, PWR_CANCEL, PWR_LOGOUT_GUI, PWR_LOGOUT_SHELL,
 static int show_power_menu(int cx, int cy)
 {
     int prev_left=0, dirty=1;
+    kbd_mode(0);                 /* modal needs cooked bytes, not scancodes */
     ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
 
     static const char *labels[6]={
@@ -823,6 +835,7 @@ static void show_passwd_dialog(int cx, int cy)
 {
     char oldp[64]={0}, newp[64]={0}, conf[64]={0}, err[48]={0};
     int prev_left=0, dirty=1;
+    kbd_mode(0);                 /* modal needs cooked bytes, not scancodes */
     ui_ctx u; for(unsigned i=0;i<sizeof u/sizeof(int);i++) ((int*)&u)[i]=0;
     u.focus=1;
 
@@ -928,6 +941,9 @@ int main(int argc, char **argv, char **envp)
         }
         int mdown=prev_left;
         int frame_key=-1;
+        /* Match the keyboard stream to the focused client: a MX_F_RAWKEYS game
+         * gets the raw make/break scancode stream, everyone else cooked bytes. */
+        kbd_mode((focus>=0 && W[focus].in_use && W[focus].rawkeys) ? 2 : 0);
         /* A key only changes the screen via the focused client's repaint (which
          * damages its own window); the WM chrome doesn't render keys, so this
          * doesn't dirty the scene by itself. */
@@ -1068,6 +1084,7 @@ int main(int argc, char **argv, char **envp)
      * and we reap it with WNOHANG.  Keep servicing IPC + reaping in a bounded
      * spin; SIGKILL + non-blocking reap any straggler that ignored CLOSE (it is
      * no longer IPC-blocked once we stop replying, so SIGKILL can land). */
+    kbd_mode(0);   /* hand the keyboard back cooked, whatever had focus */
     for(int i=0;i<MAXWIN;i++) if(W[i].in_use) win_push(&W[i],MXEV_CLOSE,0,0,0);
     for(int spin=0; spin<4000; spin++){
         ipc_msg_t m; int budget=4*MAXWIN;


### PR DESCRIPTION
First slice of the **Linux-ification** track (WWLD — *what would Linux do?*). No
behavioural risk to the tested QEMU BIOS+IDE+PS/2 path: the locking is a no-op
while syscalls are still serialized, and the memory changes only make existing
allocations lazy. Two user-visible bugs fixed (windowed DOOM input + the
load-time freeze); the rest is gateable groundwork for preemptive syscalls.

## Memory management
- **Demand-paged `brk` + anonymous `mmap`** (`c54406d`). `SYS_BRK`/`SYS_MMAP2`
  now only *reserve* the range; the page-fault handler maps zeroed frames on
  first touch (`try_handle_anon_fault`, ahead of the COW check). A multi-MiB
  `malloc` is O(1) in the syscall instead of mapping ~1500 pages in one
  interrupts-off loop — this is what fixed *"the mouse freezes while DOOM says
  Starting…"*. `task_t` gains `user_brk_base` (set at exec, inherited on fork).

## Preemptive-multitasking groundwork (no global \`sti\` flip yet)
- **Recursive FS big-lock** scoped to disk backends (`ae645a3`, `0a322fd`,
  `470de68`), reentrant readdir/stdin scratch (`b544ba4`), serialized `execve`
  argv scratch (`3b11c49`), and the installer no longer holds the FS lock across
  a stepped copy (`a42b240`).
- **IRQ-guarded the task pool + PMM** (`2bce623`): `task_create`/`task_fork`
  slot-claim/run-list relink and the PMM buddy allocator are now `cli`-guarded,
  matching the already-guarded `schedule()`, `task_exit` and kernel heap. These
  are no-ops today and become load-bearing the moment `sti` is flipped. The
  remaining prerequisite for that flip is an lwIP net lock + fork/exec stress
  testing.

## GUI / input
- **Windowed DOOM gets real make/break keys** (`fab035c`) via a new
  `MX_F_RAWKEYS` HELLO flag: while a raw-keys client holds focus the WM switches
  the keyboard to scancode-passthrough and forwards the make/break stream as
  `MXEV_KEY`, restoring cooked mode on focus loss / modals / teardown. Removes
  the old timeout-based synthesized-release hack. `Ctrl-Alt-Del` detection moved
  ahead of the passthrough so it still escapes a focused game.
- **mxinstall password confirmation** (`43ddc0c`): new-user/root passwords typed
  twice before installing.

## Docs
`internals.md` (page-fault order, lazy brk/mmap, refreshed scheduler/preemption
model), `syscalls.md` (BRK/MMAP2 lazy semantics), `gui.md` (HELLO flags +
cooked-vs-raw keyboard).

## Testing
All gates green on every commit: \`./run.sh ktest\` (885/0), \`./run.sh iso test\`
(alloctest + libc-tcc + shell-smoke + GDB checkpoints), \`./run.sh guitest\`
(GUI: READY). Windowed DOOM input + load-time smoothness confirmed interactively.