### PR TITLE
Release 0.10.5

### DIFF
--- a/.claude/skills/makar-conventions/SKILL.md
+++ b/.claude/skills/makar-conventions/SKILL.md
@@ -11,7 +11,7 @@ generic defaults. `CLAUDE.md` is the index — read it and the `docs/` it points
 to before non-trivial work. The fuller human-facing version of this checklist is
 **`docs/conventions.md`** — keep the two in sync.
 
-## Golden rule — What Would Linux Do?
+## Golden rule — default to the Linux convention
 When a design or hardware detail is ambiguous, default to the **Linux**
 convention (syscall ABI, driver shape, ACPI/HID/AHCI layout, single-user mode,
 ANSI/VT100, USER_HZ, block layer). Lean on documented references (Linux source,

--- a/CLAUDE.history.md
+++ b/CLAUDE.history.md
@@ -4,7 +4,7 @@ Companion to `CLAUDE.md`. Snapshot of subsystem state, recently-merged PRs, and 
 attribution. Consult for "what's already shipped" / "what does subsystem X do today"
 context; not needed for routine edits.
 
-## Current state (as of May 2026, v0.9.0)
+## Current state (as of June 2026, v0.10.5)
 
 **Kernel self-host milestone (v0.9)**: `./build-kernel-tcc.sh` (host) rebuilds
 the bootable Multiboot 2 kernel ELF end-to-end against the vendored source

--- a/CLAUDE.roadmap.md
+++ b/CLAUDE.roadmap.md
@@ -45,8 +45,9 @@ PRs** (it grew too big for one):
   with on-demand I/O, 64 MiB is plenty (FreeDOOM runs on DOS in <16 MiB).
 
 Longer-term, separately: a self-hosted OSDev toolchain toward **x86_64** (see
-"OS-specific cross toolchain" below), then possibly a **microkernel** evolution
-(the IPC + makx server/client split are the groundwork).
+"OS-specific cross toolchain" below), then a **hybrid / microkernel** evolution in
+the NT/XNU mould (the IPC + makx server/client split are the groundwork — lift
+display/FS/net out of the kernel behind IPC while keeping hot paths in-core).
 
 ### makx GUI follow-ups (after the server/client split)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ implementation stacks.
 This README is an entry point, not the manual. Current implementation detail
 lives in [`docs/`](docs/) and in the source.
 
-Current kernel version: `0.10.0`
+Current kernel version: `0.10.5`
 ([`src/kernel/include/kernel/version.h`](src/kernel/include/kernel/version.h)).
 
 ## Screenshots

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -19,7 +19,7 @@ cross-compiler required.
 
 ---
 
-## 1. Golden rule — *What Would Linux Do?*
+## 1. Golden rule — default to the Linux convention
 
 When a design or hardware detail is ambiguous, default to the **Linux**
 convention: the syscall ABI (`int 0x80`, i386 numbers), driver shape, ACPI / HID
@@ -27,8 +27,7 @@ convention: the syscall ABI (`int 0x80`, i386 numbers), driver shape, ACPI / HID
 block layer, `/proc` + `/dev` + `/usr` paths, dotfile names. Prefer documented
 references — the Linux source, the OSDev wiki, public-domain libraries
 (stb_image, miniz/zlib, doomgeneric) — over hand-rolling. When you follow a
-Linux convention in a non-obvious spot, say so in a comment; **do not** write
-"WWLD" in code or docs.
+Linux convention in a non-obvious spot, just say so plainly in a comment.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ C# / Cosmos counterpart. The two share a command vocabulary,
 filesystem layout, and long-term binary-format goals while exploring
 how language choice shapes the implementation.
 
-**Current version:** 0.10.0 (kernel self-host milestone; see
+**Current version:** 0.10.5 (kernel self-host milestone; see
 [`include/kernel/version.h`](https://github.com/Arawn-Davies/makar/blob/main/src/kernel/include/kernel/version.h)
 and [kernel rebuild guide](rebuild-kernel.md)).
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -819,7 +819,7 @@ It compiles C to a static `ET_EXEC` ELF on disk — no fork, no JIT, no
 `mmap(PROT_EXEC)`. The workflow is CP/M-style: boot → write source in VIX →
 `tcc hello.c -o hello.elf` → `exec hello.elf`.
 
-**Current state (May 2026, v0.9):** all original phases shipped, and
+**Current state (June 2026, v0.10.5):** all original phases shipped, and
 self-hosting now covers the kernel itself.  `tcc.elf` ships on every ISO,
 userspace apps (`hello`, `calc`, `sh`, `makbox`) self-rebuild in-OS, and
 the bootable Multiboot 2 kernel ELF rebuilds end-to-end with our shipped

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,6 +208,18 @@ These are not near-term commitments:
 Each of these is large enough to require a clear user-facing reason before
 implementation.
 
+### Architectural direction — toward a hybrid / microkernel
+
+Longer term, Makar is heading toward a **hybrid / microkernel** architecture in
+the NT/XNU mould, rather than staying a pure monolith. The groundwork is already
+in place: the kernel IPC primitives and the **makx** server/client split (the
+window server, login, and apps as separate ring-3 clients talking over shared
+surfaces) are exactly the seams a hybrid kernel pushes out of the privileged
+core. The realistic order is: finish the OS-specific cross toolchain and the
+**x86-64** port first, then progressively lift services (display, FS, net) out of
+the kernel behind IPC — a hybrid that keeps the hot paths in-kernel while the
+rest run as user-space servers.
+
 ## Release Quality Bar
 
 For any major branch:

--- a/src/kernel/arch/i386/debug/debug.c
+++ b/src/kernel/arch/i386/debug/debug.c
@@ -966,7 +966,7 @@ static void gpf_handler(registers_t *regs)
 /* Demand-paging handler (lazy brk + anonymous mmap).
  *
  * SYS_BRK and SYS_MMAP2 only *reserve* address ranges; the actual frames are
- * mapped here on first touch -- the WWLD model (Linux brk/anon-mmap are lazy).
+ * mapped here on first touch -- the Linux model (brk/anon-mmap are lazy).
  * This keeps a multi-MiB allocation (doom's 6 MiB zone) from mapping every
  * page in one interrupts-off syscall and stalling the whole system.
  *

--- a/src/kernel/arch/i386/drivers/usb/usb.c
+++ b/src/kernel/arch/i386/drivers/usb/usb.c
@@ -21,7 +21,7 @@
  * tied to PS/2.  A USB HCI + enumeration driver (the next slice) will SET_PROTO
  * (boot), poll the interrupt-IN endpoint, and hand each report here.  Until the
  * HCI lands these are exercised only by the boilerplate; PS/2 stays the live
- * source.  (WWLD: usbcore + hid-generic boot protocol routed into the shared
+ * source.  (Linux-style: usbcore + hid-generic boot protocol routed into the shared
  * input layer.) */
 
 /* HID boot mouse: byte0 buttons (b0 L, b1 R, b2 M), byte1 dx, byte2 dy (both

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -278,7 +278,7 @@ volatile uint32_t g_ring3_last_cp = 0;
  * too-small buffer -- e.g. one handed across a racing runtime mode switch,
  * before the WM has reallocated it for the new geometry -- would otherwise make
  * the kernel read past the mapping and take a ring-0 page fault, which panics.
- * A bad pointer from userspace must instead fail the syscall (WWLD: -EFAULT,
+ * A bad pointer from userspace must instead fail the syscall (Linux: -EFAULT,
  * never take the kernel down).  Walks the PD the same way the COW/#PF handler
  * does (page tables live in the low identity map).  Returns 1 if the whole
  * range is safe to read, 0 otherwise. */
@@ -1325,7 +1325,7 @@ static void syscall_dispatch_inner(registers_t *regs)
             vfs_stat_info_t si;
             int have_stat = (vfs_stat(path, &si) == 0);
 
-            /* Lazy read-only path (WWLD): a read-only open on a seekable disk
+            /* Lazy read-only path (Linux-style): a read-only open on a seekable disk
              * backend is *not* eager-loaded.  We record the size and stream the
              * file a page at a time through the kernel page cache on each read
              * (see SYS_READ) -- so opening a 29 MiB WAD costs ~0 heap instead of
@@ -1524,7 +1524,7 @@ static void syscall_dispatch_inner(registers_t *regs)
             break;
         }
 
-        /* Demand-paged heap (WWLD: Linux brk only reserves; pages are mapped
+        /* Demand-paged heap (Linux brk only reserves; pages are mapped
          * lazily on first touch).  Just advance the break -- the page-fault
          * handler maps a zeroed frame for any access in [user_brk_base,
          * user_brk).  This keeps a multi-MiB growth (e.g. doom's 6 MiB zone)
@@ -1567,7 +1567,7 @@ static void syscall_dispatch_inner(registers_t *regs)
 
         /* Demand-paged anonymous mmap: reserve the window only; the page-fault
          * handler maps a zeroed frame on first touch in [USER_MMAP_BASE,
-         * mmap_next).  Same WWLD lazy model as brk above. */
+         * mmap_next).  Same lazy model as brk above. */
         t->mmap_next = base + (pages << 12);
         regs->eax = base;
         break;

--- a/src/kernel/include/kernel/pagecache.h
+++ b/src/kernel/include/kernel/pagecache.h
@@ -8,7 +8,7 @@
  *
  * Sits under SYS_READ for lazily-opened read-only files: instead of eager-
  * loading a whole file into a kmalloc'd buffer at open(), the file is streamed
- * a page at a time through this cache (WWLD -- Linux's page cache).  Misses are
+ * a page at a time through this cache (like Linux's page cache).  Misses are
  * filled via vfs_read_at(); hits avoid the disk entirely.
  *
  * Backing store is a fixed static pool (bounded footprint, self-evicting LRU),

--- a/src/kernel/include/kernel/version.h
+++ b/src/kernel/include/kernel/version.h
@@ -28,7 +28,7 @@
  *         consolidated into one source of truth; hypervisor detection +
  *         per-platform fixes (Hyper-V mouse, VMware/Hyper-V 720p, ACPI soft-off);
  *         windowed clients re-flow on resize. */
-#define MAKAR_VERSION "0.10.0"
+#define MAKAR_VERSION "0.10.5"
 /* 0.9 -- ring-3 shell driving the makx desktop session (GUI login hand-off,
  *        focus-gain prompt rebuild, autostart). */
 #define SHELL_VERSION "0.9.0"

--- a/src/userspace/files.c
+++ b/src/userspace/files.c
@@ -1,6 +1,6 @@
 /* files.elf -- minimal fullscreen file browser (ring-3, freestanding).
  *
- * WWLD: a Midnight-Commander-lite list pane.  Arrow up/down to move, Enter to
+ * A Midnight-Commander-lite list pane.  Arrow up/down to move, Enter to
  * descend into a directory, Backspace for the parent, q/Esc to quit.  Launched
  * fullscreen from the shell or the gui "Files" icon (execve).  PoC: list +
  * navigate only (no copy/delete/open-file yet).

--- a/src/userspace/sh.c
+++ b/src/userspace/sh.c
@@ -967,7 +967,7 @@ static int run_builtin(int argc, char **argv, int *should_exit, int *exit_status
          * inside the GUI terminal (mxterm) -- our stdout is a pipe there.  Both
          * the kernel VT parser (vt.c) and mxterm's vt100 honour \033[2J\033[H,
          * so this clears correctly in the classic shell AND the GUI terminal.
-         * WWLD: this is exactly what terminfo's `clear` capability emits. */
+         * This is exactly what terminfo's `clear` capability emits. */
         put_s("\033[2J\033[H"); g_last_status = 0; return 1;
     }
     if (s_eq(argv[0], "exec")) {


### PR DESCRIPTION
## Release 0.10.5

Release-prep PR off `main`:

- **Version → `0.10.5`** — `MAKAR_VERSION` in `version.h` (the single source of
  truth for the boot banner, the `version` builtin, and `/proc/uname`), plus the
  README, `docs/index.md`, and the "current state" markers.
- **WWLD purge** — the "What Would Linux Do?" / "WWLD" shorthand is removed from
  the published conventions page, the `makar-conventions` skill, and all 9 code
  comments; the principle ("default to the Linux convention") stays.
- **Roadmap** — note the future **hybrid / microkernel** direction (NT/XNU mould;
  the kernel IPC + the makx server/client split are the groundwork) in
  `docs/roadmap.md` and `CLAUDE.roadmap.md`.

A version string, docs, and comment rewords only — no behaviour change; CI builds it.
