### PR TITLE
Self-hosted musl dynamic linking + page-cache-backed shared file mmap

### DIFF
--- a/docs/posix.md
+++ b/docs/posix.md
@@ -90,8 +90,8 @@ location during live boots.
 | Feature | Status | Notes |
 |---|---|---|
 | `brk` | Present | Main heap-growth mechanism for the userspace malloc shim. |
-| `mmap2` | Anonymous + file-backed | Anon non-fixed = demand-paged bump window at `0x90000000`; a real `fd` or `MAP_FIXED` eager-maps (file region read into private frames, bss tail zeroed). Backs musl `ld.so`'s library maps. |
-| `munmap` | Present | Unmaps the range; address reuse is not implemented. |
+| `mmap2` | Anonymous + file-backed (RO shared) | Anon non-fixed = demand-paged bump window at `0x90000000`. A **read-only** file map shares frames from the page cache (`pagecache_acquire`), so libc.so's text/rodata is one copy in RAM across all mappers; writable/tmpfs file maps and anon-fixed take a private frame. Backs musl `ld.so`'s library maps. |
+| `munmap` | Present | Unmaps the range and releases each frame (`vmm_unmap_and_free`, refcount-decrement — shared cache frames survive while others map them). Address reuse within the bump window is not implemented. |
 | `MAP_FIXED` | Present | Maps at the caller's exact address, replacing any existing mapping in that window. |
 | `mprotect` | Present | `SYS_MPROTECT` (125) rewrites PTE R/W/USER over the range (`ld.so` RELRO). i386 non-PAE has no NX, so X is implicit. |
 | executable mmap/JIT | Unsupported | TCC compiles to files and `exec`s them; `tcc -run` is not the supported model. |

--- a/docs/posix.md
+++ b/docs/posix.md
@@ -29,6 +29,8 @@ Makar currently supports:
 - UTC time APIs
 - x87/SSE FPU state saved/restored per task
 - one-slot i386 TLS through `set_thread_area`
+- dynamically-linked PIEs against a shared musl `libc.so`, loaded by musl's own
+  interpreter `ld-musl-i386.so.1` (`ET_DYN` + `PT_INTERP` + full auxv)
 - a userspace shell with pipes, redirection, list operators, background jobs,
   `wait`, quoting, and `sh -c`
 
@@ -38,8 +40,8 @@ It does not currently support:
 - process groups, sessions, or job-control terminal ownership
 - pthreads or clone-style user threads
 - networking or sockets
-- dynamic linking
-- file-backed mmap, `mprotect`, or a supported JIT execution model
+- a supported in-place JIT (`tcc -run`-style) execution model — TCC compiles to
+  files and `exec`s them instead
 - complete Linux signal-mask semantics
 - `select`, `poll`, or another fd readiness API
 - a termios-compatible terminal interface
@@ -88,11 +90,10 @@ location during live boots.
 | Feature | Status | Notes |
 |---|---|---|
 | `brk` | Present | Main heap-growth mechanism for the userspace malloc shim. |
-| `mmap2` | Anonymous only | `MAP_ANONYMOUS` mappings in a per-task bump window starting at `0x90000000`. |
+| `mmap2` | Anonymous + file-backed | Anon non-fixed = demand-paged bump window at `0x90000000`; a real `fd` or `MAP_FIXED` eager-maps (file region read into private frames, bss tail zeroed). Backs musl `ld.so`'s library maps. |
 | `munmap` | Present | Unmaps the range; address reuse is not implemented. |
-| file-backed mmap | Absent | Use `read` into a buffer. |
-| `MAP_FIXED` | Rejected | Returns `MAP_FAILED`. |
-| `mprotect` | Absent | No page-protection changing API yet. |
+| `MAP_FIXED` | Present | Maps at the caller's exact address, replacing any existing mapping in that window. |
+| `mprotect` | Present | `SYS_MPROTECT` (125) rewrites PTE R/W/USER over the range (`ld.so` RELRO). i386 non-PAE has no NX, so X is implicit. |
 | executable mmap/JIT | Unsupported | TCC compiles to files and `exec`s them; `tcc -run` is not the supported model. |
 
 Anonymous `mmap` exists because hosted libc allocators, including musl paths,
@@ -144,21 +145,28 @@ library.
 
 ## TLS and Hosted libc Startup
 
-Static i386 musl startup needs a small Linux-compatible substrate. Makar now
-provides:
+Both static and dynamically-linked i386 musl startup need a small
+Linux-compatible substrate. Makar now provides:
 
-- ELF auxv entries: `AT_PAGESZ`, `AT_RANDOM`, `AT_NULL`
+- a full System-V i386 ELF auxv: `AT_PHDR`, `AT_PHENT`, `AT_PHNUM`, `AT_BASE`,
+  `AT_ENTRY`, `AT_EXECFN`, `AT_RANDOM`, `AT_PAGESZ`, `AT_NULL`
 - `set_thread_area(243)` using one GDT TLS slot at selector `0x33`
 - `%gs` preservation across interrupts
 - scheduler TLS restore for TLS-active tasks
+- `writev` (musl's buffered stdio writes through it)
 - `exit_group`
 - `set_tid_address`
 - `rt_sigprocmask` stub
 - `ioctl` returning `-ENOTTY`
 - `futex` stub for the current single-threaded bring-up assumption
 
+For **dynamic** linking the loader additionally honours `PT_INTERP`
+(`/lib/ld-musl-i386.so.1`, == `libc.so`), enters at the interpreter, and the
+kernel services musl's `ld.so` runtime: file-backed/`MAP_FIXED` `mmap2`,
+`mprotect` (RELRO), and `open` returning `-ENOENT` so the library search walks.
+
 These are compatibility pieces, not full Linux implementations. They exist to
-get static hosted binaries through early libc initialization.
+get hosted binaries through early libc initialization and dynamic relocation.
 
 ## Userspace libc Headers
 

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -54,7 +54,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 2 | `SYS_FORK` | none | COW fork; parent gets child pid, child gets 0 |
 | 3 | `SYS_READ` | `fd, buf, len` | fd-backed read |
 | 4 | `SYS_WRITE` | `fd, buf, len` | fd-backed write |
-| 5 | `SYS_OPEN` | `path, flags, mode` | mode ignored; read-only disk files are lazy (page-cached) |
+| 5 | `SYS_OPEN` | `path, flags, mode` | mode ignored; read-only disk files are lazy (page-cached); missing file w/o `O_CREAT` → `-ENOENT` (musl `ld.so` walks its search path on this) |
 | 6 | `SYS_CLOSE` | `fd` | closes and flushes |
 | 10 | `SYS_UNLINK` | `path` | delete file |
 | 11 | `SYS_EXECVE` | `path, argv, envp` | envp ignored |
@@ -82,8 +82,9 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 141 | `SYS_READDIR` | `path, index, dirent *` | indexed Makar syscall, libc wraps it |
 | 146 | `SYS_WRITEV` | `fd, iovec *, iovcnt` | gather-write; shares the `SYS_WRITE` dispatch. musl's buffered stdio writes through this |
 | 158 | `SYS_YIELD` | none | scheduler yield |
+| 125 | `SYS_MPROTECT` | `addr, len, prot` | rewrites PTE R/W/USER over the range (`ld.so` RELRO); no NX on i386 |
 | 175 | `SYS_RT_SIGPROCMASK` | Linux args | startup compatibility stub |
-| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anonymous only, demand-paged |
+| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anon non-fixed = demand-paged reserve; a real `fd` or `MAP_FIXED` eager-maps (file region read into private frames, bss tail zeroed) — backs musl `ld.so`'s library maps |
 | 240 | `SYS_FUTEX` | Linux args | single-threaded compatibility stub |
 | 243 | `SYS_SET_THREAD_AREA` | `user_desc *` | one-slot i386 TLS |
 | 252 | `SYS_EXIT_GROUP` | `status` | same as exit |

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -74,7 +74,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 63 | `SYS_DUP2` | `oldfd, newfd` | duplicate onto requested fd |
 | 64 | `SYS_GETPPID` | none | parent pid |
 | 78 | `SYS_GETTIMEOFDAY` | `timeval *, tz` | tz ignored |
-| 91 | `SYS_MUNMAP` | `addr, len` | unmap anonymous pages |
+| 91 | `SYS_MUNMAP` | `addr, len` | unmap a range and release each frame (refcount-decrement; shared cache frames survive while others map them) |
 | 106 | `SYS_STAT` | `path, stat *` | limited Linux-shaped stat |
 | 108 | `SYS_FSTAT` | `fd, stat *` | limited Linux-shaped stat |
 | 114 | `SYS_WAIT4` | `pid, status *, options, rusage` | supports `WNOHANG`; rusage ignored |
@@ -84,7 +84,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 158 | `SYS_YIELD` | none | scheduler yield |
 | 125 | `SYS_MPROTECT` | `addr, len, prot` | rewrites PTE R/W/USER over the range (`ld.so` RELRO); no NX on i386 |
 | 175 | `SYS_RT_SIGPROCMASK` | Linux args | startup compatibility stub |
-| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anon non-fixed = demand-paged reserve; a real `fd` or `MAP_FIXED` eager-maps (file region read into private frames, bss tail zeroed) — backs musl `ld.so`'s library maps |
+| 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anon non-fixed = demand-paged reserve; a **read-only** file map shares page-cache frames (`pagecache_acquire` — one libc.so in RAM for all mappers); writable/tmpfs/anon-fixed take a private frame (bss tail zeroed) — backs musl `ld.so`'s library maps |
 | 240 | `SYS_FUTEX` | Linux args | single-threaded compatibility stub |
 | 243 | `SYS_SET_THREAD_AREA` | `user_desc *` | one-slot i386 TLS |
 | 252 | `SYS_EXIT_GROUP` | `status` | same as exit |
@@ -299,24 +299,31 @@ The scheduler restores TLS state for TLS-active tasks.
 
 ## mmap Details
 
-`SYS_MMAP2` is intentionally narrow:
+`SYS_MMAP2` covers the cases the dynamic linker and libc allocators need:
 
-- requires `MAP_ANONYMOUS`
-- rejects `MAP_FIXED`
-- ignores file descriptors and offsets
-- **demand-paged**: only reserves the range (advances a per-task bump pointer);
-  zero-filled frames are mapped on first touch by the page-fault handler, the
-  same lazy model Linux uses. A large mapping therefore costs O(1) in the call
-  rather than mapping every page up front.
+- **anonymous, non-fixed** (malloc's big allocations): **demand-paged** — only
+  reserves the range (advances a per-task bump pointer); zero-filled frames are
+  mapped on first touch by the page-fault handler, the same lazy model Linux
+  uses. A large mapping costs O(1) in the call rather than mapping every page.
+- **file-backed, read-only**: pages are shared straight from the page cache
+  (`pagecache_acquire`), so a file mapped by many processes — libc.so above all
+  — is **one physical copy in RAM**. This is the Linux page-cache model and what
+  makes dynamic linking a memory win rather than a per-process cost.
+- **file-backed, writable / tmpfs-backed**, and **`MAP_FIXED`**: eager — a
+  private frame per page (file region read in, bss tail zeroed), mapped at the
+  caller's exact address for `MAP_FIXED`. musl's `ld.so` uses `MAP_FIXED` to
+  overlay each library segment onto its whole-library reserve.
 - returns `MAP_FAILED` (`(void *)-1`) on unsupported requests
 
 `SYS_BRK` is likewise lazy: growing the break only advances `user_brk`; pages in
 `[user_brk_base, user_brk)` fault in zeroed on first touch. (Query/shrink-to
 forms behave as before; the break only ever grows.)
 
-`SYS_MUNMAP` unmaps pages but does not currently recycle virtual addresses.
-Because the mmap window is a grow-only bump arena, touching a munmap'd address
-below `mmap_next` simply re-faults a fresh zero page rather than `SIGSEGV`-ing —
+`SYS_MUNMAP` clears each PTE and releases its frame (`vmm_unmap_and_free`, a
+refcount decrement — a shared page-cache frame survives while other processes
+still map it). It does not currently recycle *virtual* addresses: because the
+mmap window is a grow-only bump arena, touching a munmap'd address below
+`mmap_next` simply re-faults a fresh zero page rather than `SIGSEGV`-ing —
 acceptable for the current bring-up (no address reuse).
 
 ## Compatibility Stubs

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -80,6 +80,7 @@ without a detailed errno. Check the wrapper before assuming Linux parity.
 | 114 | `SYS_WAIT4` | `pid, status *, options, rusage` | supports `WNOHANG`; rusage ignored |
 | 119 | `SYS_SIGRETURN` | internal | signal trampoline return |
 | 141 | `SYS_READDIR` | `path, index, dirent *` | indexed Makar syscall, libc wraps it |
+| 146 | `SYS_WRITEV` | `fd, iovec *, iovcnt` | gather-write; shares the `SYS_WRITE` dispatch. musl's buffered stdio writes through this |
 | 158 | `SYS_YIELD` | none | scheduler yield |
 | 175 | `SYS_RT_SIGPROCMASK` | Linux args | startup compatibility stub |
 | 192 | `SYS_MMAP2` | `addr, len, prot, flags, fd, pgoff` | anonymous only, demand-paged |

--- a/progress.md
+++ b/progress.md
@@ -82,8 +82,30 @@ Last reordered 2026-06-09 (after PR #204 merged).
   - [ ] **T51.3 — strip the in-kernel HTTP/TLS** now that ring 3 owns it: remove `SYS_WGET` + `cmd_wget` + `wget_fetch`/`wget_tls` from `shell_cmd_net.c`, and `libbearssl.a` from the kernel image (make.config / `Makefile`). End state: kernel = TCP/IP + sockets only (empties the http + TLS boxes in `krnlsepr.md`).
 - [ ] **T49** — SSH over the NIC, on the T51 crypto layer. **Target: a Dropbear port** (lightweight, self-contained crypto/SSH); needs the userspace TCP sockets + a pty path.
 
-### Self-hosted toolchain (after HTTPS; unblocks hosted ports)
-- [ ] **T53** — A proper **`i686-makar`** OS-specific cross toolchain (per the OSDev *OS-Specific-Toolchain* / *Hosted-GCC* / *Creating-a-C-Library* pages): patch binutils + GCC (`config.sub` / `config.gcc` / `makar.h`) for an `i686-makar` target and **port newlib** as the libc with Makar syscall stubs + a sysroot. **Decided** over the existing `i686-linux-musl` shortcut (which already builds Makar-runnable ELFs via the Linux-i386 ABI — see `toolchain/`) and over an own-libc. Big multi-session slice; the foundation for hosted ports (lynx, dash, Dropbear).
+### Self-hosted musl libc + dynamic linking (EPIC, ACTIVE — branch `feat/dynamic-libc`)
+Ship **musl as a shared `libc.so`** and run **dynamically-linked** programs, using
+musl's own dynamic linker (`ld-musl-i386.so.1`).  Reuses the existing host musl
+cross-toolchain in `toolchain/` (already produces `libc.so` + the interpreter +
+PIE startfiles).  Scope: capability + demo; the ~50 in-tree apps stay static.
+Chosen over newlib / an own-libc / an own dynamic linker.  Plan:
+`~/.claude/plans/melodic-honking-river.md`.
+- [x] **Phase 0 — static musl runs in-OS.** A real static-musl `hello`
+  (`toolchain/test/hello.c`, staged via `toolchain/build-musl-demos.sh` as
+  `/apps/muslhello.elf`, linked at `0x40000000`) executes end-to-end: musl
+  startup (auxv walk, `set_thread_area` TLS, `futex` locks), `argc` plumbing,
+  `printf`/`fprintf`, buffered-stdout flush on `exit()`, clean exit 0.  Found +
+  fixed the blocker: **`SYS_WRITEV` (146) was unimplemented** — musl's stdio
+  writes through `writev`, so all libc output was silently dropped.  Implemented
+  it sharing one `syscall_fd_write` dispatch with `SYS_WRITE`.  Smoke-gated
+  (`shell-smoke.sh: musl-static`); full gate stays 885/0.
+- [ ] **Phase 1** — dynamic build path (PIE, `PT_INTERP`) + stage `libc.so` +
+  `ld-musl-i386.so.1` into the ISO (`/lib`).
+- [ ] **Phase 2** — kernel: file-backed `mmap` (`MAP_PRIVATE`/`MAP_FIXED`) +
+  `mprotect` (`SYS_MPROTECT 125`).
+- [ ] **Phase 3** — kernel ELF loader: `ET_DYN`/PIE + `PT_INTERP` + full auxv
+  (`AT_PHDR`/`AT_BASE`/`AT_ENTRY`…), enter at the interpreter.
+- [ ] **Phase 4/5** — run `muslhellodyn.elf` dynamically; errno-negative pass for
+  the ldso-facing syscalls; docs.
 
 ### Desktop UX (T52) — framework landed, wiring in progress
 - [x] **T52.1 — menu/window framework (PR #205).** `gui_ui` gained **`ui_menubar`** (File/Edit/View/Help bar + dropdowns), **`ui_context_menu`** (right-click popup), **`ui_about`** (modal credits card) — Windows-style: greyed disabled items, separators, right-aligned accelerators, dropdown width sized to the longest label. **`ui_btn_w()`** centralises button-label padding (mxweb toolbar = first adopter). **Double-click a title bar → maximise/restore** (`wm.c`). `LICENCES/` collects every external licence (BearSSL/lwIP/doomgeneric/FreeDoom/TinyCC/Limine/musl) with per-file coverage notes, feeding the About dialogs.

--- a/progress.md
+++ b/progress.md
@@ -125,8 +125,12 @@ Chosen over newlib / an own-libc / an own dynamic linker.  Plan:
   each page with a refcounted PMM frame (`pagecache_acquire`), and a read-only
   file `mmap` maps that shared frame straight in: libc.so's ~700 KiB of
   text/rodata is **one copy in RAM** for every process (writable/data stays
-  private; the Linux page-cache model).  Also fixed a latent leak — `munmap`
-  never freed frames (`vmm_unmap_and_free`).  Proven by the `pagecache_share`
+  private; the Linux page-cache model).  Also fixed two latent teardown bugs:
+  `munmap` never freed frames (`vmm_unmap_and_free`), and `vmm_free_pd`/
+  `vmm_clone_pd_cow` skipped kernel-shared page tables with an *exact* PDE
+  compare that the CPU's async Accessed-bit updates defeated — so teardown could
+  mis-free the framebuffer's kernel PT (the `0x2EA` refcount-underflow warning);
+  now compares the PT frame address only.  Proven by the `pagecache_share`
   ktest (a 2nd mapper of a page allocates **zero** new frames).  Gate 894/0.
   This **unblocks** the userspace static→dynamic migration (was gated on exactly
   this so it wouldn't regress memory on a 32 MiB kernel).

--- a/progress.md
+++ b/progress.md
@@ -119,6 +119,17 @@ Chosen over newlib / an own-libc / an own dynamic linker.  Plan:
   window → relocates → RELRO `mprotect` → `main` prints via `writev`, exit 0
   (`shell-smoke.sh: musl-dynamic`).  `SYS_OPEN` now returns `-ENOENT` (not `-1`)
   on a missing file so `ld.so` can walk its search path.  Full gate 885/0.
+- [x] **Phase 6 — page-cache-backed *shared* file mmap (the RAM win).** Without
+  this, every dynamic process got a *private* ~800 KiB copy of `libc.so` —
+  dynamic linking would *cost* RAM vs the static shim.  Now the page cache backs
+  each page with a refcounted PMM frame (`pagecache_acquire`), and a read-only
+  file `mmap` maps that shared frame straight in: libc.so's ~700 KiB of
+  text/rodata is **one copy in RAM** for every process (writable/data stays
+  private; the Linux page-cache model).  Also fixed a latent leak — `munmap`
+  never freed frames (`vmm_unmap_and_free`).  Proven by the `pagecache_share`
+  ktest (a 2nd mapper of a page allocates **zero** new frames).  Gate 894/0.
+  This **unblocks** the userspace static→dynamic migration (was gated on exactly
+  this so it wouldn't regress memory on a 32 MiB kernel).
 
 ### Desktop UX (T52) — framework landed, wiring in progress
 - [x] **T52.1 — menu/window framework (PR #205).** `gui_ui` gained **`ui_menubar`** (File/Edit/View/Help bar + dropdowns), **`ui_context_menu`** (right-click popup), **`ui_about`** (modal credits card) — Windows-style: greyed disabled items, separators, right-aligned accelerators, dropdown width sized to the longest label. **`ui_btn_w()`** centralises button-label padding (mxweb toolbar = first adopter). **Double-click a title bar → maximise/restore** (`wm.c`). `LICENCES/` collects every external licence (BearSSL/lwIP/doomgeneric/FreeDoom/TinyCC/Limine/musl) with per-file coverage notes, feeding the About dialogs.

--- a/progress.md
+++ b/progress.md
@@ -82,7 +82,7 @@ Last reordered 2026-06-09 (after PR #204 merged).
   - [ ] **T51.3 — strip the in-kernel HTTP/TLS** now that ring 3 owns it: remove `SYS_WGET` + `cmd_wget` + `wget_fetch`/`wget_tls` from `shell_cmd_net.c`, and `libbearssl.a` from the kernel image (make.config / `Makefile`). End state: kernel = TCP/IP + sockets only (empties the http + TLS boxes in `krnlsepr.md`).
 - [ ] **T49** — SSH over the NIC, on the T51 crypto layer. **Target: a Dropbear port** (lightweight, self-contained crypto/SSH); needs the userspace TCP sockets + a pty path.
 
-### Self-hosted musl libc + dynamic linking (EPIC, ACTIVE — branch `feat/dynamic-libc`)
+### Self-hosted musl libc + dynamic linking (EPIC, LANDED — branch `feat/dynamic-libc`)
 Ship **musl as a shared `libc.so`** and run **dynamically-linked** programs, using
 musl's own dynamic linker (`ld-musl-i386.so.1`).  Reuses the existing host musl
 cross-toolchain in `toolchain/` (already produces `libc.so` + the interpreter +
@@ -98,14 +98,27 @@ Chosen over newlib / an own-libc / an own dynamic linker.  Plan:
   writes through `writev`, so all libc output was silently dropped.  Implemented
   it sharing one `syscall_fd_write` dispatch with `SYS_WRITE`.  Smoke-gated
   (`shell-smoke.sh: musl-static`); full gate stays 885/0.
-- [ ] **Phase 1** — dynamic build path (PIE, `PT_INTERP`) + stage `libc.so` +
-  `ld-musl-i386.so.1` into the ISO (`/lib`).
-- [ ] **Phase 2** — kernel: file-backed `mmap` (`MAP_PRIVATE`/`MAP_FIXED`) +
-  `mprotect` (`SYS_MPROTECT 125`).
-- [ ] **Phase 3** — kernel ELF loader: `ET_DYN`/PIE + `PT_INTERP` + full auxv
-  (`AT_PHDR`/`AT_BASE`/`AT_ENTRY`…), enter at the interpreter.
-- [ ] **Phase 4/5** — run `muslhellodyn.elf` dynamically; errno-negative pass for
-  the ldso-facing syscalls; docs.
+- [x] **Phase 1 — dynamic build path + musl staged.** `build-musl-demos.sh`
+  links `muslhellodyn.elf` as a PIE (`-pie -fPIE` → `ET_DYN`,
+  `PT_INTERP=/lib/ld-musl-i386.so.1`) and stages `libc.so` + `ld-musl-i386.so.1`
+  into `/lib`.  Wired into `run.sh`'s `_build_iso` (dev-only; skipped in CI / when
+  the host cross-toolchain is absent, so the suite's musl tests then SKIP).
+- [x] **Phase 2 — file-backed `mmap` + `MAP_FIXED` + `mprotect`.** `SYS_MMAP2`
+  (192) now honours a real `fd`: it eager-reads the file region into private
+  frames (zero-filling the bss tail) and maps `MAP_FIXED` at the caller's exact
+  address; anon non-fixed maps keep the demand-paged reserve.  New `SYS_MPROTECT`
+  (125) rewrites PTE R/W/USER bits over a range via `vmm_protect_page` (RELRO).
+- [x] **Phase 3 — dynamic ELF loader.** `elf_exec` runs `ET_DYN` PIEs: load base
+  `0x50000000`, interp (`ld-musl`) at `0x70000000`, a full System-V i386 auxv
+  (`AT_PHDR`/`PHENT`/`PHNUM`/`BASE`/`ENTRY`/`EXECFN`/`RANDOM`/`PAGESZ`), enter at
+  the interpreter.  `AT_PHDR` resolves via the `PT_LOAD` that maps `e_phoff`.  The
+  `ET_EXEC` path is byte-for-byte unchanged (a vestigial `PT_INTERP`, e.g. TCC's
+  `/lib/ld-linux.so.2`, is ignored — only `ET_DYN` consults it).
+- [x] **Phase 4/5 — verified + errno + docs.** `muslhellodyn.elf` runs
+  end-to-end: kernel → `ld-musl` → `mmap`s `libc.so` into the `0x90000000`
+  window → relocates → RELRO `mprotect` → `main` prints via `writev`, exit 0
+  (`shell-smoke.sh: musl-dynamic`).  `SYS_OPEN` now returns `-ENOENT` (not `-1`)
+  on a missing file so `ld.so` can walk its search path.  Full gate 885/0.
 
 ### Desktop UX (T52) — framework landed, wiring in progress
 - [x] **T52.1 — menu/window framework (PR #205).** `gui_ui` gained **`ui_menubar`** (File/Edit/View/Help bar + dropdowns), **`ui_context_menu`** (right-click popup), **`ui_about`** (modal credits card) — Windows-style: greyed disabled items, separators, right-aligned accelerators, dropdown width sized to the longest label. **`ui_btn_w()`** centralises button-label padding (mxweb toolbar = first adopter). **Double-click a title bar → maximise/restore** (`wm.c`). `LICENCES/` collects every external licence (BearSSL/lwIP/doomgeneric/FreeDoom/TinyCC/Limine/musl) with per-file coverage notes, feeding the About dialogs.

--- a/run.sh
+++ b/run.sh
@@ -761,6 +761,13 @@ _build_iso() {
     if [ -z "${CI:-}" ] && [ -f "$REPO_ROOT/getfreedoom.sh" ]; then
         bash "$REPO_ROOT/getfreedoom.sh" || true
     fi
+    # Stage the musl dynamic-linking demos (muslhello.elf + libc.so) into isodir
+    # so the `iso test` musl smoke tests run.  Dev-only: the script self-skips if
+    # the host musl cross-toolchain isn't built, and CI skips it entirely (CI's
+    # ktest job is kernel-only and never runs the shell drivers).
+    if [ -z "${CI:-}" ] && [ -f "$REPO_ROOT/toolchain/build-musl-demos.sh" ]; then
+        bash "$REPO_ROOT/toolchain/build-musl-demos.sh" || true
+    fi
     # Forward KERNEL_ARGS (extra GRUB cmdline, e.g. `kbtest`) into the build
     # container; iso.sh appends it to the interactive menuentry.
     local _kenv=()

--- a/src/kernel/arch/i386/mm/pagecache.c
+++ b/src/kernel/arch/i386/mm/pagecache.c
@@ -1,30 +1,42 @@
 /*
- * pagecache.c -- read-only file page cache (see pagecache.h).
+ * pagecache.c -- file page cache, shared between read() and mmap() (see
+ * pagecache.h).
  *
- * Fixed pool of PC_NPAGES 4 KiB pages in a doubly-linked LRU list (MRU at head,
- * LRU at tail).  Lookup is a linear scan keyed by {path-hash, page index} with a
+ * Fixed pool of PC_NPAGES slots in a doubly-linked LRU list (MRU at head, LRU
+ * at tail).  Lookup is a linear scan keyed by {path-hash, page index} with a
  * full-path tie-break; a miss reuses the LRU tail and fills it via vfs_read_at.
- * An irq lock keeps the list consistent once syscalls run preemptively.
  *
- * Lock order: pagecache lock is taken alone or *before* the VFS disk big-lock
+ * Unlike the original inline-buffer cache, each valid slot now owns a
+ * page-aligned, refcounted PMM frame (`frame`) rather than an inline `data[]`
+ * array.  That is what lets the same physical page back both `read()` (memcpy
+ * out of the frame) and a file `mmap()` (map the frame straight into user space
+ * read-only): pagecache_acquire() bumps the frame's refcount and hands the
+ * phys address to the mmap path, so N processes mapping libc.so share one copy.
+ * The cache keeps its own ref on every valid frame; eviction/invalidation drops
+ * it, and the PMM frees the frame only once the cache and every mapper let go.
+ * This is the Linux page-cache model on a small scale.
+ *
+ * An irq lock keeps the list consistent once syscalls run preemptively.  Lock
+ * order: pagecache lock is taken alone or *before* the VFS disk big-lock
  * (pagecache_read -> vfs_read_at).  Invalidation is invoked from the VFS mutate
  * paths *outside* that lock, so there is no reverse ordering.
  */
 #include <kernel/pagecache.h>
+#include <kernel/pmm.h>
 #include <kernel/vfs.h>
 #include <string.h>
 
 #define PC_PGSZ   PAGECACHE_PGSZ
-#define PC_NPAGES 256u                 /* 256 * 4 KiB = 1 MiB cache */
+#define PC_NPAGES 256u                 /* up to 256 * 4 KiB = 1 MiB of frames */
 
 typedef struct pcpage {
     int            valid;
     uint32_t       hash;               /* hash of path (fast reject)        */
     char           path[VFS_PATH_MAX];
     uint32_t       pidx;               /* page index within the file        */
-    uint32_t       len;                /* valid bytes in data (< PC_PGSZ at EOF) */
+    uint32_t       len;                /* valid bytes in the frame (< PGSZ at EOF) */
+    uint32_t       frame;              /* phys addr of the backing frame (0 = none) */
     struct pcpage *lp, *ln;            /* LRU links (prev=toward MRU)       */
-    uint8_t        data[PC_PGSZ];
 } pcpage_t;
 
 static pcpage_t  s_pages[PC_NPAGES];
@@ -53,6 +65,7 @@ static void pc_init(void)
 {
     for (uint32_t i = 0; i < PC_NPAGES; i++) {
         s_pages[i].valid = 0;
+        s_pages[i].frame = 0;
         s_pages[i].lp = (i == 0) ? 0 : &s_pages[i - 1];
         s_pages[i].ln = (i == PC_NPAGES - 1) ? 0 : &s_pages[i + 1];
     }
@@ -95,7 +108,8 @@ static void pc_touch(pcpage_t *p)
 }
 
 /* Caller holds the pc lock.  Return the page for (path,pidx), filling a miss
- * from disk via vfs_read_at into the recycled LRU tail.  NULL on fill error. */
+ * from disk via vfs_read_at into a refcounted frame on the recycled LRU tail.
+ * NULL on fill / allocation error. */
 static pcpage_t *pc_get(const char *path, uint32_t hash, uint32_t pidx)
 {
     for (pcpage_t *p = s_mru; p; p = p->ln) {
@@ -109,9 +123,29 @@ static pcpage_t *pc_get(const char *path, uint32_t hash, uint32_t pidx)
     /* Miss: recycle the LRU tail. */
     pcpage_t *p = s_lru;
     if (!p) return 0;
-    long got = vfs_read_at(path, pidx * PC_PGSZ, p->data, PC_PGSZ);
-    if (got < 0) { p->valid = 0; return 0; }
 
+    /* Pick a frame to fill.  Reuse the slot's own frame iff nothing else
+     * references it (refcount 1 == just the cache); otherwise a mapper still
+     * holds the previous page's content, so drop the cache's ref (the mapper
+     * keeps it alive) and take a fresh frame. */
+    uint32_t frame = p->frame;
+    if (frame && pmm_ref_count(frame) != 1) {
+        pmm_free_frame(frame);
+        frame = 0;
+    }
+    if (!frame) {
+        frame = pmm_alloc_frame();     /* refcount 1: the cache's own ref */
+        if (!frame) return 0;          /* OOM: leave the slot untouched */
+    }
+
+    long got = vfs_read_at(path, pidx * PC_PGSZ, (void *)frame, PC_PGSZ);
+    if (got < 0) { p->frame = frame; p->valid = 0; return 0; }
+
+    /* Zero the tail past EOF so a whole-frame mmap sees defined bytes. */
+    if ((uint32_t)got < PC_PGSZ)
+        memset((uint8_t *)frame + got, 0, PC_PGSZ - (uint32_t)got);
+
+    p->frame = frame;
     p->valid = 1;
     p->hash  = hash;
     p->pidx  = pidx;
@@ -146,12 +180,32 @@ long pagecache_read(const char *path, uint32_t size,
         if (poff >= p->len) break;                  /* short page = EOF */
         uint32_t chunk = p->len - poff;
         if (chunk > to_read - done) chunk = to_read - done;
-        memcpy(out + done, p->data + poff, chunk);
+        memcpy(out + done, (uint8_t *)p->frame + poff, chunk);
         done += chunk;
         if (p->len < PC_PGSZ) break;                /* last (partial) page */
     }
     pc_irq_restore(fl);
     return (long)done;
+}
+
+uint32_t pagecache_acquire(const char *path, uint32_t size,
+                           uint32_t pidx, uint32_t *out_len)
+{
+    if ((uint64_t)pidx * PC_PGSZ >= size) return 0;     /* page past EOF */
+    uint32_t hash = pc_hash(path);
+
+    uint32_t fl = pc_irq_save();
+    if (!s_inited) pc_init();
+    pcpage_t *p = pc_get(path, hash, pidx);
+    if (!p || !p->frame) { pc_irq_restore(fl); return 0; }
+
+    /* Hand the caller a ref on the frame; it owns it until the mapping is torn
+     * down (pmm_free_frame in vmm_unmap_and_free / vmm_free_pd). */
+    pmm_inc_ref(p->frame);
+    uint32_t frame = p->frame;
+    if (out_len) *out_len = p->len;
+    pc_irq_restore(fl);
+    return frame;
 }
 
 void pagecache_invalidate(const char *path)
@@ -163,6 +217,7 @@ void pagecache_invalidate(const char *path)
             pcpage_t *p = &s_pages[i];
             if (p->valid && p->hash == hash && pc_streq(p->path, path)) {
                 p->valid = 0;
+                if (p->frame) { pmm_free_frame(p->frame); p->frame = 0; }
                 pc_unlink(p);
                 pc_push_back(p);    /* invalidated slot -> recycle it first */
             }
@@ -174,7 +229,10 @@ void pagecache_invalidate(const char *path)
 void pagecache_drop_all(void)
 {
     uint32_t fl = pc_irq_save();
-    for (uint32_t i = 0; i < PC_NPAGES; i++) s_pages[i].valid = 0;
+    for (uint32_t i = 0; i < PC_NPAGES; i++) {
+        if (s_pages[i].frame) { pmm_free_frame(s_pages[i].frame); s_pages[i].frame = 0; }
+        s_pages[i].valid = 0;
+    }
     s_inited = 0;                  /* re-init the LRU list on next use */
     pc_irq_restore(fl);
 }

--- a/src/kernel/arch/i386/mm/vmm.c
+++ b/src/kernel/arch/i386/mm/vmm.c
@@ -71,6 +71,25 @@ void vmm_map_page(uint32_t *pd, uint32_t virt, uint32_t phys, uint32_t flags)
     pt[pti] = (phys & ~0xFFFu) | (flags & 0xFFFu) | PAGE_PRESENT;
 }
 
+/* vmm_protect_page – change the permission bits of an existing mapping while
+ * keeping its physical frame.  No-op if the page isn't mapped.  Backs
+ * mprotect() (musl's dynamic linker re-protects RELRO after relocation).
+ * Flushes the TLB for `virt` (the calling task owns the active address space). */
+void vmm_protect_page(uint32_t *pd, uint32_t virt, uint32_t flags)
+{
+    uint32_t pdi = virt >> 22;
+    uint32_t pti = (virt >> 12) & 0x3FFu;
+
+    if (pd[pdi] & PAGE_LARGE)      return;
+    if (!(pd[pdi] & PAGE_PRESENT)) return;
+    uint32_t *pt = (uint32_t *)(pd[pdi] & ~0xFFFu);
+    if (!(pt[pti] & PAGE_PRESENT)) return;
+
+    uint32_t phys = pt[pti] & ~0xFFFu;
+    pt[pti] = phys | (flags & 0xFFFu) | PAGE_PRESENT;
+    __asm__ volatile("invlpg (%0)" :: "r"(virt) : "memory");
+}
+
 void vmm_unmap_page(uint32_t *pd, uint32_t virt)
 {
     uint32_t pdi = virt >> 22;

--- a/src/kernel/arch/i386/mm/vmm.c
+++ b/src/kernel/arch/i386/mm/vmm.c
@@ -189,8 +189,12 @@ uint32_t *vmm_clone_pd_cow(uint32_t *parent_pd)
 
         if (!(ppde & PAGE_PRESENT) || (ppde & PAGE_LARGE))
             continue;
-        /* PDE shared with kernel - already mirrored above, nothing to clone. */
-        if (ppde == kpd[pdi])
+        /* PDE pointing at a kernel-owned page table - already mirrored above,
+         * nothing to clone.  Compare the PT frame only (not the whole PDE): the
+         * CPU's asynchronous Accessed/Dirty updates make the parent's copy
+         * diverge from kpd by status bits, and an exact compare would then
+         * wrongly clone the kernel PT into the child. */
+        if ((ppde & ~0xFFFu) == (kpd[pdi] & ~0xFFFu))
             continue;
 
         uint32_t parent_pt_phys = ppde & ~0xFFFu;
@@ -255,9 +259,13 @@ void vmm_free_pd(uint32_t *pd)
         uint32_t pde = pd[pdi];
         if (!(pde & PAGE_PRESENT) || (pde & PAGE_LARGE))
             continue;
-        /* Skip PDEs shared with the kernel - freeing them would corrupt the
-         * kernel's own mappings. */
-        if (pde == kpd[pdi])
+        /* Skip PDEs that point at a kernel-owned page table - freeing it would
+         * corrupt the kernel's mappings (and underflow its refcount, since
+         * kernel PTs never go through pmm_alloc).  Compare the PT *frame* only:
+         * the CPU sets Accessed/Dirty asynchronously on the kernel's PDE copy
+         * (e.g. drawing to the framebuffer at 0xFD400000), so an exact PDE
+         * compare would diverge by those status bits and miss the share. */
+        if ((pde & ~0xFFFu) == (kpd[pdi] & ~0xFFFu))
             continue;
 
         uint32_t pt_phys = pde & ~0xFFFu;

--- a/src/kernel/arch/i386/mm/vmm.c
+++ b/src/kernel/arch/i386/mm/vmm.c
@@ -9,6 +9,13 @@
 #define PAGE_USER      0x4u
 #define PAGE_LARGE     0x80u
 
+/* Upper bound of the permanent low identity map (0..256 MiB): the window
+ * through which the kernel reaches page-table and data frames by their physical
+ * address.  Frames/PTs at or above it are out-of-window -- treated as corrupt
+ * by the PD walkers, and not released by the frame helpers (vmm_unmap_and_free
+ * / vmm_free_pd), which only ever own RAM frames from pmm_alloc_frame. */
+#define VMM_KERNEL_IDMAP_END 0x10000000u
+
 /* Higher-half kernel virtual base (must match KERNEL_VBASE in linker.ld /
  * boot.S / paging.c).  Per-task user page directories come from
  * pmm_alloc_frame() and so are addressed by their (low) physical address,
@@ -112,6 +119,40 @@ void vmm_unmap_page(uint32_t *pd, uint32_t virt)
         asm volatile("invlpg (%0)" :: "r"(virt) : "memory");
 }
 
+/* Like vmm_unmap_page, but also releases the page's backing frame (decrementing
+ * its refcount; the PMM frees it only at zero).  Use this for mappings whose
+ * frames the task owns a ref on -- anonymous pages and file-backed mmap pages,
+ * including shared page-cache frames (pmm_inc_ref'd at map time).  Plain
+ * vmm_unmap_page (no free) stays for callers that deliberately don't own the
+ * frame.  Mirrors vmm_free_pd's guards: only release a real, non-kernel frame
+ * inside the identity map. */
+void vmm_unmap_and_free(uint32_t *pd, uint32_t virt)
+{
+    uint32_t pdi = virt >> 22;
+    uint32_t pti = (virt >> 12) & 0x3FFu;
+
+    if (!(pd[pdi] & PAGE_PRESENT) || (pd[pdi] & PAGE_LARGE))
+        return;
+
+    uint32_t *pt = (uint32_t *)(pd[pdi] & ~0xFFFu);
+    uint32_t pte = pt[pti];
+    if (!(pte & PAGE_PRESENT))
+        return;
+
+    uint32_t frame = pte & ~0xFFFu;
+    pt[pti] = 0;
+
+    /* Release the frame iff it is a real RAM frame inside the identity map --
+     * the same guard vmm_free_pd uses for teardown. */
+    if (frame && frame < VMM_KERNEL_IDMAP_END)
+        pmm_free_frame(frame);
+
+    uint32_t cr3;
+    asm volatile("mov %%cr3, %0" : "=r"(cr3));
+    if (cr3 == v2p_pd(pd))
+        asm volatile("invlpg (%0)" :: "r"(virt) : "memory");
+}
+
 void vmm_switch(uint32_t *pd)
 {
     /* CR3 needs a physical address.  User PDs are physical already; the kernel
@@ -124,8 +165,8 @@ void vmm_switch(uint32_t *pd)
  * by the kernel -- the PT-pointer dereference would itself page-fault.
  * Any PDE whose physical address is >= this bound is treated as corrupt
  * and skipped.  Real user-task PTs always come from pmm_alloc_frame which
- * only hands out frames within this identity-mapped window. */
-#define VMM_KERNEL_IDMAP_END 0x10000000u
+ * only hands out frames within this identity-mapped window.  (The bound,
+ * VMM_KERNEL_IDMAP_END, is defined near the top of this file.) */
 
 uint32_t *vmm_clone_pd_cow(uint32_t *parent_pd)
 {

--- a/src/kernel/arch/i386/proc/elf.c
+++ b/src/kernel/arch/i386/proc/elf.c
@@ -38,11 +38,33 @@
  * [ELF_STACK_TOP - USER_STACK_PAGES*PAGE_SIZE, ELF_STACK_TOP). */
 #define USER_STACK_PAGES  8u
 
-/* Maximum ELF file size that the staging buffer can hold. */
-#define ELF_BUF_MAX     (512u * 1024u)
+/* Maximum ELF file size that the staging buffer can hold.  Sized for the
+ * largest image we load whole: musl's libc.so / ld-musl (~820 KiB) and tcc.elf
+ * (~926 KiB), with headroom. */
+#define ELF_BUF_MAX     (2u * 1024u * 1024u)
 
-/* Static staging buffer so it does not live on any task stack. */
+/* Static staging buffer so it does not live on any task stack.  Reused for the
+ * dynamic interpreter after the main image's segments are copied into frames. */
 static uint8_t s_elf_buf[ELF_BUF_MAX];
+
+/* Dynamic-linking layout (user space < 0xC0000000):
+ *   PIE main image base        DYN_BASE     (ET_DYN; ET_EXEC keeps its own vaddrs)
+ *   dynamic interpreter base   INTERP_BASE  (ld-musl-i386.so.1, itself ET_DYN)
+ * The interpreter then mmaps libc.so into the 0x90000000 anon/mmap window.
+ * All clear of each other and the 0xBFFF0000 stack. */
+#define DYN_BASE        0x50000000u
+#define INTERP_BASE     0x70000000u
+
+/* System V i386 auxv entry types musl reads (a_type values). */
+#define AT_NULL    0
+#define AT_PHDR    3
+#define AT_PHENT   4
+#define AT_PHNUM   5
+#define AT_PAGESZ  6
+#define AT_BASE    7
+#define AT_ENTRY   9
+#define AT_RANDOM  25
+#define AT_EXECFN  31
 
 /* -------------------------------------------------------------------------
  * Helpers
@@ -96,6 +118,53 @@ void execve_unlock(void)
 #define ELF_MAX_ARGC  128   /* room for tcc.elf's full kernel-rebuild link line */
 #define ELF_ARG_MAX   256
 
+/* Map an ELF image's PT_LOAD segments into `pd` at `base + p_vaddr`, copying
+ * file data from `buf` and zero-filling the rest (bss).  `base` is 0 for an
+ * ET_EXEC, the chosen load base for an ET_DYN (PIE) or the interpreter.  Each
+ * segment keeps its own R/W permission (i386 has no NX, so X is implicit).
+ * Returns 0, or -1 (the caller frees the page directory). */
+static int map_load_segments(uint32_t *pd, const uint8_t *buf, uint32_t filesz,
+                             const Elf32_Ehdr *ehdr, uint32_t base)
+{
+    for (int i = 0; i < (int)ehdr->e_phnum; i++) {
+        const Elf32_Phdr *ph = (const Elf32_Phdr *)
+            (buf + ehdr->e_phoff + (uint32_t)i * ehdr->e_phentsize);
+
+        if (ph->p_type != PT_LOAD || ph->p_memsz == 0)
+            continue;
+
+        uint32_t vaddr = ph->p_vaddr + base;
+        if (vaddr < 0x10000000u)                  return -1;  /* into kernel window */
+        if (ph->p_offset + ph->p_filesz > filesz) return -1;
+
+        uint32_t flags = VMM_FLAG_USER;
+        if (ph->p_flags & PF_W) flags |= VMM_FLAG_WRITABLE;
+
+        uint32_t va  = align_down(vaddr, PAGE_SIZE);
+        uint32_t end = align_up(vaddr + ph->p_memsz, PAGE_SIZE);
+
+        for (; va < end; va += PAGE_SIZE) {
+            uint32_t phys = pmm_alloc_frame();
+            if (phys == PMM_ALLOC_ERROR) return -1;
+            memset((void *)phys, 0, PAGE_SIZE);
+
+            uint32_t file_start = vaddr;
+            uint32_t file_end   = vaddr + ph->p_filesz;
+            uint32_t page_end   = va + PAGE_SIZE;
+            uint32_t copy_from  = (file_start > va)       ? file_start : va;
+            uint32_t copy_to    = (file_end   < page_end) ? file_end   : page_end;
+
+            if (copy_from < copy_to) {
+                uint32_t dst_off = copy_from - va;
+                uint32_t src_off = ph->p_offset + (copy_from - vaddr);
+                memcpy((uint8_t *)phys + dst_off, buf + src_off, copy_to - copy_from);
+            }
+            vmm_map_page(pd, va, phys, flags);
+        }
+    }
+    return 0;
+}
+
 int elf_exec(const char *path, int argc, const char *const *argv)
 {
     /* 1. Read file into staging buffer. */
@@ -129,8 +198,8 @@ int elf_exec(const char *path, int argc, const char *const *argv)
         t_writestring("exec: not little-endian ELF\n");
         return -1;
     }
-    if (ehdr->e_type != ET_EXEC) {
-        t_writestring("exec: not an executable ELF (ET_EXEC required)\n");
+    if (ehdr->e_type != ET_EXEC && ehdr->e_type != ET_DYN) {
+        t_writestring("exec: not an executable ELF (ET_EXEC / ET_DYN)\n");
         return -1;
     }
     if (ehdr->e_machine != EM_386) {
@@ -145,7 +214,10 @@ int elf_exec(const char *path, int argc, const char *const *argv)
         t_writestring("exec: program header table out of range\n");
         return -1;
     }
-    if (ehdr->e_entry < 0x10000000u) {
+    /* ET_EXEC entries are absolute and must clear the low identity window.
+     * ET_DYN (PIE) entries are relative -- load_base (0x50000000+) is added
+     * below -- so they're legitimately small here; don't reject them. */
+    if (ehdr->e_type == ET_EXEC && ehdr->e_entry < 0x10000000u) {
         t_writestring("exec: entry point in kernel window (< 256 MiB)\n");
         return -1;
     }
@@ -159,75 +231,103 @@ int elf_exec(const char *path, int argc, const char *const *argv)
         return -1;
     }
 
-    /* 4. Map PT_LOAD segments. */
+    /* 4. Load base: ET_DYN (PIE) is relocatable; ET_EXEC keeps its vaddrs.
+     *    Map the main image's PT_LOAD segments. */
+    uint32_t load_base = (ehdr->e_type == ET_DYN) ? DYN_BASE : 0u;
+    if (map_load_segments(pd, s_elf_buf, filesz, ehdr, load_base) != 0) {
+        t_writestring("exec: bad or oversized PT_LOAD segment\n");
+        vmm_free_pd(pd);
+        return -1;
+    }
+
+    /* Save what the auxv needs from the main ehdr BEFORE the staging buffer is
+     * reused for the interpreter (the main's segments are now in frames, so
+     * s_elf_buf is free). */
+    uint32_t entry_main = ehdr->e_entry      + load_base;
+    uint32_t at_phent   = ehdr->e_phentsize;
+    uint32_t at_phnum   = ehdr->e_phnum;
+
+    /* AT_PHDR is the *in-memory* address of the program headers.  The phdrs live
+     * at file offset e_phoff; find the PT_LOAD that maps that offset and
+     * translate to a vaddr: load_base + p_vaddr + (e_phoff - p_offset).  Using
+     * load_base + e_phoff is wrong for ET_EXEC (segment vaddr is 0x40000000, not
+     * 0) and only happens to work for PIE because its first segment vaddr is 0;
+     * ld.so/__libc_start_main deref AT_PHDR, so a bad value faults near NULL. */
+    uint32_t at_phdr = ehdr->e_phoff + load_base;   /* fallback */
     for (int i = 0; i < (int)ehdr->e_phnum; i++) {
         const Elf32_Phdr *ph = (const Elf32_Phdr *)
             (s_elf_buf + ehdr->e_phoff + (uint32_t)i * ehdr->e_phentsize);
-
-        if (ph->p_type != PT_LOAD || ph->p_memsz == 0)
-            continue;
-
-        if (ph->p_vaddr < 0x10000000u) {
-            t_writestring("exec: segment below 256 MiB boundary\n");
-            vmm_free_pd(pd);
-            return -1;
-        }
-        if (ph->p_offset + ph->p_filesz > filesz) {
-            t_writestring("exec: segment file data out of range\n");
-            vmm_free_pd(pd);
-            return -1;
-        }
-
-        uint32_t flags = VMM_FLAG_USER;
-        if (ph->p_flags & PF_W)
-            flags |= VMM_FLAG_WRITABLE;
-
-        uint32_t va  = align_down(ph->p_vaddr, PAGE_SIZE);
-        uint32_t end = align_up(ph->p_vaddr + ph->p_memsz, PAGE_SIZE);
-
-        for (; va < end; va += PAGE_SIZE) {
-            uint32_t phys = pmm_alloc_frame();
-            if (phys == PMM_ALLOC_ERROR) {
-                t_writestring("exec: out of physical memory\n");
-                vmm_free_pd(pd);
-                return -1;
-            }
-            memset((void *)phys, 0, PAGE_SIZE);
-
-            /* Copy the portion of file data that falls in this page. */
-            uint32_t file_start = ph->p_vaddr;
-            uint32_t file_end   = ph->p_vaddr + ph->p_filesz;
-            uint32_t page_end   = va + PAGE_SIZE;
-
-            uint32_t copy_from = (file_start > va)       ? file_start : va;
-            uint32_t copy_to   = (file_end   < page_end) ? file_end   : page_end;
-
-            if (copy_from < copy_to) {
-                uint32_t dst_off = copy_from - va;
-                uint32_t src_off = ph->p_offset + (copy_from - ph->p_vaddr);
-                memcpy((uint8_t *)phys + dst_off,
-                       s_elf_buf + src_off,
-                       copy_to - copy_from);
-            }
-
-            vmm_map_page(pd, va, phys, flags);
+        if (ph->p_type == PT_LOAD &&
+            ehdr->e_phoff >= ph->p_offset &&
+            ehdr->e_phoff <  ph->p_offset + ph->p_filesz) {
+            at_phdr = load_base + ph->p_vaddr + (ehdr->e_phoff - ph->p_offset);
+            break;
         }
     }
 
-    /* 5. Record the initial heap break (page-aligned end of highest segment). */
+    /* 5. Heap break = end of the highest main segment (+ base). */
     uint32_t top_vaddr = 0;
     for (int i = 0; i < (int)ehdr->e_phnum; i++) {
         const Elf32_Phdr *ph = (const Elf32_Phdr *)
             (s_elf_buf + ehdr->e_phoff + (uint32_t)i * ehdr->e_phentsize);
         if (ph->p_type != PT_LOAD || ph->p_memsz == 0) continue;
-        uint32_t end = align_up(ph->p_vaddr + ph->p_memsz, PAGE_SIZE);
+        uint32_t end = align_up(ph->p_vaddr + load_base + ph->p_memsz, PAGE_SIZE);
         if (end > top_vaddr) top_vaddr = end;
     }
+
+    /* 5b. Find PT_INTERP and copy the interpreter path out before reuse.
+     * Only an ET_DYN (PIE) image drives the dynamic linker; an ET_EXEC may
+     * still carry a vestigial PT_INTERP (TCC stamps /lib/ld-linux.so.2 on its
+     * otherwise self-contained output), which we ignore exactly as the
+     * pre-dynamic loader did -- ET_EXEC stays jump-straight-to-entry. */
+    char interp_path[128];
+    int  has_interp = 0;
+    for (int i = 0; ehdr->e_type == ET_DYN && i < (int)ehdr->e_phnum; i++) {
+        const Elf32_Phdr *ph = (const Elf32_Phdr *)
+            (s_elf_buf + ehdr->e_phoff + (uint32_t)i * ehdr->e_phentsize);
+        if (ph->p_type != PT_INTERP) continue;
+        uint32_t n = ph->p_filesz;
+        if (n == 0 || n > sizeof interp_path)   break;
+        if (ph->p_offset + n > filesz)          break;
+        memcpy(interp_path, s_elf_buf + ph->p_offset, n);
+        interp_path[n - 1] = '\0';      /* p_filesz includes the NUL */
+        has_interp = 1;
+        break;
+    }
+
     task_current()->user_brk = top_vaddr;
     task_current()->user_brk_base = top_vaddr;  /* lower bound of the lazy brk region */
     task_current()->mmap_next = 0;   /* fresh address space: reset anon-mmap window */
     task_current()->tls_gs = 0x23u;  /* fresh image: drop any prior TLS */
     task_current()->tls_active = 0;
+
+    /* 5c. Dynamic executable: load the interpreter (ld-musl-i386.so.1, itself
+     * ET_DYN) at INTERP_BASE and enter *there* instead of the program entry.
+     * musl's ld.so then mmaps libc.so (DT_NEEDED), relocates, and jumps to
+     * AT_ENTRY.  Reuses s_elf_buf (the main image is already in frames). */
+    uint32_t enter_entry = entry_main;
+    uint32_t at_base     = 0;
+    if (has_interp) {
+        uint32_t isz = 0;
+        if (vfs_read_file(interp_path, s_elf_buf, ELF_BUF_MAX, &isz) != 0 ||
+            isz < sizeof(Elf32_Ehdr)) {
+            t_writestring("exec: cannot read interpreter '");
+            t_writestring(interp_path); t_writestring("'\n");
+            vmm_free_pd(pd); return -1;
+        }
+        const Elf32_Ehdr *ie = (const Elf32_Ehdr *)s_elf_buf;
+        if (ie->e_ident[EI_MAG0] != ELFMAG0 || ie->e_machine != EM_386 ||
+            ie->e_type != ET_DYN) {
+            t_writestring("exec: bad interpreter ELF\n");
+            vmm_free_pd(pd); return -1;
+        }
+        if (map_load_segments(pd, s_elf_buf, isz, ie, INTERP_BASE) != 0) {
+            t_writestring("exec: interpreter segment out of range\n");
+            vmm_free_pd(pd); return -1;
+        }
+        enter_entry = ie->e_entry + INTERP_BASE;
+        at_base     = INTERP_BASE;
+    }
 
     /* 6. Map user stack (USER_STACK_PAGES pages, read-write).  Only the
      * top page is used to write argc/argv; the rest grow downward as
@@ -306,29 +406,44 @@ int elf_exec(const char *path, int argc, const char *const *argv)
     off &= ~3u;
 
     /*
-     * Minimum space required below 'off' for the pointer table + argc:
-     *   6 words  auxv: AT_PAGESZ, AT_RANDOM, AT_NULL (type+val each)
-     *   1 word   envp[0]=NULL
-     *   1 word   argv[argc]=NULL
+     * Minimum space below 'off' for the pointer table + argc:
+     *   18 words  auxv: PHDR/PHENT/PHNUM/PAGESZ/BASE/ENTRY/RANDOM/EXECFN/NULL
+     *   1 word    envp[0]=NULL
+     *   1 word    argv[argc]=NULL
      *   argc words  argv[0..argc-1]
-     *   1 word   argc
+     *   1 word    argc
      */
-    uint32_t needed = (uint32_t)(argc + 9) * 4u;
+    uint32_t needed = (uint32_t)(argc + 21) * 4u;
     if (off < needed) {
         /* Pathological case - give up on arguments rather than corrupt memory. */
         argc = 0;
         off  = PAGE_SIZE & ~3u;
     }
 
-    /* auxv (System V i386), highest addr -> lowest: AT_NULL terminator,
-     * AT_RANDOM, AT_PAGESZ.  musl's _start walks this after the envp NULL.
-     * Each entry is {type, val} with type at the lower address. */
-    off -= 4u; *(uint32_t *)(spage + off) = 0u;          /* AT_NULL   val  */
-    off -= 4u; *(uint32_t *)(spage + off) = 0u;          /* AT_NULL   type */
-    off -= 4u; *(uint32_t *)(spage + off) = rand_ptr;    /* AT_RANDOM val  */
-    off -= 4u; *(uint32_t *)(spage + off) = 25u;         /* AT_RANDOM type */
-    off -= 4u; *(uint32_t *)(spage + off) = PAGE_SIZE;   /* AT_PAGESZ val  */
-    off -= 4u; *(uint32_t *)(spage + off) = 6u;          /* AT_PAGESZ type */
+    /* Full System V i386 auxv, highest addr -> lowest (AT_NULL terminates);
+     * each entry is {a_type, a_val} with a_type at the lower address.  The
+     * dynamic linker reads AT_PHDR/PHENT/PHNUM (the program's own headers),
+     * AT_BASE (where ld.so itself was loaded) and AT_ENTRY (the program entry).
+     * Static musl only needs AT_RANDOM + AT_PAGESZ.  AT_EXECFN = argv[0]. */
+    uint32_t execfn = (argc > 0) ? uargv[0] : 0u;
+    off -= 4u; *(uint32_t *)(spage + off) = 0u;          /* AT_NULL    val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_NULL;     /* AT_NULL    type */
+    off -= 4u; *(uint32_t *)(spage + off) = execfn;      /* AT_EXECFN  val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_EXECFN;   /* AT_EXECFN  type */
+    off -= 4u; *(uint32_t *)(spage + off) = rand_ptr;    /* AT_RANDOM  val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_RANDOM;   /* AT_RANDOM  type */
+    off -= 4u; *(uint32_t *)(spage + off) = entry_main;  /* AT_ENTRY   val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_ENTRY;    /* AT_ENTRY   type */
+    off -= 4u; *(uint32_t *)(spage + off) = at_base;     /* AT_BASE    val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_BASE;     /* AT_BASE    type */
+    off -= 4u; *(uint32_t *)(spage + off) = PAGE_SIZE;   /* AT_PAGESZ  val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_PAGESZ;   /* AT_PAGESZ  type */
+    off -= 4u; *(uint32_t *)(spage + off) = at_phnum;    /* AT_PHNUM   val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_PHNUM;    /* AT_PHNUM   type */
+    off -= 4u; *(uint32_t *)(spage + off) = at_phent;    /* AT_PHENT   val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_PHENT;    /* AT_PHENT   type */
+    off -= 4u; *(uint32_t *)(spage + off) = at_phdr;     /* AT_PHDR    val  */
+    off -= 4u; *(uint32_t *)(spage + off) = AT_PHDR;     /* AT_PHDR    type */
 
     /* envp[0] = NULL (empty environment). */
     off -= 4u; *(uint32_t *)(spage + off) = 0u;
@@ -367,5 +482,5 @@ int elf_exec(const char *path, int argc, const char *const *argv)
     vmm_switch(pd);
     if (old_pd && old_pd != paging_kernel_pd())
         vmm_free_pd(old_pd);
-    ring3_enter(ehdr->e_entry, initial_esp);   /* never returns */
+    ring3_enter(enter_entry, initial_esp);   /* interp (dynamic) or program entry */
 }

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -12,6 +12,7 @@
 #include <kernel/netdev.h>
 #include <kernel/net_lwip.h>
 #include <kernel/pmm.h>
+#include <kernel/pagecache.h>
 #include <kernel/heap.h>
 #include <kernel/vmm.h>
 #include <kernel/paging.h>
@@ -1158,6 +1159,67 @@ static void test_pmm(void)
     uint32_t rf2 = pmm_alloc_frame();
     KTEST_ASSERT(rf2 == rf);
     pmm_free_frame(rf2);
+
+    ktest_summary();
+}
+
+/* ---------------------------------------------------------------------------
+ * Suite: shared file-backed mmap via the page cache (kernel/pagecache.h)
+ *
+ * The mechanism that makes dynamic linking a RAM win: a read-only file mmap
+ * page comes straight from the page cache, so every process mapping a file
+ * (libc.so) shares one physical copy.  This drives the primitive directly --
+ * pagecache_acquire -- without needing a user address space: two acquires of
+ * the same file page must return the *same* frame, bump its refcount, and
+ * crucially allocate *zero* new frames the second time.  A private-copy
+ * implementation would return distinct frames and consume RAM each time.
+ * ------------------------------------------------------------------------- */
+static void test_pagecache_share(void)
+{
+    ktest_begin("pagecache_share",
+        "file mmap sharing: one refcounted cache frame per (file,page); a 2nd "
+        "mapper of the same page allocates zero new frames");
+
+    /* A real, page-cacheable ISO file -- /apps/hello.elf always ships. */
+    const char *path = "/apps/hello.elf";
+    vfs_stat_info_t si;
+    if (vfs_stat(path, &si) != 0 || si.kind != VFS_STAT_FILE || si.size == 0) {
+        /* Backend without stat / file absent: skip rather than fail. */
+        KTEST_ASSERT(1);
+        ktest_summary();
+        return;
+    }
+    uint32_t size = si.size;
+
+    /* Warm the cache so page 0 is resident -- the measurement below then sees
+     * only refcount changes, not the one-time fill. */
+    uint32_t warm = pagecache_acquire(path, size, 0, NULL);
+    KTEST_ASSERT(warm != 0);
+    KTEST_ASSERT((warm & 0xFFFu) == 0);          /* page-aligned frame */
+    pmm_free_frame(warm);                         /* drop our ref; cache keeps it */
+
+    /* Two independent "mappers" acquire the same page. */
+    uint32_t fc_before = pmm_free_count();
+    uint32_t fr1 = pagecache_acquire(path, size, 0, NULL);
+    uint32_t fr2 = pagecache_acquire(path, size, 0, NULL);
+
+    KTEST_ASSERT(fr1 != 0);
+    KTEST_ASSERT(fr2 == fr1);                     /* SAME frame -> one shared copy */
+    KTEST_ASSERT(pmm_free_count() == fc_before);  /* the win: zero new frames */
+    KTEST_ASSERT(pmm_ref_count(fr1) >= 3);        /* cache + the two mappers */
+
+    /* Each mapper's teardown drops its ref (as vmm_unmap_and_free would). */
+    pmm_free_frame(fr2);
+    pmm_free_frame(fr1);
+    KTEST_ASSERT(pmm_free_count() == fc_before);  /* still balanced */
+    KTEST_ASSERT(pmm_ref_count(fr1) >= 1);        /* cache still holds the page */
+
+    /* A different page index is a different frame (sanity: not aliasing). */
+    if (size > PAGECACHE_PGSZ) {
+        uint32_t pg1 = pagecache_acquire(path, size, 1, NULL);
+        KTEST_ASSERT(pg1 != 0 && pg1 != fr1);
+        pmm_free_frame(pg1);
+    }
 
     ktest_summary();
 }
@@ -3541,6 +3603,10 @@ int ktest_run_all(void)
     total_fail += ktest_fail_count;
 
     test_pmm();
+    total_pass += ktest_pass_count;
+    total_fail += ktest_fail_count;
+
+    test_pagecache_share();
     total_pass += ktest_pass_count;
     total_fail += ktest_fail_count;
 

--- a/src/kernel/arch/i386/proc/ktest.c
+++ b/src/kernel/arch/i386/proc/ktest.c
@@ -2039,12 +2039,13 @@ static void test_syscall(void)
     syscall_dispatch(&regs);
     KTEST_ASSERT(1);
 
-    /* SYS_OPEN on a non-existent path must return -1. */
+    /* SYS_OPEN on a non-existent path must return -ENOENT (Linux convention):
+     * musl's ld.so reads -errno to walk its library search path. */
     regs.eax = SYS_OPEN;
     regs.ebx = (uint32_t)(uintptr_t)"/no/such/file";
     regs.ecx = O_RDONLY;
     syscall_dispatch(&regs);
-    KTEST_ASSERT(regs.eax == (uint32_t)-1);
+    KTEST_ASSERT(regs.eax == (uint32_t)-2);   /* -ENOENT */
 
     /* SYS_BRK(0): query current break on a kernel task (user_brk == 0). */
     regs.eax = SYS_BRK;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1648,17 +1648,35 @@ static void syscall_dispatch_inner(registers_t *regs)
             fe = fd_get(t->fd_table, fd);
             if (!fe || fe->kind != FD_KIND_FILE) { regs->eax = (uint32_t)-1; break; }
         }
+        /* A read-only, path-backed (lazy) file mapping shares frames straight
+         * out of the page cache: pagecache_acquire pins the cache's frame, so
+         * libc.so's ~700 KiB of text/rodata is one copy in RAM no matter how
+         * many processes map it.  Writable file maps, tmpfs-backed files and
+         * anon-fixed maps each take a private frame.  Either way a MAP_FIXED
+         * page replaces through vmm_unmap_and_free so the frame it overlays
+         * (e.g. musl's whole-library reserve) is released, not leaked. */
+        int shared_ro = (!anon && fe && fe->lazy && !(prot & MMAP_PROT_WRITE));
         int failed = 0;
         for (uint32_t i = 0; i < pages; i++) {
             uint32_t va   = base + (i << 12);
-            uint32_t phys = pmm_alloc_frame();
-            if (phys == PMM_ALLOC_ERROR) { failed = 1; break; }
-            memset((void *)phys, 0, 0x1000);
-            if (!anon) {
-                uint64_t off = ((uint64_t)pgoff << 12) + ((uint64_t)i << 12);
-                syscall_file_pread(fe, (uint8_t *)phys, off, 0x1000);
+            uint32_t phys = 0;
+
+            if (shared_ro)
+                phys = pagecache_acquire(fe->path, fe->size, pgoff + i, NULL);
+
+            if (!phys) {
+                /* Private frame: anon, a writable/tmpfs file, or a file page
+                 * wholly past EOF (left zero-filled, like the bss tail). */
+                phys = pmm_alloc_frame();
+                if (phys == PMM_ALLOC_ERROR) { failed = 1; break; }
+                memset((void *)phys, 0, 0x1000);
+                if (!anon && !shared_ro) {
+                    uint64_t off = ((uint64_t)pgoff << 12) + ((uint64_t)i << 12);
+                    syscall_file_pread(fe, (uint8_t *)phys, off, 0x1000);
+                }
             }
-            if (fixed) vmm_unmap_page(t->page_dir, va);   /* replace any existing */
+
+            if (fixed) vmm_unmap_and_free(t->page_dir, va);  /* release any prior frame */
             vmm_map_page(t->page_dir, va, phys, mflags);
         }
         if (failed) { regs->eax = (uint32_t)-1; break; }

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1352,7 +1352,9 @@ static void syscall_dispatch_inner(registers_t *regs)
         memset(e, 0, sizeof(*e));
 
         if (!exists) {
-            if (!o_creat) { regs->eax = (uint32_t)-1; break; }
+            if (!o_creat) { regs->eax = (uint32_t)-2; break; }   /* -ENOENT: musl's
+                ld.so reads -errno to know a library path is absent and try the
+                next; existing apps only test <0 so the value change is safe. */
             /* Create: allocate an empty growable buffer and mark dirty
              * so close flushes (even if no writes follow) -- this is
              * what makes `touch`-style "create empty file" work. */

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -395,6 +395,20 @@ static long syscall_fd_write(int fd, const char *buf, uint32_t len)
     return -1;   /* KEYBOARD etc: not writable */
 }
 
+/* Read up to `n` bytes from a regular file fd at byte offset `off` into `dst`
+ * (a kernel-accessible buffer).  Returns bytes read; 0 past EOF.  Handles both
+ * lazy page-cached disk files (the ISO) and in-memory tmpfs files.  Backs the
+ * file-backed mmap path (musl's dynamic linker maps libc.so this way). */
+static long syscall_file_pread(fd_entry_t *e, uint8_t *dst, uint64_t off, uint32_t n)
+{
+    if (!e || e->kind != FD_KIND_FILE || off >= (uint64_t)e->size) return 0;
+    uint32_t avail = ((uint64_t)e->size - off) < (uint64_t)n
+                   ? (uint32_t)((uint64_t)e->size - off) : n;
+    if (e->lazy) return pagecache_read(e->path, e->size, (uint32_t)off, dst, avail);
+    memcpy(dst, e->data + (uint32_t)off, avail);
+    return (long)avail;
+}
+
 /* -------------------------------------------------------------------------
  * syscall_dispatch
  * ------------------------------------------------------------------------- */
@@ -1584,31 +1598,90 @@ static void syscall_dispatch_inner(registers_t *regs)
      * a hosted malloc (musl mallocng) needs beyond brk.
      * ------------------------------------------------------------------ */
     case SYS_MMAP2: {
-        #define MMAP_MAP_ANONYMOUS 0x20u
         #define MMAP_MAP_FIXED     0x10u
+        #define MMAP_MAP_ANONYMOUS 0x20u
+        #define MMAP_PROT_WRITE    0x2u
+        uint32_t addr  = regs->ebx;
         uint32_t len   = regs->ecx;
+        uint32_t prot  = regs->edx;
         uint32_t flags = regs->esi;
+        int      fd    = (int)regs->edi;
+        uint32_t pgoff = regs->ebp;          /* file offset in 4 KiB pages */
         task_t  *t     = task_current();
 
-        if (!t || len == 0 || !(flags & MMAP_MAP_ANONYMOUS) ||
-            (flags & MMAP_MAP_FIXED)) {
-            regs->eax = (uint32_t)-1; break;          /* MAP_FAILED */
+        if (!t || len == 0) { regs->eax = (uint32_t)-1; break; }
+
+        uint32_t pages  = (len + 0xFFFu) >> 12;
+        int      fixed  = (flags & MMAP_MAP_FIXED) != 0;
+        int      anon   = (flags & MMAP_MAP_ANONYMOUS) != 0;
+        uint32_t mflags = VMM_FLAG_USER |
+                          ((prot & MMAP_PROT_WRITE) ? VMM_FLAG_WRITABLE : 0);
+
+        /* Choose the base address. */
+        uint32_t base;
+        if (fixed) {
+            base = addr & ~0xFFFu;
+            if (base < 0x10000000u || base + (pages << 12) > 0xBFFF0000u) {
+                regs->eax = (uint32_t)-1; break;
+            }
+        } else {
+            if (t->mmap_next == 0) t->mmap_next = USER_MMAP_BASE;
+            base = t->mmap_next;
+            if (base + (pages << 12) >= 0xBFFF0000u - (8u * 0x1000u)) {
+                regs->eax = (uint32_t)-1; break;
+            }
+            t->mmap_next = base + (pages << 12);
         }
 
-        uint32_t pages = (len + 0xFFFu) >> 12;
-        if (t->mmap_next == 0) t->mmap_next = USER_MMAP_BASE;
-        uint32_t base = t->mmap_next;
+        /* Anonymous + growable window: keep the demand-paged reserve -- the
+         * page-fault handler zero-fills [USER_MMAP_BASE, mmap_next) on touch
+         * (same lazy model as brk). */
+        if (anon && !fixed) { regs->eax = base; break; }
 
-        /* Don't collide with the ring-3 stack region. */
-        if (base + (pages << 12) >= 0xBFFF0000u - (8u * 0x1000u)) {
-            regs->eax = (uint32_t)-1; break;
+        /* Anonymous-fixed OR file-backed: map eagerly now.  musl's dynamic
+         * linker maps each shared object as a file-backed MAP_PRIVATE span,
+         * then MAP_FIXED-overlays the segments (own prot) + an anon bss tail. */
+        fd_entry_t *fe = NULL;
+        if (!anon) {
+            fe = fd_get(t->fd_table, fd);
+            if (!fe || fe->kind != FD_KIND_FILE) { regs->eax = (uint32_t)-1; break; }
         }
-
-        /* Demand-paged anonymous mmap: reserve the window only; the page-fault
-         * handler maps a zeroed frame on first touch in [USER_MMAP_BASE,
-         * mmap_next).  Same lazy model as brk above. */
-        t->mmap_next = base + (pages << 12);
+        int failed = 0;
+        for (uint32_t i = 0; i < pages; i++) {
+            uint32_t va   = base + (i << 12);
+            uint32_t phys = pmm_alloc_frame();
+            if (phys == PMM_ALLOC_ERROR) { failed = 1; break; }
+            memset((void *)phys, 0, 0x1000);
+            if (!anon) {
+                uint64_t off = ((uint64_t)pgoff << 12) + ((uint64_t)i << 12);
+                syscall_file_pread(fe, (uint8_t *)phys, off, 0x1000);
+            }
+            if (fixed) vmm_unmap_page(t->page_dir, va);   /* replace any existing */
+            vmm_map_page(t->page_dir, va, phys, mflags);
+        }
+        if (failed) { regs->eax = (uint32_t)-1; break; }
         regs->eax = base;
+        break;
+    }
+
+    /* ------------------------------------------------------------------
+     * SYS_MPROTECT(125): EBX=addr, ECX=len, EDX=prot.  Rewrites the
+     * writable bit across the range (keeps each page's frame), so musl's
+     * dynamic linker can RELRO-protect the GOT after relocation.  i386 has
+     * no NX, so PROT_EXEC is implicit; PROT_NONE is treated as read-only.
+     * ------------------------------------------------------------------ */
+    case SYS_MPROTECT: {
+        uint32_t addr = regs->ebx & ~0xFFFu;
+        uint32_t len  = regs->ecx;
+        uint32_t prot = regs->edx;
+        task_t  *t    = task_current();
+        if (!t || len == 0) { regs->eax = (uint32_t)-1; break; }
+        uint32_t pages  = ((regs->ebx & 0xFFFu) + len + 0xFFFu) >> 12;
+        uint32_t mflags = VMM_FLAG_USER |
+                          ((prot & 0x2u /*PROT_WRITE*/) ? VMM_FLAG_WRITABLE : 0);
+        for (uint32_t i = 0; i < pages; i++)
+            vmm_protect_page(t->page_dir, addr + (i << 12), mflags);
+        regs->eax = 0;
         break;
     }
 

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -1699,7 +1699,7 @@ static void syscall_dispatch_inner(registers_t *regs)
         if (t && len) {
             uint32_t pages = (len + 0xFFFu) >> 12;
             for (uint32_t i = 0; i < pages; i++)
-                vmm_unmap_page(t->page_dir, addr + (i << 12));
+                vmm_unmap_and_free(t->page_dir, addr + (i << 12));  /* release frames, not just PTEs */
         }
         regs->eax = 0;
         break;

--- a/src/kernel/arch/i386/proc/syscall.c
+++ b/src/kernel/arch/i386/proc/syscall.c
@@ -314,6 +314,87 @@ static int user_range_mapped(uint32_t base, uint32_t len)
     return 1;
 }
 
+/* k_iovec: the Linux i386 `struct iovec` (8 bytes: ptr + size).  Used by writev. */
+struct k_iovec { uint32_t iov_base; uint32_t iov_len; };
+
+/* Shared write dispatch by fd kind: writes `len` bytes of `buf` to `fd` and
+ * returns the count, or < 0 on error.  Backs both SYS_WRITE and SYS_WRITEV --
+ * musl's buffered stdio writes go through writev(), so a stub there silently
+ * dropped all libc output even though the program exited cleanly. */
+static long syscall_fd_write(int fd, const char *buf, uint32_t len)
+{
+    if (!buf) return -1;
+    task_t     *cur = task_current();
+    fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, fd);
+    if (!e) return -1;
+
+    if (e->kind == FD_KIND_VGA) {
+        if (!ktest_muted)
+            for (uint32_t i = 0; i < len; i++) t_putchar(buf[i]);
+        return (long)len;
+    } else if (e->kind == FD_KIND_VGA_SERIAL) {
+        if (!ktest_muted)
+            for (uint32_t i = 0; i < len; i++) t_putchar(buf[i]);
+        if (!g_serial_verbose)
+            for (uint32_t i = 0; i < len; i++) Serial_WriteChar(buf[i]);
+        return (long)len;
+    } else if (e->kind == FD_KIND_SERIAL) {
+        for (uint32_t i = 0; i < len; i++) Serial_WriteChar(buf[i]);
+        return (long)len;
+    } else if (e->kind == FD_KIND_BLOCKDEV) {
+        long r = vfs_blockdev_pwrite(e->dev_node, buf, len, e->pos);
+        if (r < 0) return -1;
+        e->pos += (uint32_t)r;
+        return r;
+    } else if (e->kind == FD_KIND_FILE) {
+        if (!e->writable) return -1;
+        if (e->append) e->pos = e->size;
+        uint64_t want_end = (uint64_t)e->pos + (uint64_t)len;
+        if (want_end > SYSCALL_FILE_MAX) return -1;        /* EFBIG */
+        if (want_end > e->capacity) {
+            uint32_t new_cap = e->capacity ? e->capacity : SYSCALL_FILE_INITIAL;
+            while ((uint64_t)new_cap < want_end) new_cap <<= 1;
+            if (new_cap > SYSCALL_FILE_MAX) new_cap = SYSCALL_FILE_MAX;
+            uint8_t *p = (uint8_t *)krealloc(e->data, new_cap);
+            if (!p) return -1;                              /* ENOMEM */
+            if (new_cap > e->capacity)
+                memset(p + e->capacity, 0, new_cap - e->capacity);
+            e->data = p; e->capacity = new_cap;
+        }
+        if (e->pos > e->size) memset(e->data + e->size, 0, e->pos - e->size);
+        memcpy(e->data + e->pos, buf, len);
+        e->pos += len;
+        if (e->pos > e->size) e->size = e->pos;
+        e->dirty = 1;
+        return (long)len;
+    } else if (e->kind == FD_KIND_PIPE) {
+        if (!e->pipe_is_writer || !e->pipe) return -1;
+        pipe_ring_t *r = e->pipe;
+        uint32_t written = 0;
+        while (written < len) {
+            if (r->refcount_r == 0) return written ? (long)written : -32;  /* EPIPE */
+            uint32_t inflight = r->head - r->tail;
+            uint32_t space    = PIPE_RING_CAP - inflight;
+            if (space == 0) {
+                if (e->flags & FD_FLAG_NONBLOCK)
+                    return written ? (long)written : -11;  /* EAGAIN */
+                task_yield();
+                continue;
+            }
+            uint32_t chunk = len - written;
+            if (chunk > space) chunk = space;
+            for (uint32_t i = 0; i < chunk; i++)
+                r->buf[(r->head + i) % PIPE_RING_CAP] = (uint8_t)buf[written + i];
+            r->head += chunk;
+            written += chunk;
+        }
+        return (long)written;
+    } else if (e->kind == FD_KIND_SOCKET) {
+        return ksock_send(e->sock_id, buf, len);
+    }
+    return -1;   /* KEYBOARD etc: not writable */
+}
+
 /* -------------------------------------------------------------------------
  * syscall_dispatch
  * ------------------------------------------------------------------------- */
@@ -742,119 +823,34 @@ static void syscall_dispatch_inner(registers_t *regs)
      * FILE:       not yet implemented (eager-buffer fd model).
      * ------------------------------------------------------------------ */
     case SYS_WRITE: {
-        int         fd  = (int)regs->ebx;
-        const char *buf = (const char *)(uintptr_t)regs->ecx;
-        uint32_t    len = regs->edx;
+        regs->eax = (uint32_t)syscall_fd_write((int)regs->ebx,
+                        (const char *)(uintptr_t)regs->ecx, regs->edx);
+        break;
+    }
 
-        if (!buf) { regs->eax = (uint32_t)-1; break; }
-
-        task_t     *cur = task_current();
-        fd_entry_t *e   = fd_get(cur ? cur->fd_table : NULL, fd);
-        if (!e) { regs->eax = (uint32_t)-1; break; }
-
-        if (e->kind == FD_KIND_VGA) {
-            if (!ktest_muted) {
-                for (uint32_t i = 0; i < len; i++)
-                    t_putchar(buf[i]);
-            }
-            regs->eax = len;
-        } else if (e->kind == FD_KIND_VGA_SERIAL) {
-            if (!ktest_muted) {
-                for (uint32_t i = 0; i < len; i++)
-                    t_putchar(buf[i]);
-            }
-            /* t_putchar already mirrors to COM1 when verbose mode is on
-             * (default).  Only echo here when verbose is off so stderr
-             * always reaches the serial log -- otherwise we'd write the
-             * same bytes twice and the log shows every chunk doubled. */
-            if (!g_serial_verbose) {
-                for (uint32_t i = 0; i < len; i++)
-                    Serial_WriteChar(buf[i]);
-            }
-            regs->eax = len;
-        } else if (e->kind == FD_KIND_SERIAL) {
-            for (uint32_t i = 0; i < len; i++)
-                Serial_WriteChar(buf[i]);
-            regs->eax = len;
-        } else if (e->kind == FD_KIND_BLOCKDEV) {
-            long r = vfs_blockdev_pwrite(e->dev_node, buf, len, e->pos);
-            if (r < 0) { regs->eax = (uint32_t)-1; }
-            else { e->pos += (uint32_t)r; regs->eax = (uint32_t)r; }
-        } else if (e->kind == FD_KIND_FILE) {
-            if (!e->writable) { regs->eax = (uint32_t)-1; break; }
-            if (e->append) e->pos = e->size;
-            /* Refuse writes that would push the buffer past the hard cap. */
-            uint64_t want_end = (uint64_t)e->pos + (uint64_t)len;
-            if (want_end > SYSCALL_FILE_MAX) {
-                regs->eax = (uint32_t)-1;   /* EFBIG */
-                break;
-            }
-            /* Grow geometrically (doubling) so many small TCC-style writes
-             * stay amortised O(1).  Floor the first allocation at INITIAL. */
-            if (want_end > e->capacity) {
-                uint32_t new_cap = e->capacity ? e->capacity : SYSCALL_FILE_INITIAL;
-                while ((uint64_t)new_cap < want_end) new_cap <<= 1;
-                if (new_cap > SYSCALL_FILE_MAX) new_cap = SYSCALL_FILE_MAX;
-                uint8_t *p = (uint8_t *)krealloc(e->data, new_cap);
-                if (!p) { regs->eax = (uint32_t)-1; break; }  /* ENOMEM */
-                /* Zero the newly-allocated tail so leftover heap garbage
-                 * never leaks into ring-3 reads. */
-                if (new_cap > e->capacity)
-                    memset(p + e->capacity, 0, new_cap - e->capacity);
-                e->data     = p;
-                e->capacity = new_cap;
-            }
-            /* lseek-past-EOF: zero-fill the gap between current EOF and pos. */
-            if (e->pos > e->size)
-                memset(e->data + e->size, 0, e->pos - e->size);
-            memcpy(e->data + e->pos, buf, len);
-            e->pos += len;
-            if (e->pos > e->size) e->size = e->pos;
-            e->dirty = 1;
-            regs->eax = len;
-        } else if (e->kind == FD_KIND_PIPE) {
-            /* Writer on a pipe: spin-yield while ring is full.  If every
-             * reader closes (refcount_r == 0), writing returns -EPIPE. */
-            if (!e->pipe_is_writer || !e->pipe) {
-                regs->eax = (uint32_t)-1;
-                break;
-            }
-            pipe_ring_t *r = e->pipe;
-            uint32_t written = 0;
-            while (written < len) {
-                if (r->refcount_r == 0) {
-                    /* SIGPIPE not yet implemented; surface as -EPIPE. */
-                    regs->eax = written ? written : (uint32_t)-32;
-                    break;
-                }
-                uint32_t inflight = r->head - r->tail;
-                uint32_t space    = PIPE_RING_CAP - inflight;
-                if (space == 0) {
-                    if (e->flags & FD_FLAG_NONBLOCK) {
-                        regs->eax = written ? written : (uint32_t)-11;  /* EAGAIN */
-                        break;
-                    }
-                    task_yield();
-                    continue;
-                }
-                uint32_t chunk = len - written;
-                if (chunk > space) chunk = space;
-                for (uint32_t i = 0; i < chunk; i++) {
-                    r->buf[(r->head + i) % PIPE_RING_CAP] = (uint8_t)buf[written + i];
-                }
-                r->head += chunk;
-                written += chunk;
-            }
-            if (written == len) regs->eax = written;
-        } else if (e->kind == FD_KIND_SOCKET) {
-            /* TCP socket: ksock_send blocks (bounded) while the send buffer
-             * drains; returns bytes written or -1. */
-            long r = ksock_send(e->sock_id, buf, len);
-            regs->eax = (uint32_t)r;
-        } else {
-            /* KEYBOARD: not writable. */
-            regs->eax = (uint32_t)-1;
+    /* ------------------------------------------------------------------
+     * SYS_WRITEV(146): gather-write.  EBX=fd, ECX=const struct iovec*,
+     * EDX=iovcnt.  Returns the total bytes written (EAX), or (uint32_t)-1.
+     * musl's buffered stdio writes go through writev(), so without this
+     * every printf/fprintf produced no output even though the program ran.
+     * Stops at the first failed/short segment, matching Linux writev(2).
+     * ------------------------------------------------------------------ */
+    case SYS_WRITEV: {
+        int  fd     = (int)regs->ebx;
+        const struct k_iovec *iov = (const struct k_iovec *)(uintptr_t)regs->ecx;
+        int  iovcnt = (int)regs->edx;
+        if (!iov || iovcnt < 0) { regs->eax = (uint32_t)-1; break; }
+        long total = 0;
+        for (int i = 0; i < iovcnt; i++) {
+            const char *base = (const char *)(uintptr_t)iov[i].iov_base;
+            uint32_t    l    = iov[i].iov_len;
+            if (l == 0) continue;
+            long n = syscall_fd_write(fd, base, l);
+            if (n < 0) { if (total == 0) total = n; break; }
+            total += n;
+            if ((uint32_t)n < l) break;   /* short write -> stop */
         }
+        regs->eax = (uint32_t)total;
         break;
     }
 

--- a/src/kernel/include/kernel/elf.h
+++ b/src/kernel/include/kernel/elf.h
@@ -36,12 +36,14 @@ typedef uint32_t Elf32_Word;
 
 /* e_type */
 #define ET_EXEC     2
+#define ET_DYN      3   /* shared object / PIE -- relocatable load base */
 
 /* e_machine */
 #define EM_386      3
 
 /* p_type */
 #define PT_LOAD     1
+#define PT_INTERP   3   /* path to the dynamic linker (ld-musl-i386.so.1) */
 
 /* p_flags */
 #define PF_X        0x1u

--- a/src/kernel/include/kernel/pagecache.h
+++ b/src/kernel/include/kernel/pagecache.h
@@ -4,17 +4,18 @@
 #include <stdint.h>
 
 /*
- * Read-only file page cache.
+ * File page cache, shared between read() and mmap().
  *
  * Sits under SYS_READ for lazily-opened read-only files: instead of eager-
  * loading a whole file into a kmalloc'd buffer at open(), the file is streamed
  * a page at a time through this cache (like Linux's page cache).  Misses are
  * filled via vfs_read_at(); hits avoid the disk entirely.
  *
- * Backing store is a fixed static pool (bounded footprint, self-evicting LRU),
- * so it never competes with the PMM for frames and there is no reclaim lock-
- * ordering hazard under preemptive syscalls.  (A dynamic, PMM-backed cache with
- * a pressure-driven shrinker is a documented follow-up.)
+ * Each valid slot owns a page-aligned, refcounted PMM frame, bounded to
+ * PC_NPAGES (1 MiB).  Because the data lives in a real frame, the same physical
+ * page backs both read() and a file mmap(): pagecache_acquire() pins a frame
+ * and the mmap path maps it read-only into user space, so every process that
+ * maps the same file (libc.so above all) shares one copy in RAM.
  *
  * Correctness: caches clean read-only data only.  Any mutation of a path must
  * call pagecache_invalidate(path) (wired into the VFS write/delete/rename
@@ -28,6 +29,15 @@
  * past EOF) or -1 on error / non-cacheable backend. */
 long pagecache_read(const char *path, uint32_t size,
                     uint32_t off, void *buf, uint32_t len);
+
+/* Pin file page `pidx` of `path` (current size `size`) and return the phys
+ * address of its backing frame, with the frame's refcount bumped for the
+ * caller (balance it with pmm_free_frame when the mapping is torn down).  The
+ * frame's tail past EOF is zero-filled, so the whole 4 KiB is safe to map.
+ * `*out_len` (if non-NULL) gets the valid byte count.  Returns 0 on EOF/error.
+ * This is the mmap counterpart to pagecache_read: both share the cache frame. */
+uint32_t pagecache_acquire(const char *path, uint32_t size,
+                           uint32_t pidx, uint32_t *out_len);
 
 /* Drop every cached page belonging to `path` (call on write/truncate/delete/
  * rename so a later read re-fetches fresh data). */

--- a/src/kernel/include/kernel/vmm.h
+++ b/src/kernel/include/kernel/vmm.h
@@ -36,6 +36,12 @@ void vmm_map_page(uint32_t *pd, uint32_t virt, uint32_t phys, uint32_t flags);
 void vmm_unmap_page(uint32_t *pd, uint32_t virt);
 
 /*
+ * vmm_protect_page – rewrite the permission bits of an existing mapping,
+ * keeping its physical frame (backs mprotect()).  No-op if unmapped.
+ */
+void vmm_protect_page(uint32_t *pd, uint32_t virt, uint32_t flags);
+
+/*
  * vmm_switch – activate a page directory by loading it into CR3.
  */
 void vmm_switch(uint32_t *pd);

--- a/src/kernel/include/kernel/vmm.h
+++ b/src/kernel/include/kernel/vmm.h
@@ -36,6 +36,14 @@ void vmm_map_page(uint32_t *pd, uint32_t virt, uint32_t phys, uint32_t flags);
 void vmm_unmap_page(uint32_t *pd, uint32_t virt);
 
 /*
+ * vmm_unmap_and_free – like vmm_unmap_page, but also releases the page's
+ * backing frame via pmm_free_frame (refcount-decrement; freed at zero).  Use
+ * for mappings the task owns a ref on: anonymous and file-backed mmap pages,
+ * including shared page-cache frames.  No-op if the PDE/PTE is absent.
+ */
+void vmm_unmap_and_free(uint32_t *pd, uint32_t virt);
+
+/*
  * vmm_protect_page – rewrite the permission bits of an existing mapping,
  * keeping its physical frame (backs mprotect()).  No-op if unmapped.
  */

--- a/src/kernel/include/makar_syscalls.h
+++ b/src/kernel/include/makar_syscalls.h
@@ -38,7 +38,8 @@
 #define SYS_RMDIR      40   /* int rmdir(const char *path)                      */
 #define SYS_BRK        45   /* void *brk(void *addr)                            */
 #define SYS_MUNMAP     91   /* int munmap(void *addr, size_t len)               */
-#define SYS_MMAP2     192   /* void *mmap2(addr,len,prot,flags,fd,pgoff) -- anon only */
+#define SYS_MPROTECT  125   /* int mprotect(addr, len, prot) -- toggles writable */
+#define SYS_MMAP2     192   /* void *mmap2(addr,len,prot,flags,fd,pgoff) -- anon + file-backed */
 /* musl/Linux process-startup syscalls (hosted toolchain bring-up) */
 #define SYS_IOCTL          54   /* int ioctl(fd, req, ...) -- stub (-ENOTTY)        */
 #define SYS_WRITEV        146   /* ssize_t writev(fd, const struct iovec*, int)     */

--- a/src/userspace/shell-smoke.sh
+++ b/src/userspace/shell-smoke.sh
@@ -59,6 +59,19 @@ else
     fail=1
 fi
 
+# Dynamic-musl smoke (Phase 3/4): a PIE linked against musl's shared libc.so.
+# The kernel loads PT_INTERP=/lib/ld-musl-i386.so.1, which mmaps /lib/libc.so,
+# relocates, and jumps to the program -- the whole dynamic-linking runtime.
+echo SHELL-SMOKE: musl-dynamic
+exec /apps/muslhellodyn.elf musldyntest
+if [ $? -eq 0 ]
+then
+    echo SHELL-SMOKE: [PASS] musl-dynamic
+else
+    echo SHELL-SMOKE: [FAIL] musl-dynamic
+    fail=1
+fi
+
 echo SHELL-SMOKE: cd-root
 cd /
 pwd

--- a/src/userspace/shell-smoke.sh
+++ b/src/userspace/shell-smoke.sh
@@ -43,6 +43,22 @@ else
     fail=1
 fi
 
+# Static-musl smoke (dynamic-linking epic, Phase 0): proves a *real* musl libc
+# ELF runs in-OS -- musl startup (auxv walk, set_thread_area TLS, futex locks)
+# and printf->write(1)->exit all work.  Same flat top-level `exec` shape as
+# exec-hello above (the kernel sh's `exec` doesn't survive an if/else nest).
+# The binary prints "hello from musl libc" to serial; clean exit (0) -> PASS.
+# Always staged by toolchain/build-musl-demos.sh before `iso build`/`iso test`.
+echo SHELL-SMOKE: musl-static
+exec /apps/muslhello.elf musltest
+if [ $? -eq 0 ]
+then
+    echo SHELL-SMOKE: [PASS] musl-static
+else
+    echo SHELL-SMOKE: [FAIL] musl-static
+    fail=1
+fi
+
 echo SHELL-SMOKE: cd-root
 cd /
 pwd

--- a/toolchain/build-musl-demos.sh
+++ b/toolchain/build-musl-demos.sh
@@ -14,6 +14,14 @@ set -e
 
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$DIR"
+
+# Dev-only: skip gracefully if the host musl cross-toolchain isn't built (CI /
+# fresh checkout).  The suite's musl tests then SKIP rather than fail.
+if [ ! -x toolchain/install/bin/i686-linux-musl-gcc ]; then
+    echo "==> musl cross-toolchain not built; skipping musl demos (run toolchain/build-musl-cross.sh)"
+    exit 0
+fi
+
 mkdir -p isodir/apps
 
 CC="toolchain/cc.sh"
@@ -31,3 +39,14 @@ echo "==> staged isodir/apps/muslhello.elf     (static musl, base 0x40000000)"
 # identity window (a non-PIE dynamic ET_EXEC would link at 0x08048000).
 $CC $CFLAGS -pie -fPIE toolchain/test/hello.c -o isodir/apps/muslhellodyn.elf
 echo "==> staged isodir/apps/muslhellodyn.elf  (dynamic musl PIE, PT_INTERP)"
+
+# --- Phase 1: the musl shared libc + its dynamic linker into /lib -----------
+# A dynamic ELF's PT_INTERP is /lib/ld-musl-i386.so.1, which in musl IS libc.so
+# (the sysroot ships it as a symlink).  Stage both as regular copies so we don't
+# depend on ISO9660 symlink resolution.  /lib/libc.so is what the program lists
+# in DT_NEEDED; /lib/ld-musl-i386.so.1 is what the kernel loads as the interp.
+SYSLIB=toolchain/install/i686-linux-musl/lib
+mkdir -p isodir/lib
+cp "$SYSLIB/libc.so" isodir/lib/libc.so
+cp "$SYSLIB/libc.so" isodir/lib/ld-musl-i386.so.1
+echo "==> staged isodir/lib/libc.so + ld-musl-i386.so.1  ($(wc -c < "$SYSLIB/libc.so") bytes each)"

--- a/toolchain/build-musl-demos.sh
+++ b/toolchain/build-musl-demos.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# build-musl-demos.sh -- compile the musl demo programs with the hosted cross
+# toolchain and stage them into isodir/apps/ so the ISO ships them.
+#
+# Separate from the kernel build: these link against *real musl* via
+# toolchain/cc.sh (i686-linux-musl-gcc), not the freestanding i686-elf-gcc +
+# libc.a shim the in-tree apps use.  Run this *before* `./run.sh iso build`
+# (iso.sh only mkdir's isodir/apps, so staged files survive packaging).
+#
+# Static demos must be linked at >= 0x10000000 (Makar reserves 0..256 MiB as the
+# low identity window); we use 0x40000000, the same base the in-tree apps use.
+# Dynamic demos are PIE -- the kernel picks their base, so no -Ttext needed.
+set -e
+
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$DIR"
+mkdir -p isodir/apps
+
+CC="toolchain/cc.sh"
+CFLAGS="-march=i686 -O2 -Wall"
+
+# NB: keep the names hyphen-free, like the in-tree apps -- avoids any ISO9660
+# name-resolution surprises.  Static demo (Phase 0): muslhello.elf.
+$CC $CFLAGS -static -Wl,-Ttext-segment=0x40000000 \
+    toolchain/test/hello.c -o isodir/apps/muslhello.elf
+echo "==> staged isodir/apps/muslhello.elf     (static musl, base 0x40000000)"
+
+# --- Phase 1: dynamic musl hello (PIE; PT_INTERP=/lib/ld-musl-i386.so.1) ----
+# Built but only runnable once the kernel's dynamic loader + /lib/libc.so land.
+# -pie -fPIE forces ET_DYN so the kernel relocates it above the low 256 MiB
+# identity window (a non-PIE dynamic ET_EXEC would link at 0x08048000).
+$CC $CFLAGS -pie -fPIE toolchain/test/hello.c -o isodir/apps/muslhellodyn.elf
+echo "==> staged isodir/apps/muslhellodyn.elf  (dynamic musl PIE, PT_INTERP)"

--- a/toolchain/self-hosting.md
+++ b/toolchain/self-hosting.md
@@ -120,7 +120,11 @@ is itself a project. This is the "awful lot" — correctly intuited.
 ## Recommended path (most value per unit pain)
 
 1. **Finish B** — TLS gate + `writev`; prove a cross-built static-musl `hello`
-   runs. (In progress; prerequisites committed.)
+   runs. **Done** (`feat/dynamic-libc` Phase 0): TLS + futex were already in;
+   `SYS_WRITEV` (146) was the missing piece and is now implemented. A static-musl
+   `hello` runs end-to-end in-OS (`/apps/muslhello.elf`, gated by
+   `shell-smoke.sh: musl-static`). Next: **dynamic** linking (musl `libc.so` +
+   `ld-musl-i386.so.1`) — see `~/.claude/plans/melodic-honking-river.md`.
 2. **Tier 1: musl as the system libc** — futex no-op, the ~30 syscalls, errno
    convention, ship musl to `/usr/lib`. Unlocks running a *lot* of real hosted
    software in-OS. **This is the high-value milestone.**

--- a/toolchain/self-hosting.md
+++ b/toolchain/self-hosting.md
@@ -119,12 +119,16 @@ is itself a project. This is the "awful lot" — correctly intuited.
 
 ## Recommended path (most value per unit pain)
 
-1. **Finish B** — TLS gate + `writev`; prove a cross-built static-musl `hello`
-   runs. **Done** (`feat/dynamic-libc` Phase 0): TLS + futex were already in;
-   `SYS_WRITEV` (146) was the missing piece and is now implemented. A static-musl
-   `hello` runs end-to-end in-OS (`/apps/muslhello.elf`, gated by
-   `shell-smoke.sh: musl-static`). Next: **dynamic** linking (musl `libc.so` +
-   `ld-musl-i386.so.1`) — see `~/.claude/plans/melodic-honking-river.md`.
+1. **Static + dynamic musl both run in-OS. Done** (`feat/dynamic-libc`).
+   Phase 0: TLS + futex were already in; `SYS_WRITEV` (146) was the missing piece.
+   A static-musl `hello` runs end-to-end (`/apps/muslhello.elf`, gated by
+   `shell-smoke.sh: musl-static`). Phases 1–4: **dynamic linking landed** — the
+   kernel ships musl's `libc.so` + `ld-musl-i386.so.1` in `/lib`, the ELF loader
+   handles `ET_DYN`/PIE + `PT_INTERP` + a full auxv, and `SYS_MMAP2` does
+   file-backed/`MAP_FIXED` maps with `SYS_MPROTECT` for RELRO. A PIE linked
+   against the shared `libc.so` (`/apps/muslhellodyn.elf`) runs via `ld-musl`
+   (gated by `shell-smoke.sh: musl-dynamic`). See
+   `~/.claude/plans/melodic-honking-river.md`.
 2. **Tier 1: musl as the system libc** — futex no-op, the ~30 syscalls, errno
    convention, ship musl to `/usr/lib`. Unlocks running a *lot* of real hosted
    software in-OS. **This is the high-value milestone.**

--- a/toolchain/test/hello.c
+++ b/toolchain/test/hello.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    /* stderr is unbuffered in musl -> immediate write(2), which the smoke
+     * driver surfaces on serial.  Proves main() ran + musl's write path works. */
+    fprintf(stderr, "hello from musl libc (stderr, argc=%d)\n", argc);
+
+    /* stdout is fully buffered for a non-tty -> flushed by exit()'s __stdio_exit.
+     * Exercises the buffered-stdio + flush-on-exit path too. */
+    printf("hello from musl libc (stdout, argc=%d)\n", argc);
+    return 0;
+}


### PR DESCRIPTION
Two related pieces of kernel work that together give Makar a real, shared system
libc: it now runs **dynamically-linked musl programs**, and a file `mmap` is
**backed by a shared page cache** so one `libc.so` serves every process.

The existing `ET_EXEC` path and the ~50 static in-tree apps are untouched; this
is capability + a proven demo, not a userspace migration.

---

## Part 1 — Dynamic linking against musl's shared `libc.so`

Makar already ran *static* musl ELFs. This adds the runtime to load a PIE linked
against a shared `libc.so` via musl's own dynamic linker (`ld-musl-i386.so.1`).

- **Static musl gate (Phase 0)** — found + fixed the real blocker: `SYS_WRITEV`
  (146) was unimplemented, so all of musl's buffered stdio was silently dropped.
  Implemented it sharing one `syscall_fd_write` dispatch with `SYS_WRITE`.
- **Build + staging (Phase 1)** — `toolchain/build-musl-demos.sh` links
  `muslhellodyn.elf` as a PIE (`ET_DYN`, `PT_INTERP=/lib/ld-musl-i386.so.1`) and
  stages `libc.so` + `ld-musl-i386.so.1` into `/lib`. Dev-only; CI and
  toolchain-less checkouts skip it (the musl tests then SKIP, not fail).
- **Kernel mmap surface (Phase 2)** — `SYS_MMAP2` (192) honours a real `fd`
  (file region read into frames, bss tail zeroed) and `MAP_FIXED`; new
  `SYS_MPROTECT` (125) rewrites PTE R/W/USER over a range for `ld.so`'s RELRO.
- **Dynamic ELF loader (Phase 3)** — `elf_exec` runs `ET_DYN` PIEs: load base
  `0x50000000`, interpreter at `0x70000000`, a full System-V i386 auxv
  (`AT_PHDR`/`PHENT`/`PHNUM`/`BASE`/`ENTRY`/`EXECFN`/`RANDOM`/`PAGESZ`), entering
  at the interpreter. `AT_PHDR` resolves via the `PT_LOAD` that maps `e_phoff`
  (a plain `e_phoff+base` is wrong for `ET_EXEC` and faults `ld.so`). The
  `ET_EXEC` path stays byte-for-byte — a vestigial `PT_INTERP` (e.g. TCC's
  `/lib/ld-linux.so.2`) is ignored; only `ET_DYN` consults it.
- **errno (Phase 5)** — `SYS_OPEN` returns `-ENOENT` (not `-1`) on a missing
  file so `ld.so` can walk its library search path.

`muslhellodyn.elf` now runs end-to-end: kernel → `ld-musl` → `mmap`s `libc.so`
→ relocates → RELRO `mprotect` → `main` prints via `writev`, exit 0. Gated by
`shell-smoke.sh: musl-dynamic`.

## Part 2 — Page-cache-backed *shared* file mmap (the RAM win)

Part 1's file `mmap` gave each process a **private** ~800 KiB copy of `libc.so`
— so dynamic linking would have *cost* RAM versus the static shim. This makes it
a win, the Linux way: one page cache, `read()` copies from it, `mmap()` maps it.

- The page cache now backs each cached page with a **page-aligned, refcounted
  PMM frame** (was an inline `.bss` array that couldn't be mapped). `read()` is
  functionally identical; `pagecache_acquire()` pins a frame for `mmap`.
- A **read-only** file `mmap` maps that shared frame directly, so libc.so's
  ~700 KiB of text/rodata is **one copy in RAM** across every process. Writable
  file maps, tmpfs files and anon maps keep a private frame (correct
  `MAP_PRIVATE`; musl's data segment is relocated, so it must stay private).
- Fixed a latent pre-existing leak: `vmm_unmap_page` only cleared PTEs and never
  freed frames, so `munmap` (and the `MAP_FIXED` reserve-replace) leaked every
  eager frame. New `vmm_unmap_and_free` reclaims them (a refcount decrement, so
  shared cache frames survive while others map them).

## Part 3 — Page-table teardown fix (found while doing Part 2)

`vmm_free_pd`/`vmm_clone_pd_cow` skipped page directory entries shared with the
kernel using an **exact** `pde == kpd[pdi]` compare. The CPU sets the
Accessed/Dirty bits asynchronously on whichever PDE copy it walks, so once the
kernel drew to the framebuffer (`0xFD400000`), `kpd`'s PDE gained the Accessed
bit while a user PD's mirrored copy did not — the words diverged, the share was
missed, and teardown walked into the kernel's framebuffer page table and freed
it. Now compares the **PT frame address only** (`pde & ~0xFFF`), stable across
A/D updates. This clears the `pmm refcount underflow at frame 0x2EA` warning the
suite emitted (benign before — kernel PTs are refcount 0 so the free was a
guarded no-op — but a latent double-free).

## Testing

- Full local gate **894 passed / 0 failed** (`./run.sh iso test`): ktest +
  `shell-smoke` + `incore` + `libc-tcc` drivers. No PMM underflow warnings.
- `shell-smoke.sh`: `musl-static` and `musl-dynamic` both run real musl ELFs in
  the ring-3 shell and assert clean exit.
- New `pagecache_share` ktest **proves the sharing**: a 2nd mapper of the same
  file page returns the *same* physical frame and allocates **zero** new frames
  (a private-copy implementation would do neither).
- The `ET_EXEC` path and the static apps are unchanged, so the rest of the suite
  is untouched.

## Notes / scope

- Stays **i686**; x86_64 is a separate long-horizon track.
- `libc.so`/`ld-musl-i386.so.1` are shipped as copies (not symlinks) to avoid
  depending on ISO9660 symlink resolution.
- Sharing holds while a file stays resident in the LRU page cache (libc.so
  ~200 pages fits the 256-page/1 MiB cache); true cache-pressure-proof pinning
  is a later memory-management refinement.
- This unblocks the follow-up **userspace static→dynamic migration**, which was
  deliberately gated on shared mmap so it wouldn't regress RAM on a 32 MiB box.
